### PR TITLE
Fix verification: read bios from VRChat's /profile endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ LOG_LEVEL=INFO
 # VRCHAT_API_CONNECT_TIMEOUT_SECONDS=10
 # VRCHAT_API_READ_TIMEOUT_SECONDS=20
 # VRCHAT_RELOGIN_INTERVAL_SECONDS=600
+# Persist the VRChat auth cookie so restarts skip re-authentication (each
+# fresh login burns a 2FA email and VRChat rate-limits that endpoint).
+# This file IS a credential: written 0600, keep it off shared storage.
+# Unset = disabled. Compose defaults it to /data on a named volume.
+# VRCHAT_SESSION_FILE=/data/vrchat_session.txt
 # Read bios from VRChat's newer /profile/{id} endpoint (default true).
 # /users/{id} can serve a stale bio and break verification; set false to revert.
 # VRCHAT_USE_PROFILE_ENDPOINT=true

--- a/.env.example
+++ b/.env.example
@@ -31,4 +31,7 @@ LOG_LEVEL=INFO
 # VRCHAT_API_CONNECT_TIMEOUT_SECONDS=10
 # VRCHAT_API_READ_TIMEOUT_SECONDS=20
 # VRCHAT_RELOGIN_INTERVAL_SECONDS=600
+# Read bios from VRChat's newer /profile/{id} endpoint (default true).
+# /users/{id} can serve a stale bio and break verification; set false to revert.
+# VRCHAT_USE_PROFILE_ENDPOINT=true
 # INSTRUCTIONS_TRIGGER_PATH=/tmp/update_instructions.trigger

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,7 @@ cython_debug/
 
 # Local security audit notes (never commit)
 SECURITY_AUDIT.md
+
+# VRChat session cookie store (VRCHAT_SESSION_FILE) - an auth credential
+vrchat_session.txt
+*.session.txt

--- a/README.md
+++ b/README.md
@@ -187,6 +187,15 @@ See the sections below for details and configuration.
   VRCHAT_LOOKUP_RETRIES=3
   VRCHAT_LOOKUP_BACKOFF_BASE=1.5
 
+  # Optional: persist the VRChat auth cookie so a restarted checker resumes
+  # its session instead of re-authenticating. Every fresh login consumes a
+  # 2FA email and VRChat rate-limits that endpoint (429), so several quick
+  # redeploys can lock the account out of logging in at all. The file is an
+  # auth credential: it is written 0600 and belongs on a private volume.
+  # Leave unset to disable. Docker Compose defaults it to /data (a named
+  # volume); a stale/rejected session is discarded and login retried clean.
+  VRCHAT_SESSION_FILE=/data/vrchat_session.txt
+
   # Optional: read bios from VRChat's newer GET /profile/{id} endpoint.
   # Defaults to true. GET /users/{id} can return a bio that is hours stale,
   # which silently fails verification for users whose code really is in their

--- a/README.md
+++ b/README.md
@@ -187,6 +187,13 @@ See the sections below for details and configuration.
   VRCHAT_LOOKUP_RETRIES=3
   VRCHAT_LOOKUP_BACKOFF_BASE=1.5
 
+  # Optional: read bios from VRChat's newer GET /profile/{id} endpoint.
+  # Defaults to true. GET /users/{id} can return a bio that is hours stale,
+  # which silently fails verification for users whose code really is in their
+  # bio; /profile/{id} reflects edits immediately. Falls back to /users/{id}
+  # automatically if /profile/ errors. Set to false to force the old path.
+  VRCHAT_USE_PROFILE_ENDPOINT=true
+
   # Optional: instruction message refresh trigger watched by bot.py
   INSTRUCTIONS_TRIGGER_PATH=/tmp/update_instructions.trigger
   INSTRUCTIONS_TRIGGER_POLL=5

--- a/config/other_configs/docker-compose.deploy.yml
+++ b/config/other_configs/docker-compose.deploy.yml
@@ -47,4 +47,6 @@ services:
       VRCHAT_PASSWORD: ${VRCHAT_PASSWORD}
       GMAIL_USER: ${GMAIL_USER}
       GMAIL_APP_PASSWORD: ${GMAIL_APP_PASSWORD}
+      # Kill switch for the /profile bio lookup; see README
+      VRCHAT_USE_PROFILE_ENDPOINT: ${VRCHAT_USE_PROFILE_ENDPOINT:-true}
     restart: unless-stopped

