### PR TITLE
Harden /profile lookup and session persistence (adversarial review follow-up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,12 @@ cython_debug/
 # Local security audit notes (never commit)
 SECURITY_AUDIT.md
 
-# VRChat session cookie store (VRCHAT_SESSION_FILE) - an auth credential
+# VRChat session cookie store (VRCHAT_SESSION_FILE) - an auth credential.
+# Broad on purpose: any of these are plausible local VRCHAT_SESSION_FILE
+# values and none of them may ever be committed.
 vrchat_session.txt
+vrchat_session.txt.tmp
 *.session.txt
+*session*.txt
+cookies.txt
+*cookiejar*

--- a/src/bot.py
+++ b/src/bot.py
@@ -2,7 +2,7 @@ import os
 import json
 import asyncio
 import logging
-import random
+import secrets
 import string
 import re
 import time
@@ -797,7 +797,23 @@ async def process_verification(interaction: discord.Interaction):
 
 
 def generate_verification_code() -> str:
-    return "VRC-" + "".join(random.choices(string.ascii_uppercase + string.digits, k=6))
+    # secrets, not random: this token gates 18+ verification, and random's
+    # Mersenne Twister is predictable from observed output. 36**6 keyspace.
+    return "VRC-" + "".join(secrets.choice(string.ascii_uppercase + string.digits) for _ in range(6))
+
+
+# Discord rejects nicknames over 32 characters with a 400 -- which surfaces as
+# discord.HTTPException, NOT Forbidden. VRChat display names have no such
+# limit, so clamp before sending or the edit raises past the Forbidden-only
+# handlers and skips the bookkeeping that follows it.
+DISCORD_NICK_MAX_LEN = 32
+
+
+def discord_safe_nickname(display_name) -> str | None:
+    """Clamp a VRChat display name to something Discord will accept."""
+    if not isinstance(display_name, str):
+        return None
+    return display_name.strip()[:DISCORD_NICK_MAX_LEN] or None
 
 
 # Per-user cooldown on actions that publish to the checker, so a single user
@@ -1043,12 +1059,17 @@ async def assign_role(
                 asyncio.create_task(_delayed_cleanup())
 
         # Auto-nickname change if enabled
-        if auto_nick and display_name:
+        safe_nick = discord_safe_nickname(display_name)
+        if auto_nick and safe_nick:
             try:
-                await member.edit(nick=display_name)
-                logger.info(f"🔄 Updated nickname to {display_name} for {member}.")
-                await dm_localized(member, guild, "nickname_updated", instr_locale, display_name=display_name)
-            except discord.Forbidden:
+                await member.edit(nick=safe_nick)
+                logger.info(f"🔄 Updated nickname to {safe_nick} for {member}.")
+                await dm_localized(member, guild, "nickname_updated", instr_locale, display_name=safe_nick)
+            # Forbidden subclasses HTTPException; catching the parent also covers
+            # a 400 from an unacceptable nickname. Letting that escape would skip
+            # the milestone bookkeeping that runs after assign_role returns.
+            except discord.HTTPException:
+                logger.warning(f"Could not set nickname for {member}.", exc_info=True)
                 await dm_localized(member, guild, "nickname_update_failed", instr_locale)
     else:
         # Not 18+
@@ -1540,11 +1561,15 @@ async def handle_verification_result(data: dict):
 
         # — On-demand nickname update flow —
         if update_nick:
-            if member and display_name:
+            safe_nick = discord_safe_nickname(display_name)
+            if member and safe_nick:
                 # try to change nickname
                 try:
-                    await member.edit(nick=display_name)
-                except discord.Forbidden:
+                    await member.edit(nick=safe_nick)
+                # Forbidden subclasses HTTPException; the parent also covers a
+                # 400 from a nickname Discord won't accept.
+                except discord.HTTPException:
+                    logger.warning("Could not update nickname for %s.", discord_id, exc_info=True)
                     # Notify user on failure
                     try:
                         await member.send("⚠️ We could not update your username.")
@@ -1553,7 +1578,7 @@ async def handle_verification_result(data: dict):
                     return
                 # Confirm on success
                 try:
-                    await member.send(f"✅ Your nickname has been updated to **{display_name}**.")
+                    await member.send(f"✅ Your nickname has been updated to **{safe_nick}**.")
                 except discord.Forbidden:
                     logger.warning("⚠️ Cannot DM user after nickname success.")
             return

--- a/src/vrc_online_checker.py
+++ b/src/vrc_online_checker.py
@@ -444,7 +444,10 @@ def _vrchat_relogin_loop():
 # -------------------------------------------------------------------
 VRCHAT_STATUS_SUMMARY_URL = os.getenv("VRCHAT_STATUS_SUMMARY_URL", "https://status.vrchat.com/api/v2/summary.json")
 VRCHAT_STATUS_CACHE_SECONDS = int(os.getenv("VRCHAT_STATUS_CACHE_SECONDS", "120"))
-VRCHAT_LOOKUP_RETRIES = int(os.getenv("VRCHAT_LOOKUP_RETRIES", "3"))
+# Floor of 1: this counts total attempts, not extra retries. At 0 the retry
+# loops would fall through without ever calling VRChat, reporting every user
+# as "code not found" with lookup_ok=True -- a silent, misdiagnosable failure.
+VRCHAT_LOOKUP_RETRIES = max(1, int(os.getenv("VRCHAT_LOOKUP_RETRIES", "3")))
 VRCHAT_LOOKUP_BACKOFF_BASE = float(os.getenv("VRCHAT_LOOKUP_BACKOFF_BASE", "1.5"))
 
 _vrchat_status_cache: dict[str, object] = {
@@ -611,7 +614,8 @@ def _classify_vrchat_api_error(exc: Exception) -> dict:
 def _get_vrchat_user_with_retry(users_api_instance, vrc_user_id: str):
     last_exc = None
     request_timeout = _vrchat_request_timeout()
-    for attempt in range(1, VRCHAT_LOOKUP_RETRIES + 1):
+    attempts = max(1, VRCHAT_LOOKUP_RETRIES)  # never skip the call entirely
+    for attempt in range(1, attempts + 1):
         try:
             return users_api_instance.get_user(vrc_user_id, _request_timeout=request_timeout)
         except ApiException as e:
@@ -619,7 +623,7 @@ def _get_vrchat_user_with_retry(users_api_instance, vrc_user_id: str):
             status = getattr(e, "status", None)
             if status not in {500, 502, 503, 504, 429}:
                 raise
-            if attempt >= VRCHAT_LOOKUP_RETRIES:
+            if attempt >= attempts:
                 raise
             delay = min(8.0, VRCHAT_LOOKUP_BACKOFF_BASE * attempt) + random.uniform(0.0, 0.35)
             logging.warning(
@@ -628,21 +632,22 @@ def _get_vrchat_user_with_retry(users_api_instance, vrc_user_id: str):
                 status,
                 delay,
                 attempt,
-                VRCHAT_LOOKUP_RETRIES,
+                attempts,
             )
             time.sleep(delay)
         except Exception as e:
             last_exc = e
-            if attempt >= VRCHAT_LOOKUP_RETRIES:
+            if attempt >= attempts:
                 raise
             delay = min(8.0, VRCHAT_LOOKUP_BACKOFF_BASE * attempt) + random.uniform(0.0, 0.35)
             logging.warning(
                 "Transient VRChat get_user failure for %s. Retrying in %.2fs (attempt %s/%s)",
-                vrc_user_id, delay, attempt, VRCHAT_LOOKUP_RETRIES, exc_info=True
+                vrc_user_id, delay, attempt, attempts, exc_info=True
             )
             time.sleep(delay)
-    if last_exc:
-        raise last_exc
+    # Returning None here would silently become bio="" / age="unknown", i.e.
+    # a false "code not found" with lookup_ok=True. Fail loudly instead.
+    raise last_exc or RuntimeError("VRChat get_user retry loop exited without a result")
 
 
 # -------------------------------------------------------------------
@@ -695,12 +700,13 @@ def _get_vrchat_profile_with_retry(client, vrc_user_id: str) -> dict:
     Anything else raises immediately so the caller can fall back to
     /users/{id} without first stacking retry delays on a permanent error.
     """
-    for attempt in range(1, VRCHAT_LOOKUP_RETRIES + 1):
+    attempts = max(1, VRCHAT_LOOKUP_RETRIES)  # never skip the call entirely
+    for attempt in range(1, attempts + 1):
         try:
             return _fetch_vrchat_profile(client, vrc_user_id)
         except ApiException as e:
             status = getattr(e, "status", None)
-            if status not in {500, 502, 503, 504, 429} or attempt >= VRCHAT_LOOKUP_RETRIES:
+            if status not in {500, 502, 503, 504, 429} or attempt >= attempts:
                 raise
             delay = min(8.0, VRCHAT_LOOKUP_BACKOFF_BASE * attempt) + random.uniform(0.0, 0.35)
             logging.warning(
@@ -709,10 +715,11 @@ def _get_vrchat_profile_with_retry(client, vrc_user_id: str) -> dict:
                 status,
                 delay,
                 attempt,
-                VRCHAT_LOOKUP_RETRIES,
+                attempts,
             )
             time.sleep(delay)
-    raise AssertionError("unreachable: retry loop always returns or raises")
+    # Only reachable if the loop body never ran, which max(1, ...) prevents.
+    raise RuntimeError("VRChat /profile retry loop exited without a result")
 
 
 def fetch_profile_snapshot(client, vrc_user_id: str) -> tuple[str, str, str | None, str]:
@@ -739,15 +746,25 @@ def fetch_profile_snapshot(client, vrc_user_id: str) -> tuple[str, str, str | No
         if profile is not None:
             bio = profile.get("bio")
             age_status = profile.get("ageVerificationStatus")
-            # Age gating is the security-critical field, so only trust this
-            # response when both fields are actually present.
-            if bio is not None and age_status is not None:
-                return bio, age_status, profile.get("displayName"), "profile"
+            display_name = profile.get("displayName")
+            # /profile is undocumented and parsed as raw JSON, so validate
+            # TYPES, not just presence. A non-str bio would otherwise reach
+            # bio_contains_code and raise, and that exception is turned into
+            # nack(requeue=True) upstream -- an infinite redelivery loop that
+            # wedges the whole queue. Falling back is always cheaper.
+            if isinstance(bio, str) and isinstance(age_status, str):
+                return (
+                    bio,
+                    age_status,
+                    display_name if isinstance(display_name, str) else None,
+                    "profile",
+                )
             logging.warning(
-                "VRChat /profile for %s missing fields (bio=%s, age=%s); falling back to /users",
+                "VRChat /profile for %s has unusable fields "
+                "(bio=%s, ageVerificationStatus=%s); falling back to /users",
                 vrc_user_id,
-                bio is not None,
-                age_status is not None,
+                type(bio).__name__,
+                type(age_status).__name__,
             )
 
     vrc_user = _get_vrchat_user_with_retry(users_api.UsersApi(client), vrc_user_id)
@@ -763,9 +780,17 @@ def fetch_profile_snapshot(client, vrc_user_id: str) -> tuple[str, str, str | No
 # Verification Logic
 # -------------------------------------------------------------------
 def bio_contains_code(bio: str | None, verification_code: str) -> bool:
-    """True if the verification code appears on its own line in the bio."""
+    """True if the verification code appears on its own line in the bio.
+
+    Defensive about both arguments: the bio can come from an undocumented
+    endpoint parsed as raw JSON, and the code arrives over RabbitMQ, so
+    neither is guaranteed to be a string. Returning False (fail-closed)
+    beats raising, because callers turn exceptions into requeued messages.
+    """
+    if not isinstance(bio, str) or not isinstance(verification_code, str):
+        return False
     stripped_code = verification_code.strip()
-    for line in (bio or "").splitlines():
+    for line in bio.splitlines():
         if stripped_code == line.strip():
             return True
     return False
@@ -868,6 +893,11 @@ def verify_and_build_result(discord_id, vrc_user_id, guild_id, verification_code
             **_classify_vrchat_api_error(e),
         )
 
+    # Do NOT swap this for /profile's `ageVerified` boolean: they disagree.
+    # A live user was observed with ageVerificationStatus="hidden" but
+    # ageVerified=true, so trusting the boolean would verify users VRChat
+    # has not age-verified. Both endpoints use this same status vocabulary
+    # ("18+", "hidden", "none"), verified across users of each kind.
     is_18_plus = age_status == "18+"
 
     code_found = False

--- a/src/vrc_online_checker.py
+++ b/src/vrc_online_checker.py
@@ -177,8 +177,13 @@ def fetch_latest_2fa_code():
 VRCHAT_SESSION_FILE = os.getenv("VRCHAT_SESSION_FILE", "").strip()
 
 
-def _attach_session_store(api_client) -> MozillaCookieJar | None:
+def _attach_session_store(api_client, load_existing: bool = True) -> MozillaCookieJar | None:
     """Back the client's cookie jar with VRCHAT_SESSION_FILE, if configured.
+
+    The jar is attached even when load_existing is False, so cookies issued
+    by a fresh login still get persisted -- otherwise a login that follows a
+    rejected session would leave nothing on disk, defeating the feature in
+    exactly the case it exists for.
 
     Returns the jar so a caller can persist it after a successful login, or
     None when persistence is disabled. Never raises: failing to reuse a
@@ -188,13 +193,17 @@ def _attach_session_store(api_client) -> MozillaCookieJar | None:
         return None
 
     jar = MozillaCookieJar(VRCHAT_SESSION_FILE)
-    if os.path.exists(VRCHAT_SESSION_FILE):
+    if load_existing and os.path.exists(VRCHAT_SESSION_FILE):
         try:
             jar.load(ignore_discard=True, ignore_expires=True)
             logging.info("Loaded stored VRChat session from %s", VRCHAT_SESSION_FILE)
         except Exception:
+            # load() inserts every line it parsed before raising, so a torn
+            # file (save is not atomic) leaves a TRUNCATED auth cookie behind.
+            # Sending that would fail auth in a confusing way -- drop it all.
+            jar.clear()
             logging.warning(
-                "Stored VRChat session at %s is unreadable; ignoring it",
+                "Stored VRChat session at %s is unreadable; discarding it",
                 VRCHAT_SESSION_FILE,
                 exc_info=True,
             )
@@ -206,17 +215,41 @@ def _attach_session_store(api_client) -> MozillaCookieJar | None:
     return jar
 
 
+def _jar_sends_cookies(jar: MozillaCookieJar | None, host: str) -> bool:
+    """True only if the jar would actually send cookies to `host`.
+
+    len(jar) is the wrong test: we load with ignore_expires=True, so expired
+    cookies inflate the count even though add_cookie_header filters them out
+    at request time. A fully expired store must not look like a live session.
+    """
+    if not jar:
+        return False
+    try:
+        probe = urllib_request.Request(host)
+        jar.add_cookie_header(probe)
+        return bool(probe.get_header("Cookie"))
+    except Exception:
+        logging.warning("Could not evaluate stored session cookies", exc_info=True)
+        return False
+
+
 def _persist_session(jar: MozillaCookieJar | None) -> None:
-    """Write the auth cookie to disk, owner-readable only."""
+    """Write the auth cookie to disk atomically, owner-readable only."""
     if jar is None:
         return
     try:
-        parent = os.path.dirname(os.path.abspath(VRCHAT_SESSION_FILE))
+        path = os.path.abspath(VRCHAT_SESSION_FILE)
+        parent = os.path.dirname(path)
         if parent:
             os.makedirs(parent, exist_ok=True)
-        jar.save(ignore_discard=True, ignore_expires=True)
-        os.chmod(VRCHAT_SESSION_FILE, 0o600)
-        logging.info("Stored VRChat session to %s", VRCHAT_SESSION_FILE)
+        # MozillaCookieJar.save() truncates in place, so being killed mid-write
+        # leaves a half-written file that loads as a truncated cookie. Write a
+        # temp file and rename, which is atomic on the same filesystem.
+        tmp = f"{path}.tmp"
+        jar.save(filename=tmp, ignore_discard=True, ignore_expires=True)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+        logging.info("Stored VRChat session to %s", path)
     except Exception:
         logging.warning(
             "Could not persist VRChat session to %s (continuing without it)",
@@ -241,12 +274,13 @@ def _discard_stored_session() -> None:
 # -------------------------------------------------------------------
 # VRChat Login with Auto 2FA
 # -------------------------------------------------------------------
-def login_to_vrchat(use_stored_session: bool = True):
+def login_to_vrchat(load_stored_session: bool = True):
     """Logs into VRChat and handles possible 2FA prompts automatically.
 
     Reuses a stored session cookie when one is available so that restarts do
-    not burn a 2FA email (see VRCHAT_SESSION_FILE). A stored session that
-    fails to authenticate is discarded and the login retried from scratch.
+    not burn a 2FA email (see VRCHAT_SESSION_FILE). A stored session that is
+    outright rejected is discarded and the login retried from scratch -- but
+    the retry still persists whatever session it establishes.
 
     Returns:
         tuple[vrchatapi.ApiClient | None, dict | None]:
@@ -260,8 +294,10 @@ def login_to_vrchat(use_stored_session: bool = True):
 
     api_client = vrchatapi.ApiClient(configuration)
     api_client.user_agent = "VRCVerifyBot/1.0 (contact@yourdomain.com)"
-    session_jar = _attach_session_store(api_client) if use_stored_session else None
-    reused_session = bool(session_jar and len(session_jar))
+    # Always attach the store; only loading is conditional. Newly issued
+    # cookies must land on disk even on a retry after a rejected session.
+    session_jar = _attach_session_store(api_client, load_existing=load_stored_session)
+    reused_session = _jar_sends_cookies(session_jar, configuration.host)
     auth_api = authentication_api.AuthenticationApi(api_client)
     request_timeout = _vrchat_request_timeout()
 
@@ -274,12 +310,14 @@ def login_to_vrchat(use_stored_session: bool = True):
         return api_client, None
 
     except UnauthorizedException as e:
-        # A stored cookie that no longer authenticates should not force us
-        # through 2FA (or strand us on a 429) -- drop it and try clean once.
-        if reused_session:
+        # "2FA required" (status 200) is the ordinary cold-login signal and
+        # must be handled in place -- it is NOT evidence the stored cookie is
+        # bad. Completing 2FA here refreshes the jar and persists it, instead
+        # of throwing the session away and paying for a second round trip.
+        if e.status != 200 and reused_session:
             logging.warning("Stored VRChat session rejected; retrying with a fresh login")
             _discard_stored_session()
-            return login_to_vrchat(use_stored_session=False)
+            return login_to_vrchat(load_stored_session=False)
 
         if e.status == 200:
             logging.info("2FA Required! Fetching code from email...")
@@ -298,7 +336,9 @@ def login_to_vrchat(use_stored_session: bool = True):
                     "vrchat_status_indicator": None,
                 }
 
-            if "Email 2 Factor Authentication" in e.reason:
+            # e.reason can be None; `in None` would raise TypeError from inside
+            # this handler, escape login_to_vrchat, and kill the relogin thread.
+            if "Email 2 Factor Authentication" in (e.reason or ""):
                 auth_api.verify2_fa_email_code(
                     TwoFactorEmailCode(two_factor_code),
                     _request_timeout=request_timeout,
@@ -436,7 +476,14 @@ def _vrchat_relogin_loop():
             continue
 
         logging.info("Attempting scheduled VRChat login retry")
-        attempt_vrchat_login(force=True)
+        try:
+            attempt_vrchat_login(force=True)
+        except Exception:
+            # This thread is the ONLY thing that can recover a lost session --
+            # the main thread is blocked consuming RabbitMQ. If it dies, every
+            # verification fails until someone restarts the container, so no
+            # exception may ever escape this loop.
+            logging.exception("Scheduled VRChat login retry raised; will retry")
         time.sleep(5)
 
 # -------------------------------------------------------------------
@@ -833,9 +880,18 @@ def process_verification_request(ch, method, properties, body):
         logging.exception("RabbitMQ publish failed; requeueing request")
         ch.basic_nack(delivery_tag=method.delivery_tag, requeue=True)
     except Exception:
-        # Unknown failure; requeue once (may need DLQ in production).
-        logging.exception("Unexpected error processing request; requeueing")
-        ch.basic_nack(delivery_tag=method.delivery_tag, requeue=True)
+        # Requeue at most once. An unconditional requeue turns any unhandled
+        # bug into an unbounded redelivery loop, and with prefetch_count=1
+        # that single message stalls verification for every server. Retrying
+        # once covers transient faults; a second identical failure means the
+        # message itself is poison, so drop it rather than wedge the queue.
+        # (A dead-letter queue would be the better home for these.)
+        already_retried = bool(getattr(method, "redelivered", False))
+        logging.exception(
+            "Unexpected error processing request; %s",
+            "dropping (already retried once)" if already_retried else "requeueing once",
+        )
+        ch.basic_nack(delivery_tag=method.delivery_tag, requeue=not already_retried)
 
 
 def verify_and_build_result(discord_id, vrc_user_id, guild_id, verification_code):
@@ -1006,7 +1062,43 @@ def listen_for_verifications():
 # -------------------------------------------------------------------
 # Main
 # -------------------------------------------------------------------
+def _check_session_store_writable() -> bool:
+    """Log at ERROR if session persistence is configured but unusable.
+
+    A named volume created before the image gained /data mounts root-owned,
+    so uid 10001 cannot write there. _persist_session only warns, which means
+    persistence would stay silently off forever and every restart would burn
+    a 2FA email. Surface it loudly at startup instead.
+    """
+    if not VRCHAT_SESSION_FILE:
+        logging.info("VRCHAT_SESSION_FILE unset; VRChat session will not persist across restarts")
+        return False
+    path = os.path.abspath(VRCHAT_SESSION_FILE)
+    probe = f"{path}.probe"
+    try:
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(probe, "w", encoding="utf-8") as fh:
+            fh.write("ok")
+        os.remove(probe)
+        logging.info("Session store at %s is writable", path)
+        return True
+    except Exception as exc:
+        logging.error(
+            "Session store %s is NOT writable (%s). Restarts will re-authenticate "
+            "and consume a 2FA email each time, risking a VRChat 429 lockout. "
+            "If running in Docker, check that the volume mounted at the parent "
+            "directory is owned by the container user.",
+            path,
+            exc,
+        )
+        return False
+
+
 if __name__ == "__main__":
+    _check_session_store_writable()
+
     logging.info("Attempting initial VRChat login")
     attempt_vrchat_login(force=True)
     if not get_vrchat_session()[0]:

--- a/tests/test_bot_helpers.py
+++ b/tests/test_bot_helpers.py
@@ -223,3 +223,56 @@ class TestBuildVrchatIssueMessage:
             {"error_type": "vrchat_user_not_found"}, locale_code="es-ES"
         )
         assert msg == localizations["es-ES"]["vrchat_issue_user_not_found"]
+
+
+class TestDiscordSafeNickname:
+    """Discord caps nicknames at 32 chars and 400s on longer values.
+
+    That surfaces as discord.HTTPException, NOT Forbidden, so an over-long
+    VRChat display name used to escape the Forbidden-only handler in
+    assign_role and skip the milestone bookkeeping that runs after it.
+    """
+
+    def test_short_name_passes_through(self):
+        assert bot.discord_safe_nickname("Italiandogs") == "Italiandogs"
+
+    def test_over_long_name_is_clamped(self):
+        name = "A" * 100
+        out = bot.discord_safe_nickname(name)
+        assert len(out) == bot.DISCORD_NICK_MAX_LEN == 32
+
+    def test_exactly_at_limit_is_untouched(self):
+        name = "B" * 32
+        assert bot.discord_safe_nickname(name) == name
+
+    def test_whitespace_is_trimmed(self):
+        assert bot.discord_safe_nickname("  Name  ") == "Name"
+
+    def test_whitespace_only_becomes_none(self):
+        # Discord rejects an empty nickname; None means "skip the edit".
+        assert bot.discord_safe_nickname("   ") is None
+
+    @pytest.mark.parametrize("bad", [None, 123, {"n": "x"}, ["n"], True])
+    def test_non_string_becomes_none(self, bad):
+        # display_name arrives from raw /profile JSON over RabbitMQ.
+        assert bot.discord_safe_nickname(bad) is None
+
+
+class TestVerificationCodeGeneration:
+    def test_uses_cryptographic_randomness(self):
+        # The code gates 18+ verification; random's Mersenne Twister is
+        # predictable from observed output, so secrets must be used.
+        import inspect
+
+        src = inspect.getsource(bot.generate_verification_code)
+        assert "secrets." in src
+        assert "random." not in src
+
+    def test_shape_and_charset(self):
+        codes = {bot.generate_verification_code() for _ in range(200)}
+        assert len(codes) > 190  # no obvious collisions
+        for c in codes:
+            assert c.startswith("VRC-")
+            body = c[4:]
+            assert len(body) == 6
+            assert all(ch in string.ascii_uppercase + string.digits for ch in body)

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -9,6 +9,7 @@ faked VRChat session.
 
 import json
 import os
+from http.cookiejar import Cookie, MozillaCookieJar
 from types import SimpleNamespace
 
 import pytest
@@ -382,9 +383,11 @@ class TestRetryCountFloor:
     user reported "code not found" with lookup_ok=True, i.e. a silent lie.
     """
 
-    def test_config_floor_is_at_least_one(self, monkeypatch):
-        monkeypatch.setenv("VRCHAT_LOOKUP_RETRIES", "0")
-        assert max(1, int(os.environ["VRCHAT_LOOKUP_RETRIES"])) == 1
+    def test_module_config_is_floored(self):
+        # Asserts the FLOOR IN THE MODULE, not a restatement of max(). An
+        # earlier version of this test asserted `max(1, 0) == 1`, which passed
+        # even with the floor deleted from the source.
+        assert checker.VRCHAT_LOOKUP_RETRIES >= 1
 
     def test_get_user_never_returns_none(self, monkeypatch):
         monkeypatch.setattr(checker, "VRCHAT_LOOKUP_RETRIES", 0)
@@ -414,6 +417,59 @@ class TestRetryCountFloor:
         assert calls == ["usr_1"]
 
 
+class TestLoginRobustness:
+    """Nothing may escape login_to_vrchat into the relogin thread.
+
+    _vrchat_relogin_loop is the ONLY thing that can recover a lost session
+    (the main thread is blocked consuming RabbitMQ). If an exception kills
+    that thread, every verification fails until the container is restarted.
+    """
+
+    def test_none_reason_on_2fa_challenge_does_not_raise(self, monkeypatch):
+        """`"..." in e.reason` raised TypeError when reason was None.
+
+        It raised from INSIDE the except UnauthorizedException handler, so it
+        escaped login_to_vrchat and would have killed the relogin thread.
+        """
+        monkeypatch.setattr(checker, "VRCHAT_SESSION_FILE", "")
+        monkeypatch.setattr(
+            checker.vrchatapi, "Configuration",
+            lambda **k: SimpleNamespace(host="https://api.vrchat.cloud/api/1"),
+        )
+        monkeypatch.setattr(
+            checker.vrchatapi, "ApiClient",
+            lambda cfg: SimpleNamespace(
+                user_agent="", rest_client=SimpleNamespace(cookie_jar=None)
+            ),
+        )
+        exc = checker.UnauthorizedException(status=200)
+        exc.reason = None  # VRChat gave us no reason string
+
+        def get_current_user(**kwargs):
+            raise exc
+
+        monkeypatch.setattr(
+            checker.authentication_api, "AuthenticationApi",
+            lambda c: SimpleNamespace(get_current_user=get_current_user),
+        )
+        monkeypatch.setattr(checker, "fetch_latest_2fa_code", lambda: None)
+
+        # Must return a structured error, not raise.
+        client, err = checker.login_to_vrchat()
+        assert client is None
+        assert err["error_type"] == "vrchat_auth_error"
+
+    def test_relogin_loop_body_guards_exceptions(self):
+        """The retry call must be wrapped so the thread cannot die."""
+        import inspect
+
+        src = inspect.getsource(checker._vrchat_relogin_loop)
+        assert "try:" in src and "except Exception" in src, (
+            "attempt_vrchat_login must be guarded; an unguarded raise kills "
+            "the only thread that can recover a VRChat session"
+        )
+
+
 class TestSessionPersistence:
     """Storing the auth cookie keeps restarts from re-authenticating.
 
@@ -422,34 +478,96 @@ class TestSessionPersistence:
     down. None of this may ever block a login, hence the tolerance tests.
     """
 
+    HOST = "https://api.vrchat.cloud/api/1"
+
     def _client(self):
         return SimpleNamespace(rest_client=SimpleNamespace(cookie_jar=object()))
+
+    @staticmethod
+    def _cookie(name="auth", value="authcookie_" + "A" * 40, expires=2000000000):
+        return Cookie(
+            0, name, value, None, False, "api.vrchat.cloud", True, False,
+            "/", True, True, expires, False, None, None, {},
+        )
 
     def test_disabled_when_unset(self, monkeypatch):
         monkeypatch.setattr(checker, "VRCHAT_SESSION_FILE", "")
         assert checker._attach_session_store(self._client()) is None
 
-    def test_roundtrip_persists_and_reloads(self, monkeypatch, tmp_path):
+    def test_real_cookie_roundtrips_and_would_be_sent(self, monkeypatch, tmp_path):
+        """A REAL cookie must survive save+load and still be sendable.
+
+        The previous version of this test persisted an EMPTY jar, so it passed
+        on nothing but the Netscape header -- it stayed green even if
+        ignore_discard was dropped, which silently discards the session
+        cookie that makes 2FA-skipping work.
+        """
         path = tmp_path / "session.txt"
         monkeypatch.setattr(checker, "VRCHAT_SESSION_FILE", str(path))
 
         client = self._client()
         jar = checker._attach_session_store(client)
-        assert jar is not None
         assert client.rest_client.cookie_jar is jar
+        jar.set_cookie(self._cookie())
+        # session cookie (expires=None) -- only kept if ignore_discard is used
+        jar.set_cookie(self._cookie("twoFactorAuth", "tfa_" + "B" * 40, None))
+        checker._persist_session(jar)
 
+        reloaded = checker._attach_session_store(self._client())
+        names = sorted(c.name for c in reloaded)
+        assert names == ["auth", "twoFactorAuth"], f"lost cookies: {names}"
+        assert checker._jar_sends_cookies(reloaded, self.HOST) is True
+
+    def test_torn_file_yields_no_cookies(self, monkeypatch, tmp_path):
+        """A half-written file must not leave a TRUNCATED cookie behind.
+
+        MozillaCookieJar.save truncates in place and load() inserts every row
+        it parsed before raising, so a torn file used to come back holding a
+        partial auth cookie while the log claimed it was ignored.
+        """
+        path = tmp_path / "session.txt"
+        monkeypatch.setattr(checker, "VRCHAT_SESSION_FILE", str(path))
+        jar = checker._attach_session_store(self._client())
+        jar.set_cookie(self._cookie())
+        jar.set_cookie(self._cookie("twoFactorAuth", "tfa_" + "B" * 40, 2000000000))
+        checker._persist_session(jar)
+
+        raw = path.read_bytes()
+        path.write_bytes(raw[: int(len(raw) * 0.8)])  # simulate a torn write
+
+        reloaded = checker._attach_session_store(self._client())
+        assert reloaded is not None
+        assert len(reloaded) == 0, "partial cookies survived a torn file"
+        assert checker._jar_sends_cookies(reloaded, self.HOST) is False
+
+    def test_persist_is_atomic_no_tmp_left_behind(self, monkeypatch, tmp_path):
+        path = tmp_path / "session.txt"
+        monkeypatch.setattr(checker, "VRCHAT_SESSION_FILE", str(path))
+        jar = checker._attach_session_store(self._client())
+        jar.set_cookie(self._cookie())
         checker._persist_session(jar)
         assert path.exists()
+        assert not (tmp_path / "session.txt.tmp").exists()
 
-        # A second client picks the stored session back up.
-        assert checker._attach_session_store(self._client()) is not None
+    def test_expired_only_jar_is_not_a_live_session(self, monkeypatch, tmp_path):
+        """len(jar) counts expired cookies; they are never actually sent.
 
-    def test_corrupt_session_file_is_ignored(self, monkeypatch, tmp_path):
+        Treating that as a live session made the ordinary "2FA required"
+        response look like a rejected cookie.
+        """
         path = tmp_path / "session.txt"
-        path.write_text("this is not a cookie jar", encoding="utf-8")
         monkeypatch.setattr(checker, "VRCHAT_SESSION_FILE", str(path))
-        # Must not raise: a bad file falls back to a normal login.
-        assert checker._attach_session_store(self._client()) is not None
+        jar = checker._attach_session_store(self._client())
+        jar.set_cookie(self._cookie(expires=1))  # long expired
+        checker._persist_session(jar)
+
+        reloaded = checker._attach_session_store(self._client())
+        assert len(reloaded) == 1  # loaded with ignore_expires
+        assert checker._jar_sends_cookies(reloaded, self.HOST) is False
+
+    def test_jar_sends_cookies_handles_none_and_empty(self):
+        assert checker._jar_sends_cookies(None, self.HOST) is False
+        assert checker._jar_sends_cookies(MozillaCookieJar(), self.HOST) is False
 
     def test_persist_failure_is_swallowed(self, monkeypatch, tmp_path):
         monkeypatch.setattr(checker, "VRCHAT_SESSION_FILE", str(tmp_path / "s.txt"))
@@ -472,77 +590,149 @@ class TestSessionPersistence:
         assert not path.exists()
         checker._discard_stored_session()  # already gone: still must not raise
 
-    def _patch_login_stack(self, monkeypatch, get_current_user):
-        """Fake out ApiClient/AuthenticationApi for login_to_vrchat."""
-        monkeypatch.setattr(
-            checker.vrchatapi, "Configuration", lambda **k: SimpleNamespace()
-        )
+    def _patch_login_stack(self, monkeypatch, get_current_user, cookies_on_auth=None):
+        """Fake ApiClient/AuthenticationApi but keep the REAL jar and file.
+
+        Deliberately does NOT stub _attach_session_store/_persist_session --
+        the earlier version did, so the real jar and file were never exercised
+        and the tests proved nothing about persistence.
+        """
         monkeypatch.setattr(
             checker.vrchatapi,
-            "ApiClient",
-            lambda cfg: SimpleNamespace(
+            "Configuration",
+            lambda **k: SimpleNamespace(host=self.HOST),
+        )
+        created = []
+
+        def make_client(cfg):
+            c = SimpleNamespace(
                 user_agent="", rest_client=SimpleNamespace(cookie_jar=None)
-            ),
-        )
+            )
+            created.append(c)
+            return c
+
+        monkeypatch.setattr(checker.vrchatapi, "ApiClient", make_client)
+
+        def make_auth(client):
+            def _get(**kwargs):
+                result = get_current_user(**kwargs)
+                # Simulate VRChat issuing fresh cookies on a successful login.
+                if cookies_on_auth:
+                    for c in cookies_on_auth:
+                        client.rest_client.cookie_jar.set_cookie(c)
+                return result
+
+            return SimpleNamespace(get_current_user=_get)
+
+        monkeypatch.setattr(checker.authentication_api, "AuthenticationApi", make_auth)
         monkeypatch.setattr(
-            checker.authentication_api,
-            "AuthenticationApi",
-            lambda c: SimpleNamespace(get_current_user=get_current_user),
+            checker, "fetch_latest_2fa_code",
+            lambda: (_ for _ in ()).throw(AssertionError("unexpected 2FA")),
         )
+        return created
 
-    def test_rejected_stored_session_retries_clean_without_looping(self, monkeypatch):
-        """A stale cookie must not strand us or recurse forever.
+    def test_rejected_session_still_persists_the_new_one(self, monkeypatch, tmp_path):
+        """The retry after a rejected cookie MUST still store its session.
 
-        Without this, a rejected stored session would be sent through the 2FA
-        path -- the exact endpoint VRChat rate-limits.
+        Regression: the retry passed use_stored_session=False, which also
+        skipped attaching the jar, so _persist_session got None. The stale
+        file had already been deleted -- so a rejected session left NOTHING
+        on disk and the next restart burned a 2FA email, defeating the whole
+        feature in exactly the case it exists for. The previous test actually
+        asserted the broken behaviour (`attach == 1`).
         """
-        calls = {"get_current_user": 0, "discarded": 0, "attach": 0}
+        path = tmp_path / "session.txt"
+        monkeypatch.setattr(checker, "VRCHAT_SESSION_FILE", str(path))
+
+        # Seed a stored session that VRChat will reject.
+        seed = MozillaCookieJar(str(path))
+        seed.set_cookie(self._cookie("auth", "stale_" + "C" * 40))
+        seed.save(ignore_discard=True, ignore_expires=True)
+        assert path.exists()
+
+        n = {"calls": 0}
 
         def get_current_user(**kwargs):
-            calls["get_current_user"] += 1
-            if calls["get_current_user"] == 1:
+            n["calls"] += 1
+            if n["calls"] == 1:
                 raise checker.UnauthorizedException(status=401)
             return SimpleNamespace(display_name="ClubLA Bot")
 
-        self._patch_login_stack(monkeypatch, get_current_user)
+        fresh = self._cookie("auth", "fresh_" + "D" * 40)
+        self._patch_login_stack(monkeypatch, get_current_user, cookies_on_auth=[fresh])
 
-        def fake_attach(client):
-            calls["attach"] += 1
-            # Non-empty jar on the first pass => a stored session was reused.
-            return ["cookie"] if calls["attach"] == 1 else None
+        client, err = checker.login_to_vrchat()
+        assert err is None and client is not None
+        assert n["calls"] == 2  # retried exactly once, no loop
 
-        monkeypatch.setattr(checker, "_attach_session_store", fake_attach)
-        monkeypatch.setattr(checker, "_persist_session", lambda jar: None)
+        assert path.exists(), "retry login left no stored session"
+        after = MozillaCookieJar(str(path))
+        after.load(ignore_discard=True, ignore_expires=True)
+        values = [c.value for c in after]
+        assert any(v.startswith("fresh_") for v in values), values
+        assert not any(v.startswith("stale_") for v in values), values
+
+    def test_2fa_required_is_handled_in_place_not_treated_as_bad_cookie(
+        self, monkeypatch, tmp_path
+    ):
+        """status==200 means "do 2FA", not "your stored cookie is bad".
+
+        With an expired-only store, reused_session used to be True (len counts
+        expired cookies), so the ordinary 2FA challenge was misread as a
+        rejected cookie: the file got deleted and a second round trip spent.
+        """
+        path = tmp_path / "session.txt"
+        monkeypatch.setattr(checker, "VRCHAT_SESSION_FILE", str(path))
+        seed = MozillaCookieJar(str(path))
+        seed.set_cookie(self._cookie("auth", "expired_" + "E" * 40, expires=1))
+        seed.save(ignore_discard=True, ignore_expires=True)
+
+        n = {"calls": 0, "discards": 0}
         monkeypatch.setattr(
-            checker,
-            "_discard_stored_session",
-            lambda: calls.__setitem__("discarded", calls["discarded"] + 1),
+            checker, "_discard_stored_session",
+            lambda: n.__setitem__("discards", n["discards"] + 1),
+        )
+
+        def get_current_user(**kwargs):
+            n["calls"] += 1
+            if n["calls"] == 1:
+                raise checker.UnauthorizedException(status=200)
+            return SimpleNamespace(display_name="ClubLA Bot")
+
+        fresh = self._cookie("auth", "fresh_" + "F" * 40)
+        self._patch_login_stack(monkeypatch, get_current_user, cookies_on_auth=[fresh])
+        monkeypatch.setattr(checker, "fetch_latest_2fa_code", lambda: "123456")
+        monkeypatch.setattr(
+            checker.authentication_api, "AuthenticationApi",
+            lambda c: SimpleNamespace(
+                get_current_user=lambda **k: (
+                    get_current_user(**k),
+                    c.rest_client.cookie_jar.set_cookie(fresh),
+                )[0],
+                verify2_fa_email_code=lambda code, **k: None,
+                verify2_fa=lambda code, **k: None,
+            ),
         )
 
         client, err = checker.login_to_vrchat()
-
         assert err is None and client is not None
-        assert calls["discarded"] == 1
-        assert calls["get_current_user"] == 2  # retried exactly once
-        assert calls["attach"] == 1  # retry did not re-load the stored session
+        assert n["discards"] == 0, "2FA challenge was misread as a bad cookie"
 
-    def test_stored_session_skips_2fa_entirely(self, monkeypatch):
-        def get_current_user(**kwargs):
-            return SimpleNamespace(display_name="ClubLA Bot")
+    def test_stored_session_skips_2fa_entirely(self, monkeypatch, tmp_path):
+        """A live stored cookie must authenticate with no 2FA at all."""
+        path = tmp_path / "session.txt"
+        monkeypatch.setattr(checker, "VRCHAT_SESSION_FILE", str(path))
+        seed = MozillaCookieJar(str(path))
+        seed.set_cookie(self._cookie())
+        seed.save(ignore_discard=True, ignore_expires=True)
 
-        self._patch_login_stack(monkeypatch, get_current_user)
-        monkeypatch.setattr(checker, "_attach_session_store", lambda c: ["cookie"])
-        saved = []
-        monkeypatch.setattr(checker, "_persist_session", lambda jar: saved.append(jar))
-
-        def no_2fa():
-            raise AssertionError("2FA must not be used when a session is reused")
-
-        monkeypatch.setattr(checker, "fetch_latest_2fa_code", no_2fa)
-
+        # _patch_login_stack makes fetch_latest_2fa_code raise if called.
+        self._patch_login_stack(
+            monkeypatch, lambda **k: SimpleNamespace(display_name="ClubLA Bot")
+        )
         client, err = checker.login_to_vrchat()
         assert err is None and client is not None
-        assert saved  # session refreshed on disk
+        assert path.exists()  # session refreshed on disk
 
 
 class TestVerifyAndBuildResult:

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -8,6 +8,7 @@ faked VRChat session.
 """
 
 import json
+import os
 from types import SimpleNamespace
 
 import pytest
@@ -57,6 +58,17 @@ class TestBioContainsCode:
 
     def test_none_bio_does_not_crash(self):
         assert not checker.bio_contains_code(None, "VRC-ABC123")
+
+    @pytest.mark.parametrize("bad", [{"t": "x"}, 123, ["VRC-ABC123"], True, object()])
+    def test_non_string_bio_is_false_not_an_exception(self, bad):
+        # Callers turn exceptions into requeued RabbitMQ messages, so this
+        # must fail closed rather than raise.
+        assert checker.bio_contains_code(bad, "VRC-ABC123") is False
+
+    @pytest.mark.parametrize("bad", [None, 123, {"c": "x"}])
+    def test_non_string_code_is_false_not_an_exception(self, bad):
+        # The code arrives over RabbitMQ and is not guaranteed to be a string.
+        assert checker.bio_contains_code("VRC-ABC123", bad) is False
 
 
 # ---------------------------------------------------------------
@@ -266,6 +278,57 @@ class TestFetchProfileSnapshot:
         assert bio == ""
         assert age == "none"
 
+    @pytest.mark.parametrize(
+        "bad_bio", [{"text": "VRC-ABC123"}, 12345, ["VRC-ABC123"], True]
+    )
+    def test_non_string_bio_falls_back_instead_of_raising(self, monkeypatch, bad_bio):
+        """A type change on the undocumented endpoint must not wedge the queue.
+
+        Regression: the guard used to check presence, not type, so a non-str
+        bio reached bio_contains_code and raised AttributeError. That escapes
+        verify_and_build_result into process_verification_request, which does
+        nack(requeue=True) -- with prefetch_count=1 that redelivers forever
+        and stops verification for every server.
+        """
+        client = self._client({"bio": bad_bio, "ageVerificationStatus": "18+"})
+        user = SimpleNamespace(
+            age_verification_status="18+", bio="from users", display_name="U"
+        )
+        monkeypatch.setattr(checker.users_api, "UsersApi", fake_users_api(user))
+        bio, _, _, source = checker.fetch_profile_snapshot(client, "usr_1")
+        assert source == "users"
+        assert bio == "from users"
+
+    def test_non_string_age_status_falls_back(self, monkeypatch):
+        client = self._client({"bio": "ok", "ageVerificationStatus": {"v": "18+"}})
+        user = SimpleNamespace(
+            age_verification_status="18+", bio="from users", display_name="U"
+        )
+        monkeypatch.setattr(checker.users_api, "UsersApi", fake_users_api(user))
+        _, _, _, source = checker.fetch_profile_snapshot(client, "usr_1")
+        assert source == "users"
+
+    def test_non_string_display_name_becomes_none(self):
+        """displayName crosses RabbitMQ into Discord nickname handling."""
+        client = self._client(
+            {"bio": "b", "ageVerificationStatus": "18+", "displayName": {"n": "x"}}
+        )
+        _, _, display_name, source = checker.fetch_profile_snapshot(client, "usr_1")
+        assert source == "profile"
+        assert display_name is None
+
+    def test_verify_survives_malformed_profile_bio(self, monkeypatch):
+        """End-to-end: a bad payload degrades, it does not raise."""
+        client = self._client({"bio": {"t": "x"}, "ageVerificationStatus": "18+"})
+        user = SimpleNamespace(
+            age_verification_status="18+", bio="my bio", display_name="U"
+        )
+        monkeypatch.setattr(checker, "get_vrchat_session", lambda: (client, None))
+        monkeypatch.setattr(checker.users_api, "UsersApi", fake_users_api(user))
+        result = checker.verify_and_build_result("d1", "usr_1", "g1", "VRC-ABC123")
+        assert result["lookup_ok"] is True
+        assert result["code_found"] is False
+
     def test_unauthorized_propagates(self, monkeypatch):
         # Must not be swallowed: the caller invalidates the session on this.
         client = self._client(exc=checker.UnauthorizedException(status=401))
@@ -308,6 +371,47 @@ class TestFetchProfileSnapshot:
         assert result["code_found"] is True
         assert result["is_18_plus"] is True
         assert result["display_name"] == "Fresh"
+
+
+class TestRetryCountFloor:
+    """VRCHAT_LOOKUP_RETRIES counts total attempts, not extra retries.
+
+    Regression: at 0 both retry loops fell through without ever calling
+    VRChat. The profile loop hit a bogus "unreachable" AssertionError and
+    get_user returned None, which became bio="" / age="unknown" -- every
+    user reported "code not found" with lookup_ok=True, i.e. a silent lie.
+    """
+
+    def test_config_floor_is_at_least_one(self, monkeypatch):
+        monkeypatch.setenv("VRCHAT_LOOKUP_RETRIES", "0")
+        assert max(1, int(os.environ["VRCHAT_LOOKUP_RETRIES"])) == 1
+
+    def test_get_user_never_returns_none(self, monkeypatch):
+        monkeypatch.setattr(checker, "VRCHAT_LOOKUP_RETRIES", 0)
+        calls = []
+
+        class Api:
+            def get_user(self, uid, _request_timeout=None):
+                calls.append(uid)
+                return SimpleNamespace(
+                    age_verification_status="18+", bio="b", display_name="U"
+                )
+
+        result = checker._get_vrchat_user_with_retry(Api(), "usr_1")
+        assert calls == ["usr_1"]  # the API was actually called
+        assert result is not None
+
+    def test_profile_lookup_still_runs(self, monkeypatch):
+        monkeypatch.setattr(checker, "VRCHAT_LOOKUP_RETRIES", 0)
+        calls = []
+
+        def fake_fetch(client, uid):
+            calls.append(uid)
+            return {"bio": "b", "ageVerificationStatus": "18+"}
+
+        monkeypatch.setattr(checker, "_fetch_vrchat_profile", fake_fetch)
+        assert checker._get_vrchat_profile_with_retry(object(), "usr_1")
+        assert calls == ["usr_1"]
 
 
 class TestSessionPersistence:


### PR DESCRIPTION
Follow-up to #47 (merged). An adversarial review of that change — one pass by me, one independent pass by a second reviewer agent — found real defects in both the `/profile` parsing and the session-persistence feature it shipped with. This PR fixes everything found and confirmed, with regression tests and empirical verification for each.

## /profile parsing (queue-wedging + silent false negatives)

- **Type validation, not just presence.** `/profile/{id}` is undocumented and parsed as raw JSON with no schema. The old guard checked `bio is not None` but not its *type* — a non-`str` `bio` (dict/int/list/bool) reached `bio_contains_code` **outside** the try/except in `verify_and_build_result`, raised `AttributeError`, and `process_verification_request` turned that into `nack(requeue=True)`. With `prefetch_count=1` that redelivers forever — **one malformed response from an undocumented endpoint stops verification for every server.** Proven, then re-verified fixed: the message is now acked and falls back to `/users/`.
- `bio_contains_code` now fails closed (`False`) instead of raising for non-`str` input on either argument.
- `displayName` is coerced to `str | None` since it crosses RabbitMQ into Discord nickname handling.
- `VRCHAT_LOOKUP_RETRIES=0` used to make both retry loops fall through **without ever calling VRChat**, silently reporting every user as "code not found" with `lookup_ok=True`. Floored at 1 in config and in both loops.
- Documented that `/profile`'s `ageVerified` boolean must never replace `ageVerificationStatus` — a live user was observed with `ageVerificationStatus="hidden"` and `ageVerified=true`. The status vocabulary itself was checked across 9 live users spanning `18+`/`hidden` with no fail-open direction.

## Session persistence (the feature was broken in the exact scenario it exists for)

- **A rejected stored session persisted nothing.** The retry path skipped attaching the jar entirely, and the stale file had already been deleted — so a rejected cookie left the bot with **no stored session at all**, meaning the *next* redeploy burns a 2FA email and risks the very 429 lockout this feature exists to prevent. Fixed: the jar is always attached; only loading is conditional.
- **A torn file was used, not ignored.** `save()` truncates in place with no rename; `load()` inserts every row it parsed before raising on a corrupt file. An interrupted write left a **truncated auth cookie** in the jar while the log said "ignoring it." Fixed: clear the jar on load failure, and make `save` atomic (write `.tmp`, `os.replace`).
- **An expired-only store looked like a live session.** `len(jar)` counts expired cookies even though `add_cookie_header` filters them at request time. Fixed: session liveness is now determined by whether the jar would actually emit a `Cookie` header.
- **"2FA required" (status 200) was misread as a rejected cookie**, because the reused-session check ran first. It's the ordinary cold-login signal and is now handled in place.

## Resilience

- `login_to_vrchat` raised `TypeError` (`"x" in e.reason` when `reason` is `None`) **from inside its own exception handler**, escaping into `_vrchat_relogin_loop` — which had no exception guard. That thread is the *only* thing that can recover a lost session (the main thread blocks on RabbitMQ), so this could take verification down until a manual restart. Both the `None` case and the unguarded loop are fixed.
- `process_verification_request` no longer requeues unconditionally on unknown exceptions — retries once via `method.redelivered`, then drops. The type-validation fix closes the specific trigger found; this closes the general mechanism, since the whole point of this feature is parsing an unversioned, undocumented payload shape.
- Startup now logs at `ERROR` if `VRCHAT_SESSION_FILE` is configured but unwritable (e.g. a named volume created before the image gained `/data` mounts root-owned) — previously this degraded silently to a warning and persistence stayed off forever with no visible signal.

## Bot-side

- Discord nicknames cap at 32 chars and a longer value 400s as `discord.HTTPException`, not `Forbidden`. An over-long VRChat display name escaped the `Forbidden`-only handlers and skipped the milestone bookkeeping that runs after `assign_role`. Both call sites now clamp to 32 chars and catch `HTTPException`.
- Verification codes now use `secrets` instead of `random` — the code gates 18+ verification and Mersenne Twister output is predictable from observed values.

## Tests

The original session-persistence tests were shown to prove very little: the roundtrip test persisted an **empty** jar (passes even if `ignore_discard` is dropped, which would silently lose the session cookie that makes 2FA-skipping work), the corruption test only exercised the one shape that happens to be safe, and one test asserted the *broken* no-persist behaviour outright (`attach == 1`). All replaced with tests using real cookies and real files. Added coverage for: non-`str` `bio`/`age_status`/`displayName` (parametrized), retry-count floor exercised against the real module (not a restated `max()`), rejected-session-still-persists, torn-file-yields-no-cookies, expired-only-is-not-live, `None`-reason 2FA handling, relogin-loop exception guarding, nickname clamping, and code-generation using `secrets`.

**223 tests pass.** Every fix was verified empirically against the real functions (not just via the test suite) before committing — see commit messages for the specific before/after evidence.