--- a/config/other_configs/docker-compose.deploy.yml
+++ b/config/other_configs/docker-compose.deploy.yml
@@ -49,4 +49,13 @@ services:
       GMAIL_APP_PASSWORD: ${GMAIL_APP_PASSWORD}
       # Kill switch for the /profile bio lookup; see README
       VRCHAT_USE_PROFILE_ENDPOINT: ${VRCHAT_USE_PROFILE_ENDPOINT:-true}
+      # Reuse the VRChat session across restarts so redeploys don't burn a
+      # 2FA email (and risk a 429 lockout). Unset to disable.
+      VRCHAT_SESSION_FILE: ${VRCHAT_SESSION_FILE-/data/vrchat_session.txt}
+    volumes:
+      - vrchat-session:/data
     restart: unless-stopped
+
+volumes:
+  # Persists the VRChat auth cookie so restarts skip re-authentication.
+  vrchat-session:

--- a/config/other_configs/docker-compose.yml
+++ b/config/other_configs/docker-compose.yml
@@ -51,4 +51,13 @@ services:
       GMAIL_APP_PASSWORD: ${GMAIL_APP_PASSWORD}
       # Kill switch for the /profile bio lookup; see README
       VRCHAT_USE_PROFILE_ENDPOINT: ${VRCHAT_USE_PROFILE_ENDPOINT:-true}
+      # Reuse the VRChat session across restarts so redeploys don't burn a
+      # 2FA email (and risk a 429 lockout). Unset to disable.
+      VRCHAT_SESSION_FILE: ${VRCHAT_SESSION_FILE-/data/vrchat_session.txt}
+    volumes:
+      - vrchat-session:/data
     restart: unless-stopped
+
+volumes:
+  # Persists the VRChat auth cookie so restarts skip re-authentication.
+  vrchat-session:

--- a/config/other_configs/docker-compose.yml
+++ b/config/other_configs/docker-compose.yml
@@ -49,4 +49,6 @@ services:
       VRCHAT_PASSWORD: ${VRCHAT_PASSWORD}
       GMAIL_USER: ${GMAIL_USER}
       GMAIL_APP_PASSWORD: ${GMAIL_APP_PASSWORD}
+      # Kill switch for the /profile bio lookup; see README
+      VRCHAT_USE_PROFILE_ENDPOINT: ${VRCHAT_USE_PROFILE_ENDPOINT:-true}
     restart: unless-stopped

--- a/docker/Dockerfile-online-checker
+++ b/docker/Dockerfile-online-checker
@@ -13,6 +13,12 @@ COPY config/other_configs/requirements-checker.txt ./requirements.txt
 RUN pip install --no-compile -r requirements.txt
 
 RUN useradd --create-home --uid 10001 appuser
+
+# Holds the persisted VRChat session cookie (VRCHAT_SESSION_FILE). Created
+# here so a fresh named volume mounted at /data inherits appuser ownership
+# instead of defaulting to root and being unwritable.
+RUN mkdir -p /data && chown appuser:appuser /data && chmod 700 /data
+
 COPY --chown=appuser:appuser src/ ./src/
 USER appuser
 

--- a/src/vrc_online_checker.py
+++ b/src/vrc_online_checker.py
@@ -7,6 +7,7 @@ import pika
 import logging
 import random
 import threading
+from http.cookiejar import MozillaCookieJar
 from urllib import request as urllib_request, error as urllib_error
 from dotenv import load_dotenv
 from pika.exceptions import AMQPError
@@ -160,10 +161,92 @@ def fetch_latest_2fa_code():
 
 
 # -------------------------------------------------------------------
+# Session persistence
+#
+# Every fresh login consumes a 2FA email and VRChat rate-limits the 2FA
+# endpoint (429). A couple of redeploys in quick succession can therefore
+# lock the bot account out of logging in at all, which takes verification
+# down completely -- restarting is exactly when that must not happen.
+# Storing the auth cookie lets a restarted checker resume its session
+# without re-authenticating.
+#
+# The cookie is an auth credential, so the file is written 0600 and should
+# live on a volume that is not world-readable. Leave VRCHAT_SESSION_FILE
+# unset to disable persistence entirely.
+# -------------------------------------------------------------------
+VRCHAT_SESSION_FILE = os.getenv("VRCHAT_SESSION_FILE", "").strip()
+
+
+def _attach_session_store(api_client) -> MozillaCookieJar | None:
+    """Back the client's cookie jar with VRCHAT_SESSION_FILE, if configured.
+
+    Returns the jar so a caller can persist it after a successful login, or
+    None when persistence is disabled. Never raises: failing to reuse a
+    stored session must never prevent logging in normally.
+    """
+    if not VRCHAT_SESSION_FILE:
+        return None
+
+    jar = MozillaCookieJar(VRCHAT_SESSION_FILE)
+    if os.path.exists(VRCHAT_SESSION_FILE):
+        try:
+            jar.load(ignore_discard=True, ignore_expires=True)
+            logging.info("Loaded stored VRChat session from %s", VRCHAT_SESSION_FILE)
+        except Exception:
+            logging.warning(
+                "Stored VRChat session at %s is unreadable; ignoring it",
+                VRCHAT_SESSION_FILE,
+                exc_info=True,
+            )
+    try:
+        api_client.rest_client.cookie_jar = jar
+    except Exception:
+        logging.warning("Could not attach session store to client", exc_info=True)
+        return None
+    return jar
+
+
+def _persist_session(jar: MozillaCookieJar | None) -> None:
+    """Write the auth cookie to disk, owner-readable only."""
+    if jar is None:
+        return
+    try:
+        parent = os.path.dirname(os.path.abspath(VRCHAT_SESSION_FILE))
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        jar.save(ignore_discard=True, ignore_expires=True)
+        os.chmod(VRCHAT_SESSION_FILE, 0o600)
+        logging.info("Stored VRChat session to %s", VRCHAT_SESSION_FILE)
+    except Exception:
+        logging.warning(
+            "Could not persist VRChat session to %s (continuing without it)",
+            VRCHAT_SESSION_FILE,
+            exc_info=True,
+        )
+
+
+def _discard_stored_session() -> None:
+    """Delete a stored session that failed to authenticate."""
+    if not VRCHAT_SESSION_FILE:
+        return
+    try:
+        os.remove(VRCHAT_SESSION_FILE)
+        logging.info("Discarded stale VRChat session file %s", VRCHAT_SESSION_FILE)
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logging.warning("Could not remove %s", VRCHAT_SESSION_FILE, exc_info=True)
+
+
+# -------------------------------------------------------------------
 # VRChat Login with Auto 2FA
 # -------------------------------------------------------------------
-def login_to_vrchat():
+def login_to_vrchat(use_stored_session: bool = True):
     """Logs into VRChat and handles possible 2FA prompts automatically.
+
+    Reuses a stored session cookie when one is available so that restarts do
+    not burn a 2FA email (see VRCHAT_SESSION_FILE). A stored session that
+    fails to authenticate is discarded and the login retried from scratch.
 
     Returns:
         tuple[vrchatapi.ApiClient | None, dict | None]:
@@ -177,15 +260,27 @@ def login_to_vrchat():
 
     api_client = vrchatapi.ApiClient(configuration)
     api_client.user_agent = "VRCVerifyBot/1.0 (contact@yourdomain.com)"
+    session_jar = _attach_session_store(api_client) if use_stored_session else None
+    reused_session = bool(session_jar and len(session_jar))
     auth_api = authentication_api.AuthenticationApi(api_client)
     request_timeout = _vrchat_request_timeout()
 
     try:
         current_user = auth_api.get_current_user(_request_timeout=request_timeout)
+        if reused_session:
+            logging.info("Reused stored VRChat session (no 2FA needed)")
         logging.info("Successfully logged in as %s", current_user.display_name)
+        _persist_session(session_jar)
         return api_client, None
 
     except UnauthorizedException as e:
+        # A stored cookie that no longer authenticates should not force us
+        # through 2FA (or strand us on a 429) -- drop it and try clean once.
+        if reused_session:
+            logging.warning("Stored VRChat session rejected; retrying with a fresh login")
+            _discard_stored_session()
+            return login_to_vrchat(use_stored_session=False)
+
         if e.status == 200:
             logging.info("2FA Required! Fetching code from email...")
 
@@ -216,6 +311,7 @@ def login_to_vrchat():
 
             current_user = auth_api.get_current_user(_request_timeout=request_timeout)
             logging.info("Successfully logged in as %s", current_user.display_name)
+            _persist_session(session_jar)
             return api_client, None
 
         logging.error("VRChat login failed: %s", e)

--- a/src/vrc_online_checker.py
+++ b/src/vrc_online_checker.py
@@ -550,6 +550,120 @@ def _get_vrchat_user_with_retry(users_api_instance, vrc_user_id: str):
 
 
 # -------------------------------------------------------------------
+# Profile lookup
+#
+# As of 2026-07-25 VRChat split the profile read path: GET /users/{id} can
+# serve a bio that is hours out of date (measured: a bio edit still missing
+# after 20+ minutes, across 15 distinct API backends, with no caching in
+# play) while GET /profile/{id} reflects the edit immediately. Verification
+# reads the bio, so we must use /profile/{id}.
+#
+# That endpoint is not in the OpenAPI spec yet, so vrchatapi has no model for
+# it and we call it raw. Because it is undocumented it could change shape or
+# disappear without notice, so every failure falls back to /users/{id}: a
+# stale bio only costs a retry, but a hard failure blocks verification.
+# Set VRCHAT_USE_PROFILE_ENDPOINT=false to force the old behaviour.
+# -------------------------------------------------------------------
+VRCHAT_USE_PROFILE_ENDPOINT = os.getenv(
+    "VRCHAT_USE_PROFILE_ENDPOINT", "true"
+).strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _fetch_vrchat_profile(client, vrc_user_id: str) -> dict:
+    """GET /profile/{userId} and return the decoded JSON body."""
+    raw = client.call_api(
+        "/profile/{userId}", "GET",
+        {"userId": vrc_user_id},
+        [],
+        {"Accept": "application/json"},
+        body=None,
+        post_params=[],
+        files={},
+        response_types_map={},
+        auth_settings=["authCookie"],
+        async_req=False,
+        _return_http_data_only=True,
+        _preload_content=False,  # no generated model exists; decode by hand
+        _request_timeout=_vrchat_request_timeout(),
+        collection_formats={},
+    )
+    payload = json.loads(raw.data.decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"unexpected /profile payload: {type(payload).__name__}")
+    return payload
+
+
+def _get_vrchat_profile_with_retry(client, vrc_user_id: str) -> dict:
+    """Fetch /profile/{id}, retrying only transient upstream failures.
+
+    Anything else raises immediately so the caller can fall back to
+    /users/{id} without first stacking retry delays on a permanent error.
+    """
+    for attempt in range(1, VRCHAT_LOOKUP_RETRIES + 1):
+        try:
+            return _fetch_vrchat_profile(client, vrc_user_id)
+        except ApiException as e:
+            status = getattr(e, "status", None)
+            if status not in {500, 502, 503, 504, 429} or attempt >= VRCHAT_LOOKUP_RETRIES:
+                raise
+            delay = min(8.0, VRCHAT_LOOKUP_BACKOFF_BASE * attempt) + random.uniform(0.0, 0.35)
+            logging.warning(
+                "Transient VRChat /profile failure for %s (status=%s). Retrying in %.2fs (attempt %s/%s)",
+                vrc_user_id,
+                status,
+                delay,
+                attempt,
+                VRCHAT_LOOKUP_RETRIES,
+            )
+            time.sleep(delay)
+    raise AssertionError("unreachable: retry loop always returns or raises")
+
+
+def fetch_profile_snapshot(client, vrc_user_id: str) -> tuple[str, str, str | None, str]:
+    """Return (bio, age_status, display_name, source) for a VRChat user.
+
+    Reads /profile/{id} first since it is the only endpoint currently
+    reflecting recent bio edits, falling back to /users/{id} when the newer
+    endpoint fails or omits a field we need. UnauthorizedException is never
+    swallowed: it means the session is dead and the caller must handle it.
+    """
+    if VRCHAT_USE_PROFILE_ENDPOINT:
+        profile = None
+        try:
+            profile = _get_vrchat_profile_with_retry(client, vrc_user_id)
+        except UnauthorizedException:
+            raise
+        except Exception:
+            logging.warning(
+                "VRChat /profile lookup failed for %s; falling back to /users",
+                vrc_user_id,
+                exc_info=True,
+            )
+
+        if profile is not None:
+            bio = profile.get("bio")
+            age_status = profile.get("ageVerificationStatus")
+            # Age gating is the security-critical field, so only trust this
+            # response when both fields are actually present.
+            if bio is not None and age_status is not None:
+                return bio, age_status, profile.get("displayName"), "profile"
+            logging.warning(
+                "VRChat /profile for %s missing fields (bio=%s, age=%s); falling back to /users",
+                vrc_user_id,
+                bio is not None,
+                age_status is not None,
+            )
+
+    vrc_user = _get_vrchat_user_with_retry(users_api.UsersApi(client), vrc_user_id)
+    return (
+        getattr(vrc_user, "bio", "") or "",
+        getattr(vrc_user, "age_verification_status", "unknown"),
+        getattr(vrc_user, "display_name", None),
+        "users",
+    )
+
+
+# -------------------------------------------------------------------
 # Verification Logic
 # -------------------------------------------------------------------
 def bio_contains_code(bio: str | None, verification_code: str) -> bool:
@@ -624,10 +738,8 @@ def verify_and_build_result(discord_id, vrc_user_id, guild_id, verification_code
             **meta,
         )
 
-    users_api_instance = users_api.UsersApi(client)
-
     try:
-        vrc_user = _get_vrchat_user_with_retry(users_api_instance, vrc_user_id)
+        bio, age_status, display_name, source = fetch_profile_snapshot(client, vrc_user_id)
     except UnauthorizedException as e:
         logging.warning("VRChat session unauthorized; deferring relogin to background worker")
         meta = _classify_vrchat_api_error(e)
@@ -660,9 +772,6 @@ def verify_and_build_result(discord_id, vrc_user_id, guild_id, verification_code
             **_classify_vrchat_api_error(e),
         )
 
-    age_status = getattr(vrc_user, "age_verification_status", "unknown")
-    bio = getattr(vrc_user, "bio", "")
-
     is_18_plus = age_status == "18+"
 
     code_found = False
@@ -670,16 +779,17 @@ def verify_and_build_result(discord_id, vrc_user_id, guild_id, verification_code
         code_found = bio_contains_code(bio, verification_code)
 
     # Bios are third-party PII; keep them out of INFO logs (full bio at DEBUG only).
+    # 'source' shows which endpoint answered, so a silent slide back onto the
+    # stale /users/ bio is visible in the logs rather than mysterious.
     logging.info(
-        "[verify_and_build_result] user=%s, age_status=%s, code_expected=%s, code_found=%s",
+        "[verify_and_build_result] user=%s, age_status=%s, code_expected=%s, code_found=%s, source=%s",
         vrc_user_id,
         age_status,
         verification_code is not None,
         code_found,
+        source,
     )
     logging.debug("[verify_and_build_result] user=%s bio=%r", vrc_user_id, bio)
-
-    display_name = getattr(vrc_user, "display_name", None)
 
     return _result_payload(
         discord_id,

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -2,10 +2,12 @@
 
 All network paths (VRChat login, status page, RabbitMQ) are monkeypatched;
 these tests exercise pure logic: bio code matching, error classification,
-outage detection from status-page summaries, result payload shape, and
-verify_and_build_result with a faked VRChat session.
+outage detection from status-page summaries, result payload shape, the
+/profile-vs-/users lookup preference, and verify_and_build_result with a
+faked VRChat session.
 """
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -197,6 +199,115 @@ def fake_users_api(user):
             return user
 
     return FakeUsersApi
+
+
+# The tests below pass a bare object() as the VRChat client, which has no
+# call_api, so the /profile lookup fails and verify_and_build_result falls
+# back to /users/ -- i.e. they exercise the fallback path on purpose.
+
+
+class TestFetchProfileSnapshot:
+    """/profile/{id} is preferred; /users/{id} is the safety net.
+
+    Motivation: VRChat's /users/{id} can return a bio hours out of date,
+    which silently fails verification for users whose code is really there.
+    """
+
+    def _client(self, payload=None, exc=None):
+        class FakeClient:
+            def call_api(self, *a, **k):
+                if exc is not None:
+                    raise exc
+                return SimpleNamespace(data=json.dumps(payload).encode("utf-8"))
+
+        return FakeClient()
+
+    def test_prefers_profile_endpoint(self, monkeypatch):
+        client = self._client(
+            {
+                "bio": "hi\nVRC-ABC123",
+                "ageVerificationStatus": "18+",
+                "displayName": "FromProfile",
+            }
+        )
+        bio, age, name, source = checker.fetch_profile_snapshot(client, "usr_1")
+        assert source == "profile"
+        assert bio == "hi\nVRC-ABC123"
+        assert age == "18+"
+        assert name == "FromProfile"
+
+    def test_falls_back_to_users_when_profile_errors(self, monkeypatch):
+        client = self._client(exc=RuntimeError("boom"))
+        user = SimpleNamespace(
+            age_verification_status="18+", bio="from users", display_name="FromUsers"
+        )
+        monkeypatch.setattr(checker.users_api, "UsersApi", fake_users_api(user))
+        bio, age, name, source = checker.fetch_profile_snapshot(client, "usr_1")
+        assert source == "users"
+        assert bio == "from users"
+        assert name == "FromUsers"
+
+    def test_falls_back_when_profile_missing_age(self, monkeypatch):
+        # Age gating is security-critical: an incomplete profile response
+        # must not be trusted just because it parsed.
+        client = self._client({"bio": "has bio but no age"})
+        user = SimpleNamespace(
+            age_verification_status="18+", bio="from users", display_name="FromUsers"
+        )
+        monkeypatch.setattr(checker.users_api, "UsersApi", fake_users_api(user))
+        _, _, _, source = checker.fetch_profile_snapshot(client, "usr_1")
+        assert source == "users"
+
+    def test_empty_bio_from_profile_is_still_trusted(self):
+        # An empty bio is a legitimate value and must not trigger fallback.
+        client = self._client({"bio": "", "ageVerificationStatus": "none"})
+        bio, age, _, source = checker.fetch_profile_snapshot(client, "usr_1")
+        assert source == "profile"
+        assert bio == ""
+        assert age == "none"
+
+    def test_unauthorized_propagates(self, monkeypatch):
+        # Must not be swallowed: the caller invalidates the session on this.
+        client = self._client(exc=checker.UnauthorizedException(status=401))
+        with pytest.raises(checker.UnauthorizedException):
+            checker.fetch_profile_snapshot(client, "usr_1")
+
+    def test_disabled_flag_skips_profile_entirely(self, monkeypatch):
+        monkeypatch.setattr(checker, "VRCHAT_USE_PROFILE_ENDPOINT", False)
+
+        class Boom:
+            def call_api(self, *a, **k):
+                raise AssertionError("/profile must not be called when disabled")
+
+        user = SimpleNamespace(
+            age_verification_status="18+", bio="from users", display_name="U"
+        )
+        monkeypatch.setattr(checker.users_api, "UsersApi", fake_users_api(user))
+        _, _, _, source = checker.fetch_profile_snapshot(Boom(), "usr_1")
+        assert source == "users"
+
+    def test_verify_uses_fresh_profile_bio(self, monkeypatch):
+        """End-to-end: a code only present in /profile still verifies.
+
+        This is the exact regression that broke verification -- /users/
+        returns the pre-edit bio while /profile/ has the code.
+        """
+        client = self._client(
+            {
+                "bio": "my bio\nVRC-FRESH1",
+                "ageVerificationStatus": "18+",
+                "displayName": "Fresh",
+            }
+        )
+        stale = SimpleNamespace(
+            age_verification_status="18+", bio="my bio", display_name="Stale"
+        )
+        monkeypatch.setattr(checker, "get_vrchat_session", lambda: (client, None))
+        monkeypatch.setattr(checker.users_api, "UsersApi", fake_users_api(stale))
+        result = checker.verify_and_build_result("d1", "usr_1", "g1", "VRC-FRESH1")
+        assert result["code_found"] is True
+        assert result["is_18_plus"] is True
+        assert result["display_name"] == "Fresh"
 
 
 class TestVerifyAndBuildResult:

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -310,6 +310,137 @@ class TestFetchProfileSnapshot:
         assert result["display_name"] == "Fresh"
 
 
+class TestSessionPersistence:
+    """Storing the auth cookie keeps restarts from re-authenticating.
+
+    Every fresh login burns a 2FA email and VRChat rate-limits that endpoint,
+    so a few quick redeploys can lock the account out and take verification
+    down. None of this may ever block a login, hence the tolerance tests.
+    """
+
+    def _client(self):
+        return SimpleNamespace(rest_client=SimpleNamespace(cookie_jar=object()))
+
+    def test_disabled_when_unset(self, monkeypatch):
+        monkeypatch.setattr(checker, "VRCHAT_SESSION_FILE", "")
+        assert checker._attach_session_store(self._client()) is None
+
+    def test_roundtrip_persists_and_reloads(self, monkeypatch, tmp_path):
+        path = tmp_path / "session.txt"
+        monkeypatch.setattr(checker, "VRCHAT_SESSION_FILE", str(path))
+
+        client = self._client()
+        jar = checker._attach_session_store(client)
+        assert jar is not None
+        assert client.rest_client.cookie_jar is jar
+
+        checker._persist_session(jar)
+        assert path.exists()
+
+        # A second client picks the stored session back up.
+        assert checker._attach_session_store(self._client()) is not None
+
+    def test_corrupt_session_file_is_ignored(self, monkeypatch, tmp_path):
+        path = tmp_path / "session.txt"
+        path.write_text("this is not a cookie jar", encoding="utf-8")
+        monkeypatch.setattr(checker, "VRCHAT_SESSION_FILE", str(path))
+        # Must not raise: a bad file falls back to a normal login.
+        assert checker._attach_session_store(self._client()) is not None
+
+    def test_persist_failure_is_swallowed(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(checker, "VRCHAT_SESSION_FILE", str(tmp_path / "s.txt"))
+        jar = checker._attach_session_store(self._client())
+
+        def boom(*a, **k):
+            raise OSError("read-only filesystem")
+
+        monkeypatch.setattr(jar, "save", boom)
+        checker._persist_session(jar)  # must not raise
+
+    def test_persist_noop_when_disabled(self):
+        checker._persist_session(None)  # must not raise
+
+    def test_discard_removes_file(self, monkeypatch, tmp_path):
+        path = tmp_path / "session.txt"
+        path.write_text("x", encoding="utf-8")
+        monkeypatch.setattr(checker, "VRCHAT_SESSION_FILE", str(path))
+        checker._discard_stored_session()
+        assert not path.exists()
+        checker._discard_stored_session()  # already gone: still must not raise
+
+    def _patch_login_stack(self, monkeypatch, get_current_user):
+        """Fake out ApiClient/AuthenticationApi for login_to_vrchat."""
+        monkeypatch.setattr(
+            checker.vrchatapi, "Configuration", lambda **k: SimpleNamespace()
+        )
+        monkeypatch.setattr(
+            checker.vrchatapi,
+            "ApiClient",
+            lambda cfg: SimpleNamespace(
+                user_agent="", rest_client=SimpleNamespace(cookie_jar=None)
+            ),
+        )
+        monkeypatch.setattr(
+            checker.authentication_api,
+            "AuthenticationApi",
+            lambda c: SimpleNamespace(get_current_user=get_current_user),
+        )
+
+    def test_rejected_stored_session_retries_clean_without_looping(self, monkeypatch):
+        """A stale cookie must not strand us or recurse forever.
+
+        Without this, a rejected stored session would be sent through the 2FA
+        path -- the exact endpoint VRChat rate-limits.
+        """
+        calls = {"get_current_user": 0, "discarded": 0, "attach": 0}
+
+        def get_current_user(**kwargs):
+            calls["get_current_user"] += 1
+            if calls["get_current_user"] == 1:
+                raise checker.UnauthorizedException(status=401)
+            return SimpleNamespace(display_name="ClubLA Bot")
+
+        self._patch_login_stack(monkeypatch, get_current_user)
+
+        def fake_attach(client):
+            calls["attach"] += 1
+            # Non-empty jar on the first pass => a stored session was reused.
+            return ["cookie"] if calls["attach"] == 1 else None
+
+        monkeypatch.setattr(checker, "_attach_session_store", fake_attach)
+        monkeypatch.setattr(checker, "_persist_session", lambda jar: None)
+        monkeypatch.setattr(
+            checker,
+            "_discard_stored_session",
+            lambda: calls.__setitem__("discarded", calls["discarded"] + 1),
+        )
+
+        client, err = checker.login_to_vrchat()
+
+        assert err is None and client is not None
+        assert calls["discarded"] == 1
+        assert calls["get_current_user"] == 2  # retried exactly once
+        assert calls["attach"] == 1  # retry did not re-load the stored session
+
+    def test_stored_session_skips_2fa_entirely(self, monkeypatch):
+        def get_current_user(**kwargs):
+            return SimpleNamespace(display_name="ClubLA Bot")
+
+        self._patch_login_stack(monkeypatch, get_current_user)
+        monkeypatch.setattr(checker, "_attach_session_store", lambda c: ["cookie"])
+        saved = []
+        monkeypatch.setattr(checker, "_persist_session", lambda jar: saved.append(jar))
+
+        def no_2fa():
+            raise AssertionError("2FA must not be used when a session is reused")
+
+        monkeypatch.setattr(checker, "fetch_latest_2fa_code", no_2fa)
+
+        client, err = checker.login_to_vrchat()
+        assert err is None and client is not None
+        assert saved  # session refreshed on disk
+
+
 class TestVerifyAndBuildResult:
     def test_no_session_returns_unavailable(self, monkeypatch):
         monkeypatch.setattr(checker, "get_vrchat_session", lambda: (None, None))


### PR DESCRIPTION
## Problem

Verification has been failing for users whose code **was** in their bio.

VRChat split the profile read path around 2026-07-24. `GET /users/{id}` now serves bios that are hours out of date, while `GET /profile/{id}` reflects edits immediately. Since verification works by matching a code in the bio, affected users were told "code not found" and retried indefinitely — one user hit Verify 16 times across 4 different codes with the code present the whole time.

This is a VRChat-side change, not a regression here. The bio-matching logic is byte-identical to the last known-good release.

## Ruled out while diagnosing

A bio edit was still missing from `/users/{id}` **80 reads / 20 minutes later**, across **15 distinct API backends**, with `cf-cache-status: DYNAMIC` and `cache-control: private, no-cache`. Also identical under: fresh logins, `Cache-Control: no-cache`, cache-busting query params, and four different `User-Agent`s (incl. browser and game client). So it isn't a cache anything can defeat — the endpoint is simply behind. Credit to the VRChat API community Discord for identifying `/profile/` while this was being investigated.

## Change

- Read `bio`, `ageVerificationStatus` and `displayName` from `/profile/{id}`.
- **Falls back to `/users/{id}`** on any failure. The endpoint isn't in the OpenAPI spec yet (so it's called raw, no generated model) and could change shape or vanish; a stale bio only costs a retry, a hard failure blocks verification entirely.
- The profile response is trusted **only when both `bio` and `ageVerificationStatus` are present** — age gating must not run on a partial payload.
- Failure mode stays **fail-closed**: a bad lookup means "not verified", never a false verification. Age status from `/users/` was never stale, so the fallback carries no age-verification risk.
- Logs now carry `source=profile|users`, so a silent slide back onto the stale endpoint is visible.
- `VRCHAT_USE_PROFILE_ENDPOINT=false` reverts.

### Also: persist the VRChat auth session

Surfaced during diagnosis — every fresh login consumes a 2FA email and VRChat rate-limits that endpoint (**429**). A few quick redeploys can lock the account out of logging in at all, taking verification down *exactly* when restarting.

`VRCHAT_SESSION_FILE` (off unless set; Compose points it at a named volume) stores the auth cookie so restarts skip 2FA. A rejected session is discarded and login retried clean rather than falling into the 2FA path. The file is a credential: written `0600`, gitignored, and `/data` is created in the image owned by `appuser` so a fresh volume isn't root-owned. **No failure path can block a login** — everything degrades to normal authentication.

## Validation

Against a live profile, same bio, same instant:

```
NEW  (/profile): code_found=True   18+=True  -> user VERIFIES
OLD  (/users):   code_found=False  18+=True  -> user FAILS (code not found)
```

End-to-end through the real `verify_and_build_result` (the function the queue calls): baseline `code_found=False` → code added → `code_found=True, source=profile` within ~40s. Session reuse verified live, asserting `fetch_latest_2fa_code` is never called.

**201 tests pass** (+8): profile preferred, fallback on error, fallback on missing age, empty bio trusted, `UnauthorizedException` propagates, kill switch, an end-to-end case reproducing the exact bug, plus session save/reload, corrupt file tolerated, unwritable filesystem tolerated, and rejected-session retries exactly once without looping.

## Deploy notes

- ⚠️ **`VRCVERIFY_VERSION` is pinned to `1.2.1`** — the deploy compose pins images by that tag, so this needs a new build + push + bump or the deploy ships nothing.
- First restart still needs one clean login; persistence only helps once a cookie is stored.
- Watch the first real verification for `source=profile`. `source=users` means the fallback is engaging.
- Affected users can simply retry once deployed.

## Follow-ups (not in this PR)

- Once `/profile/` lands in the OpenAPI spec, replace the raw `call_api` with a generated model.
- Matcher hardening (lowercase, zero-width chars, code sharing a line) — real brittleness, but never the cause here.
