### PR TITLE
Speed up instruction panel reinitialization on startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,5 +41,8 @@ LOG_LEVEL=INFO
 # VRCHAT_USE_PROFILE_ENDPOINT=true
 # INSTRUCTIONS_TRIGGER_PATH=/tmp/update_instructions.trigger
 # How many instruction panels are re-attached at once on startup (default 10).
-# Raise to speed up boot on large fleets; lower if Discord starts rate limiting.
 # INSTRUCTIONS_REFRESH_CONCURRENCY=10
+# Panel edits started per second (default 25). Discord's global ceiling is ~50
+# req/s for the whole bot, so keep headroom here or startup will throttle
+# verification traffic too.
+# INSTRUCTIONS_REFRESH_RATE=25

--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,6 @@ LOG_LEVEL=INFO
 # /users/{id} can serve a stale bio and break verification; set false to revert.
 # VRCHAT_USE_PROFILE_ENDPOINT=true
 # INSTRUCTIONS_TRIGGER_PATH=/tmp/update_instructions.trigger
+# How many instruction panels are re-attached at once on startup (default 10).
+# Raise to speed up boot on large fleets; lower if Discord starts rate limiting.
+# INSTRUCTIONS_REFRESH_CONCURRENCY=10

--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ See the sections below for details and configuration.
   # Optional: instruction message refresh trigger watched by bot.py
   INSTRUCTIONS_TRIGGER_PATH=/tmp/update_instructions.trigger
   INSTRUCTIONS_TRIGGER_POLL=5
+
+  # Optional: concurrent instruction panel edits on startup (default 10)
+  INSTRUCTIONS_REFRESH_CONCURRENCY=10
    ```
 
 4. **Database Setup:**

--- a/README.md
+++ b/README.md
@@ -207,8 +207,11 @@ See the sections below for details and configuration.
   INSTRUCTIONS_TRIGGER_PATH=/tmp/update_instructions.trigger
   INSTRUCTIONS_TRIGGER_POLL=5
 
-  # Optional: concurrent instruction panel edits on startup (default 10)
+  # Optional: startup instruction panel refresh tuning
+  # (edits in flight, and edits started per second; keep RATE under
+  # Discord's ~50 req/s global ceiling so verification traffic isn't throttled)
   INSTRUCTIONS_REFRESH_CONCURRENCY=10
+  INSTRUCTIONS_REFRESH_RATE=25
    ```
 
 4. **Database Setup:**

--- a/README.md
+++ b/README.md
@@ -214,6 +214,15 @@ See the sections below for details and configuration.
   INSTRUCTIONS_REFRESH_RATE=25
    ```
 
+   **Instruction panel buttons on restart.** Panel buttons use fixed
+   `custom_id`s and are registered once at startup via a persistent view, so
+   already-posted panels keep working across restarts without being re-edited.
+   The `instruction_panel_views` table records which button version each guild's
+   panel carries; it is created automatically, no manual migration needed. On
+   boot the bot only re-edits panels that predate the current version, plus any
+   that previously failed (revoked permissions, archived threads), which are
+   retried each boot so they recover once an admin fixes the channel.
+
 4. **Database Setup:**
 
    The bot automatically creates the necessary tables using SQLAlchemy when it runs. Make sure your database is reachable via the `DATABASE_URL`.

--- a/src/bot.py
+++ b/src/bot.py
@@ -1838,27 +1838,73 @@ async def watch_update_trigger_file(path: str = None, poll_interval: int = 5):
 
 
 # -------------------------------------------------------------------
+# Background task supervision
+# -------------------------------------------------------------------
+# on_ready fires again after every gateway reconnect, so anything it starts has
+# to be idempotent. Without this, each reconnect leaked another RabbitMQ
+# consumer (plus its executor thread), another cleanup loop, and another
+# trigger-file watcher racing the others to os.remove() the same file.
+background_tasks = {}
+
+
+def start_background_task(name: str, coro, run_once: bool = False):
+    """Schedule `coro` under `name`, unless that task is already accounted for.
+
+    A long-lived task is (re)started only when it is missing or has died, so a
+    crashed consumer recovers on the next reconnect. `run_once` work — the
+    startup panel refresh — never runs a second time in the same process, since
+    its views stay registered with discord.py across reconnects.
+    """
+    existing = background_tasks.get(name)
+    if existing is not None and (run_once or not existing.done()):
+        # We never awaited this one; close it so Python doesn't warn about it.
+        coro.close()
+        return existing
+
+    task = asyncio.create_task(coro, name=name)
+
+    def report_exit(finished):
+        if finished.cancelled():
+            logger.info(f"Background task '{name}' was cancelled.")
+            return
+        error = finished.exception()
+        if error is not None:
+            logger.error(
+                f"Background task '{name}' died; it will restart on the next reconnect.",
+                exc_info=error,
+            )
+
+    task.add_done_callback(report_exit)
+    background_tasks[name] = task
+    return task
+
+
+# -------------------------------------------------------------------
 # Bot Events
 # -------------------------------------------------------------------
 @bot.event
 async def on_ready():
     logger.info(f"Bot is ready. Logged in as {bot.user} (ID: {bot.user.id})")
-    bot.loop.create_task(consume_results_queue())
+    start_background_task("results_consumer", consume_results_queue())
     # Start periodic cleanup of expired pending verifications
-    bot.loop.create_task(expired_pending_cleanup_task())
+    start_background_task("expired_pending_cleanup", expired_pending_cleanup_task())
 
     # Reinitialize instruction messages across servers (with locale). Runs in the
     # background so the bot starts serving commands immediately instead of waiting
     # on one edit per guild.
-    bot.loop.create_task(
-        refresh_all_instruction_panels(rebuild_embed=False, reason="startup")
+    start_background_task(
+        "instruction_panel_refresh",
+        refresh_all_instruction_panels(rebuild_embed=False, reason="startup"),
+        run_once=True,
     )
 
     # Start watching for a trigger file so you can update instructions at runtime
     # To trigger an instruction panel update type "touch /tmp/update_instructions.trigger" into a terminal
     trigger_path = os.getenv("INSTRUCTIONS_TRIGGER_PATH", "/tmp/update_instructions.trigger")
     poll = int(os.getenv("INSTRUCTIONS_TRIGGER_POLL", "5"))
-    bot.loop.create_task(watch_update_trigger_file(trigger_path, poll))
+    start_background_task(
+        "instructions_trigger_watcher", watch_update_trigger_file(trigger_path, poll)
+    )
 
     # Panel refresh logs its own completion summary once it finishes.
     logger.info("Bot startup tasks launched and ready to go!")

--- a/src/bot.py
+++ b/src/bot.py
@@ -1768,6 +1768,18 @@ class RequestPacer:
             await asyncio.sleep(delay)
 
 
+def panel_view_key(server_id) -> str:
+    """Normalise a guild id for the instruction_panel_views table.
+
+    `servers.server_id` is declared String but can come back as an int, because
+    the deployed column is an integer type and SQLAlchemy returns whatever the
+    driver gives. instruction_panel_views.server_id really is text, so an
+    un-normalised id makes Postgres reject `character varying = bigint` — and,
+    worse, makes the in-memory version lookup silently never match.
+    """
+    return str(server_id)
+
+
 def load_instruction_panels(stale_only: bool = False):
     """Snapshot saved instruction panels from the DB.
 
@@ -1780,12 +1792,12 @@ def load_instruction_panels(stale_only: bool = False):
             session.query(Server).filter(Server.instructions_message_id != None).all()
         )
         versions = {
-            row.server_id: row.view_version
+            panel_view_key(row.server_id): row.view_version
             for row in session.query(InstructionPanelView).all()
         }
         panels = []
         for server in servers:
-            version = versions.get(server.server_id, 0)
+            version = versions.get(panel_view_key(server.server_id), 0)
             if stale_only and version >= INSTRUCTIONS_VIEW_VERSION:
                 continue
             panels.append(
@@ -1800,15 +1812,14 @@ def load_instruction_panels(stale_only: bool = False):
         return panels
 
 
-def record_panel_view_version(server_id: str, version: int = INSTRUCTIONS_VIEW_VERSION):
+def record_panel_view_version(server_id, version: int = INSTRUCTIONS_VIEW_VERSION):
     """Remember that this guild's panel now carries `version`'s custom_ids."""
+    key = panel_view_key(server_id)
     try:
         with session_scope() as session:
-            row = (
-                session.query(InstructionPanelView).filter_by(server_id=server_id).first()
-            )
+            row = session.query(InstructionPanelView).filter_by(server_id=key).first()
             if row is None:
-                row = InstructionPanelView(server_id=server_id)
+                row = InstructionPanelView(server_id=key)
                 session.add(row)
             row.view_version = version
             row.updated_at = datetime.now(timezone.utc)
@@ -1817,11 +1828,13 @@ def record_panel_view_version(server_id: str, version: int = INSTRUCTIONS_VIEW_V
         logger.exception(f"Failed to record panel view version for guild {server_id}")
 
 
-def forget_panel_view_version(server_id: str):
+def forget_panel_view_version(server_id):
     """Drop the recorded version so a re-posted panel is never wrongly skipped."""
     try:
         with session_scope() as session:
-            session.query(InstructionPanelView).filter_by(server_id=server_id).delete()
+            session.query(InstructionPanelView).filter_by(
+                server_id=panel_view_key(server_id)
+            ).delete()
     except Exception:
         logger.exception(f"Failed to clear panel view version for guild {server_id}")
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -1357,16 +1357,8 @@ async def vrcverify_instructions(interaction: discord.Interaction):
             if srv and srv.instructions_locale
             else get_locale(interaction)
         )
-    # fetch localized messages for instructions
-    strings = localizations.get(instr_locale, localizations["en-US"])
-    embed = Embed(
-        title=strings["instructions_title"],
-        description=strings["instructions_desc"],
-        color=discord.Color.blue()
-    )
-
-    usage_example = "**Example Usage**:\n" "```bash\n" "/vrcverify\n" "```"
-    embed.add_field(name="Example Command", value=usage_example, inline=False)
+    # Same builder the refresh path uses, so a posted panel and a refreshed one match.
+    embed = build_instructions_embed(instr_locale)
 
     view = VRCVerifyInstructionView(locale=instr_locale)
     # Send the initial response and then fetch the message

--- a/src/bot.py
+++ b/src/bot.py
@@ -73,15 +73,27 @@ RABBITMQ_VHOST = os.getenv("RABBITMQ_VHOST")
 KOFI_URL = "https://ko-fi.com/italiandogs"
 # Verifications a guild must complete before the one-time owner thank-you DM.
 MILESTONE_VERIFICATION_COUNT = 100
-# Instruction panels are refreshed concurrently rather than one guild at a time;
-# this caps how many Discord edits are in flight so a few thousand panels don't
+# Instruction panels are refreshed concurrently rather than one guild at a time.
+# Two independent limits apply:
+#
+# CONCURRENCY caps how many edits are in flight, so a few thousand panels don't
 # serialize behind each other's round trips.
-try:
-    INSTRUCTIONS_REFRESH_CONCURRENCY = max(
-        1, int(os.getenv("INSTRUCTIONS_REFRESH_CONCURRENCY", "10"))
-    )
-except ValueError:
-    INSTRUCTIONS_REFRESH_CONCURRENCY = 10
+#
+# RATE caps how many we *start* per second. A concurrency cap alone does not
+# bound the request rate: these edits often fail fast (403/404 come back in tens
+# of milliseconds), so even a handful of workers can push well past Discord's
+# ~50 req/s global ceiling. Exceeding it throttles the whole bot — verification
+# results and command replies included — not just this loop. Default 25 leaves
+# half the global budget for real traffic.
+def _int_env(name: str, default: int) -> int:
+    try:
+        return max(1, int(os.getenv(name, str(default))))
+    except ValueError:
+        return default
+
+
+INSTRUCTIONS_REFRESH_CONCURRENCY = _int_env("INSTRUCTIONS_REFRESH_CONCURRENCY", 10)
+INSTRUCTIONS_REFRESH_RATE = _int_env("INSTRUCTIONS_REFRESH_RATE", 25)
 
 # -------------------------------------------------------------------
 # Logging setup
@@ -1688,6 +1700,28 @@ async def expired_pending_cleanup_task(interval_seconds: int = 60):
 instruction_refresh_lock = asyncio.Lock()
 
 
+class RequestPacer:
+    """Hands out evenly spaced start times to stay under a per-second ceiling.
+
+    discord.py only reacts to 429s after the fact; this keeps the fleet refresh
+    from provoking them in the first place.
+    """
+
+    def __init__(self, per_second: float):
+        self.min_interval = 1.0 / per_second
+        self.next_slot = 0.0
+        self.lock = asyncio.Lock()
+
+    async def wait(self):
+        async with self.lock:
+            now = time.monotonic()
+            slot = max(now, self.next_slot)
+            self.next_slot = slot + self.min_interval
+        delay = slot - now
+        if delay > 0:
+            await asyncio.sleep(delay)
+
+
 def load_instruction_panels():
     """Snapshot every saved instruction panel (guild/channel/message/locale) from the DB."""
     with session_scope() as session:
@@ -1773,13 +1807,23 @@ async def refresh_instruction_panel(entry, rebuild_embed: bool) -> bool:
             f"{channel_id} for guild {entry['server_id']}; skipping."
         )
         return False
+    except discord.HTTPException as error:
+        # Discord refused the edit for a reason that isn't ours to fix — most
+        # often 50083, the panel lives in a thread that has since been archived.
+        # The reference is still valid (unarchiving revives it), so keep it and
+        # log a single line instead of a traceback per guild.
+        logger.warning(
+            f"⚠️ Discord rejected the instruction panel edit for guild "
+            f"{entry['server_id']} (HTTP {error.status}, code {error.code}): {error.text}"
+        )
+        return False
     except Exception:
         logger.exception(f"Failed to edit instructions message for guild {entry['server_id']}")
         return False
 
 
 async def refresh_all_instruction_panels(rebuild_embed: bool, reason: str):
-    """Refresh every saved instruction panel concurrently, bounded by a semaphore.
+    """Refresh every saved instruction panel concurrently, paced and bounded.
 
     Serialized behind a lock so a startup pass and a trigger-file pass can't
     fight over the same messages.
@@ -1792,8 +1836,12 @@ async def refresh_all_instruction_panels(rebuild_embed: bool, reason: str):
 
         started = time.monotonic()
         semaphore = asyncio.Semaphore(INSTRUCTIONS_REFRESH_CONCURRENCY)
+        pacer = RequestPacer(INSTRUCTIONS_REFRESH_RATE)
 
         async def refresh_one(entry):
+            # Pace before taking a slot so waiting tasks don't idle in the
+            # semaphore and starve the ones ready to run.
+            await pacer.wait()
             async with semaphore:
                 return await refresh_instruction_panel(entry, rebuild_embed)
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -1798,7 +1798,11 @@ def load_instruction_panels(stale_only: bool = False):
         panels = []
         for server in servers:
             version = versions.get(panel_view_key(server.server_id), 0)
-            if stale_only and version >= INSTRUCTIONS_VIEW_VERSION:
+            # Deliberately `==`, not `>=`: skip only panels matching this
+            # process exactly. One recorded *newer* carries custom_ids we never
+            # registered, so rolling a release back has to re-migrate it or its
+            # buttons stay dead.
+            if stale_only and version == INSTRUCTIONS_VIEW_VERSION:
                 continue
             panels.append(
                 {
@@ -1885,11 +1889,12 @@ async def refresh_instruction_panel(entry, rebuild_embed: bool) -> bool:
         logger.warning(f"⚠️ Malformed channel/message id for guild {entry['server_id']}; skipping.")
         return False
 
-    payload = {"view": VRCVerifyInstructionView(locale=entry["locale"])}
-    if rebuild_embed:
-        payload["embed"] = build_instructions_embed(entry["locale"])
-
     try:
+        # Built inside the try on purpose: a bad locale row must not escape and
+        # abort the whole fleet pass, it only costs this one guild.
+        payload = {"view": VRCVerifyInstructionView(locale=entry["locale"])}
+        if rebuild_embed:
+            payload["embed"] = build_instructions_embed(entry["locale"])
         await message.edit(**payload)
         if entry.get("view_version") != INSTRUCTIONS_VIEW_VERSION:
             record_panel_view_version(entry["server_id"])
@@ -1950,11 +1955,29 @@ async def refresh_all_instruction_panels(
             async with semaphore:
                 return await refresh_instruction_panel(entry, rebuild_embed)
 
-        results = await asyncio.gather(*(refresh_one(entry) for entry in panels))
+        # return_exceptions so one guild can never abort the pass: the startup
+        # task is run_once, so an escaped error would strand every remaining
+        # panel until the next process restart.
+        results = await asyncio.gather(
+            *(refresh_one(entry) for entry in panels), return_exceptions=True
+        )
+
+        updated = 0
+        crashed = 0
+        for result in results:
+            if result is True:
+                updated += 1
+            elif isinstance(result, asyncio.CancelledError):
+                raise result  # shutdown; don't report it as a per-panel failure
+            elif isinstance(result, BaseException):
+                crashed += 1
+                logger.error("Instruction panel refresh worker crashed", exc_info=result)
+
         elapsed = time.monotonic() - started
+        crashed_note = f", {crashed} crashed" if crashed else ""
         logger.info(
-            f"Instruction panel refresh ({reason}): {sum(results)}/{len(panels)} "
-            f"updated in {elapsed:.1f}s"
+            f"Instruction panel refresh ({reason}): {updated}/{len(panels)} "
+            f"updated in {elapsed:.1f}s{crashed_note}"
         )
 
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -73,6 +73,15 @@ RABBITMQ_VHOST = os.getenv("RABBITMQ_VHOST")
 KOFI_URL = "https://ko-fi.com/italiandogs"
 # Verifications a guild must complete before the one-time owner thank-you DM.
 MILESTONE_VERIFICATION_COUNT = 100
+# Instruction panels are refreshed concurrently rather than one guild at a time;
+# this caps how many Discord edits are in flight so a few thousand panels don't
+# serialize behind each other's round trips.
+try:
+    INSTRUCTIONS_REFRESH_CONCURRENCY = max(
+        1, int(os.getenv("INSTRUCTIONS_REFRESH_CONCURRENCY", "10"))
+    )
+except ValueError:
+    INSTRUCTIONS_REFRESH_CONCURRENCY = 10
 
 # -------------------------------------------------------------------
 # Logging setup
@@ -1683,13 +1692,17 @@ async def expired_pending_cleanup_task(interval_seconds: int = 60):
         await asyncio.sleep(interval_seconds)
 
 
-async def update_all_instruction_messages():
-    """Rebuild and edit saved instruction messages for all servers (uses DB-stored locale)."""
+# Guards against a startup refresh and a trigger-file refresh overlapping.
+instruction_refresh_lock = asyncio.Lock()
+
+
+def load_instruction_panels():
+    """Snapshot every saved instruction panel (guild/channel/message/locale) from the DB."""
     with session_scope() as session:
         servers = (
             session.query(Server).filter(Server.instructions_message_id != None).all()
         )
-        servers_data = [
+        return [
             {
                 "server_id": server.server_id,
                 "channel_id": server.instructions_channel_id,
@@ -1699,74 +1712,110 @@ async def update_all_instruction_messages():
             for server in servers
         ]
 
-    for entry in servers_data:
-        channel_id = entry.get("channel_id")
-        message_id = entry.get("message_id")
-        if not channel_id or not message_id:
-            logger.warning(f"⚠️ Missing channel/message id for guild {entry['server_id']}; skipping.")
-            continue
 
-        # Try to obtain the channel via cache first, then the API. This avoids requiring the
-        # guild to be present in the gateway cache (previously caused 'guild not cached').
-        try:
-            ch = bot.get_channel(int(channel_id))
-            if ch is None:
-                ch = await bot.fetch_channel(int(channel_id))
-        except discord.NotFound:
-            logger.warning(f"⚠️ Channel {channel_id} not found (404) for guild {entry['server_id']}; removing saved message reference.")
-            # clear DB entry so we don't repeatedly try to update a missing channel/message
-            try:
-                with session_scope() as session:
-                    srv = session.query(Server).filter_by(server_id=entry["server_id"]).first()
-                    if srv:
-                        srv.instructions_channel_id = None
-                        srv.instructions_message_id = None
-            except Exception:
-                logger.exception("Failed to clear missing channel entry in DB.")
-            continue
-        except discord.Forbidden:
-            logger.warning(f"⚠️ No permission to access channel {channel_id} in guild {entry['server_id']}; skipping.")
-            continue
-        except Exception:
-            logger.exception(f"Unexpected error fetching channel {channel_id} for guild {entry['server_id']}")
-            continue
+def forget_instruction_panel(server_id: str):
+    """Drop a saved panel reference whose channel or message no longer exists."""
+    try:
+        with session_scope() as session:
+            srv = session.query(Server).filter_by(server_id=server_id).first()
+            if srv:
+                srv.instructions_channel_id = None
+                srv.instructions_message_id = None
+    except Exception:
+        logger.exception(f"Failed to clear missing instruction panel for guild {server_id}")
 
-        try:
-            message = await ch.fetch_message(int(message_id))
-        except discord.NotFound:
-            logger.warning(f"⚠️ Message {message_id} not found (404) in channel {channel_id} for guild {entry['server_id']}; removing saved message reference.")
-            try:
-                with session_scope() as session:
-                    srv = session.query(Server).filter_by(server_id=entry["server_id"]).first()
-                    if srv:
-                        srv.instructions_channel_id = None
-                        srv.instructions_message_id = None
-            except Exception:
-                logger.exception("Failed to clear missing message entry in DB.")
-            continue
-        except discord.Forbidden:
-            logger.warning(f"⚠️ No permission to fetch message {message_id} in channel {channel_id} for guild {entry['server_id']}; skipping.")
-            continue
-        except Exception:
-            logger.exception(f"Unexpected error fetching message {message_id} in channel {channel_id} for guild {entry['server_id']}")
-            continue
 
-        # Rebuild localized embed + example field
-        try:
-            strings = localizations.get(entry["locale"], localizations["en-US"])
-            new_embed = Embed(
-                title=strings.get("instructions_title", ""),
-                description=strings.get("instructions_desc", ""),
-                color=discord.Color.blue(),
-            )
-            usage_example = "**Example Usage**:\n" "```bash\n" "/vrcverify\n" "```"
-            new_embed.clear_fields()
-            new_embed.add_field(name="Example Command", value=usage_example, inline=False)
-            view = VRCVerifyInstructionView(locale=entry["locale"])
-            await message.edit(embed=new_embed, view=view)
-            logger.info(f"Updated instructions message for guild {entry['server_id']}")
-        except Exception:
-            logger.exception(f"Failed to edit instructions message for guild {entry['server_id']}")
+def build_instructions_embed(locale: str) -> Embed:
+    """Build the localized instruction panel embed."""
+    strings = localizations.get(locale, localizations["en-US"])
+    embed = Embed(
+        title=strings.get("instructions_title", ""),
+        description=strings.get("instructions_desc", ""),
+        color=discord.Color.blue(),
+    )
+    usage_example = "**Example Usage**:\n" "```bash\n" "/vrcverify\n" "```"
+    embed.add_field(name="Example Command", value=usage_example, inline=False)
+    return embed
+
+
+async def refresh_instruction_panel(entry, rebuild_embed: bool) -> bool:
+    """Re-attach a fresh view (and optionally a rebuilt embed) to one saved panel.
+
+    Uses a partial message so this costs exactly one API call and needs nothing
+    in the gateway cache — no channel fetch, no message fetch.
+    """
+    channel_id = entry.get("channel_id")
+    message_id = entry.get("message_id")
+    if not channel_id or not message_id:
+        logger.warning(f"⚠️ Missing channel/message id for guild {entry['server_id']}; skipping.")
+        return False
+
+    try:
+        message = bot.get_partial_messageable(int(channel_id)).get_partial_message(
+            int(message_id)
+        )
+    except (TypeError, ValueError):
+        logger.warning(f"⚠️ Malformed channel/message id for guild {entry['server_id']}; skipping.")
+        return False
+
+    payload = {"view": VRCVerifyInstructionView(locale=entry["locale"])}
+    if rebuild_embed:
+        payload["embed"] = build_instructions_embed(entry["locale"])
+
+    try:
+        await message.edit(**payload)
+        logger.debug(f"Refreshed instructions message for guild {entry['server_id']}")
+        return True
+    except discord.NotFound:
+        # Either the channel or the message is gone; both cases make the saved
+        # reference useless, so stop retrying it on every restart.
+        logger.warning(
+            f"⚠️ Instruction panel {message_id} in channel {channel_id} not found (404) "
+            f"for guild {entry['server_id']}; removing saved message reference."
+        )
+        forget_instruction_panel(entry["server_id"])
+        return False
+    except discord.Forbidden:
+        logger.warning(
+            f"⚠️ No permission to edit instruction panel {message_id} in channel "
+            f"{channel_id} for guild {entry['server_id']}; skipping."
+        )
+        return False
+    except Exception:
+        logger.exception(f"Failed to edit instructions message for guild {entry['server_id']}")
+        return False
+
+
+async def refresh_all_instruction_panels(rebuild_embed: bool, reason: str):
+    """Refresh every saved instruction panel concurrently, bounded by a semaphore.
+
+    Serialized behind a lock so a startup pass and a trigger-file pass can't
+    fight over the same messages.
+    """
+    async with instruction_refresh_lock:
+        panels = load_instruction_panels()
+        if not panels:
+            logger.info(f"No saved instruction panels to refresh ({reason}).")
+            return
+
+        started = time.monotonic()
+        semaphore = asyncio.Semaphore(INSTRUCTIONS_REFRESH_CONCURRENCY)
+
+        async def refresh_one(entry):
+            async with semaphore:
+                return await refresh_instruction_panel(entry, rebuild_embed)
+
+        results = await asyncio.gather(*(refresh_one(entry) for entry in panels))
+        elapsed = time.monotonic() - started
+        logger.info(
+            f"Instruction panel refresh ({reason}): {sum(results)}/{len(panels)} "
+            f"updated in {elapsed:.1f}s"
+        )
+
+
+async def update_all_instruction_messages():
+    """Rebuild and edit saved instruction messages for all servers (uses DB-stored locale)."""
+    await refresh_all_instruction_panels(rebuild_embed=True, reason="manual trigger")
 
 
 async def watch_update_trigger_file(path: str = None, poll_interval: int = 5):
@@ -1806,36 +1855,12 @@ async def on_ready():
     # Start periodic cleanup of expired pending verifications
     bot.loop.create_task(expired_pending_cleanup_task())
 
-    # Reinitialize instruction messages across servers (with locale)
-    with session_scope() as session:
-        servers = (
-            session.query(Server).filter(Server.instructions_message_id != None).all()
-        )
-        # Build a list carrying each server’s locale
-        servers_data = [
-            {
-                "server_id": server.server_id,
-                "channel_id": server.instructions_channel_id,
-                "message_id": server.instructions_message_id,
-                "locale": server.instructions_locale or "en-US"
-            }
-            for server in servers
-        ]
-
-    for entry in servers_data:
-        guild = bot.get_guild(int(entry["server_id"]))
-        if not guild:
-            continue
-        try:
-            channel = guild.get_channel(int(entry["channel_id"]))
-            if channel:
-                message = await channel.fetch_message(int(entry["message_id"]))
-                # Pass in the stored locale when reconstructing the view
-                view = VRCVerifyInstructionView(locale=entry["locale"])
-                await message.edit(view=view)
-                logger.info(f"Reinitialized instructions message for guild {entry['server_id']}")
-        except Exception as e:
-            logger.error(f"Error reinitializing instructions message for guild {entry['server_id']}: {e}")
+    # Reinitialize instruction messages across servers (with locale). Runs in the
+    # background so the bot starts serving commands immediately instead of waiting
+    # on one edit per guild.
+    bot.loop.create_task(
+        refresh_all_instruction_panels(rebuild_embed=False, reason="startup")
+    )
 
     # Start watching for a trigger file so you can update instructions at runtime
     # To trigger an instruction panel update type "touch /tmp/update_instructions.trigger" into a terminal
@@ -1843,7 +1868,8 @@ async def on_ready():
     poll = int(os.getenv("INSTRUCTIONS_TRIGGER_POLL", "5"))
     bot.loop.create_task(watch_update_trigger_file(trigger_path, poll))
 
-    logger.info("Bot is reinitialized and ready to go!")
+    # Panel refresh logs its own completion summary once it finishes.
+    logger.info("Bot startup tasks launched and ready to go!")
 
 
 @bot.event

--- a/src/bot.py
+++ b/src/bot.py
@@ -95,6 +95,17 @@ def _int_env(name: str, default: int) -> int:
 INSTRUCTIONS_REFRESH_CONCURRENCY = _int_env("INSTRUCTIONS_REFRESH_CONCURRENCY", 10)
 INSTRUCTIONS_REFRESH_RATE = _int_env("INSTRUCTIONS_REFRESH_RATE", 25)
 
+# Instruction panel buttons carry fixed custom_ids so a single bot.add_view()
+# call routes clicks for every panel ever posted, instead of the bot having to
+# re-edit all of them on boot just to hand out ids it recognises.
+#
+# Bump this when the button set changes: the custom_ids change with it, panels
+# still carrying an older version stop matching the registered view, and the
+# startup pass re-edits exactly those.
+INSTRUCTIONS_VIEW_VERSION = 1
+BEGIN_VERIFICATION_CUSTOM_ID = f"vrcverify:begin:v{INSTRUCTIONS_VIEW_VERSION}"
+UPDATE_NICKNAME_CUSTOM_ID = f"vrcverify:nickname:v{INSTRUCTIONS_VIEW_VERSION}"
+
 # -------------------------------------------------------------------
 # Logging setup
 # -------------------------------------------------------------------
@@ -177,7 +188,24 @@ class PendingVerification(Base):
     expires_at = Column(DateTime(timezone=True), nullable=False)
 
 
-# Create tables and ensure the new instructions_locale column exists
+class InstructionPanelView(Base):
+    """Which button custom_id set each guild's posted panel is carrying.
+
+    A separate table rather than a column on `servers` on purpose: create_all()
+    below creates missing *tables* automatically but never adds columns to an
+    existing one, and a column present in the model but absent in the database
+    breaks every Server query — not just the ones reading it. This keeps the
+    rollout to zero manual DDL.
+    """
+
+    __tablename__ = "instruction_panel_views"
+    server_id = Column(String, primary_key=True)
+    view_version = Column(Integer, nullable=False, default=0)
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+
+
+# Creates any missing tables. Note this does NOT add columns to tables that
+# already exist — those still need a manual ALTER.
 Base.metadata.create_all(engine)
 
 
@@ -307,6 +335,12 @@ class VRCVerifyBot(discord.Client):
         self.tree = app_commands.CommandTree(self)
 
     async def setup_hook(self):
+        # One persistent registration handles button clicks on every panel in
+        # every guild. Only the custom_ids are matched, so this instance's
+        # locale (and therefore its labels) never reaches a user — each panel
+        # keeps whatever labels it was rendered with, and the callbacks resolve
+        # locale per interaction.
+        self.add_view(VRCVerifyInstructionView(locale="en-US"))
         # Sync slash commands to the server
         await self.tree.sync()
 
@@ -355,12 +389,21 @@ class VRCVerifyInstructionView(View):
         # dynamic labels from localization
         begin_label = localizations.get(locale, localizations['en-US'])['btn_begin_verification']
         update_label = localizations.get(locale, localizations['en-US'])['btn_update_nickname']
-        # Begin Verification button
-        begin_btn = Button(label=begin_label, style=discord.ButtonStyle.primary)
+        # Fixed custom_ids keep already-posted panels routable after a restart;
+        # the labels below are per-guild, but the ids never vary.
+        begin_btn = Button(
+            label=begin_label,
+            style=discord.ButtonStyle.primary,
+            custom_id=BEGIN_VERIFICATION_CUSTOM_ID,
+        )
         begin_btn.callback = self.begin_verification
         self.add_item(begin_btn)
         # Update Nickname button
-        update_btn = Button(label=update_label, style=discord.ButtonStyle.secondary)
+        update_btn = Button(
+            label=update_label,
+            style=discord.ButtonStyle.secondary,
+            custom_id=UPDATE_NICKNAME_CUSTOM_ID,
+        )
         update_btn.callback = self.update_nickname
         self.add_item(update_btn)
         # Donate button (link buttons can't be colored; the emoji makes it stand out)
@@ -1386,6 +1429,9 @@ async def vrcverify_instructions(interaction: discord.Interaction):
             server.instructions_channel_id = channel_id
             server.instructions_message_id = str(message.id)
 
+    # Posted with the current custom_ids already, so no restart needs to touch it.
+    record_panel_view_version(guild_id)
+
     # Quiet, admin-only nudge after the public panel is posted
     await interaction.followup.send(
         get_message("setup_donate_hint", interaction, kofi_link=KOFI_URL).strip(),
@@ -1722,21 +1768,62 @@ class RequestPacer:
             await asyncio.sleep(delay)
 
 
-def load_instruction_panels():
-    """Snapshot every saved instruction panel (guild/channel/message/locale) from the DB."""
+def load_instruction_panels(stale_only: bool = False):
+    """Snapshot saved instruction panels from the DB.
+
+    With `stale_only`, returns just the panels whose buttons predate the current
+    INSTRUCTIONS_VIEW_VERSION — the ones a restart actually has to re-edit.
+    Everything else is already routable through the persistent view.
+    """
     with session_scope() as session:
         servers = (
             session.query(Server).filter(Server.instructions_message_id != None).all()
         )
-        return [
-            {
-                "server_id": server.server_id,
-                "channel_id": server.instructions_channel_id,
-                "message_id": server.instructions_message_id,
-                "locale": server.instructions_locale or "en-US",
-            }
-            for server in servers
-        ]
+        versions = {
+            row.server_id: row.view_version
+            for row in session.query(InstructionPanelView).all()
+        }
+        panels = []
+        for server in servers:
+            version = versions.get(server.server_id, 0)
+            if stale_only and version >= INSTRUCTIONS_VIEW_VERSION:
+                continue
+            panels.append(
+                {
+                    "server_id": server.server_id,
+                    "channel_id": server.instructions_channel_id,
+                    "message_id": server.instructions_message_id,
+                    "locale": server.instructions_locale or "en-US",
+                    "view_version": version,
+                }
+            )
+        return panels
+
+
+def record_panel_view_version(server_id: str, version: int = INSTRUCTIONS_VIEW_VERSION):
+    """Remember that this guild's panel now carries `version`'s custom_ids."""
+    try:
+        with session_scope() as session:
+            row = (
+                session.query(InstructionPanelView).filter_by(server_id=server_id).first()
+            )
+            if row is None:
+                row = InstructionPanelView(server_id=server_id)
+                session.add(row)
+            row.view_version = version
+            row.updated_at = datetime.now(timezone.utc)
+    except Exception:
+        # Losing this only costs a redundant edit on the next boot.
+        logger.exception(f"Failed to record panel view version for guild {server_id}")
+
+
+def forget_panel_view_version(server_id: str):
+    """Drop the recorded version so a re-posted panel is never wrongly skipped."""
+    try:
+        with session_scope() as session:
+            session.query(InstructionPanelView).filter_by(server_id=server_id).delete()
+    except Exception:
+        logger.exception(f"Failed to clear panel view version for guild {server_id}")
 
 
 def forget_instruction_panel(server_id: str):
@@ -1749,6 +1836,7 @@ def forget_instruction_panel(server_id: str):
                 srv.instructions_message_id = None
     except Exception:
         logger.exception(f"Failed to clear missing instruction panel for guild {server_id}")
+    forget_panel_view_version(server_id)
 
 
 def build_instructions_embed(locale: str) -> Embed:
@@ -1790,6 +1878,8 @@ async def refresh_instruction_panel(entry, rebuild_embed: bool) -> bool:
 
     try:
         await message.edit(**payload)
+        if entry.get("view_version") != INSTRUCTIONS_VIEW_VERSION:
+            record_panel_view_version(entry["server_id"])
         logger.debug(f"Refreshed instructions message for guild {entry['server_id']}")
         return True
     except discord.NotFound:
@@ -1822,16 +1912,18 @@ async def refresh_instruction_panel(entry, rebuild_embed: bool) -> bool:
         return False
 
 
-async def refresh_all_instruction_panels(rebuild_embed: bool, reason: str):
-    """Refresh every saved instruction panel concurrently, paced and bounded.
+async def refresh_all_instruction_panels(
+    rebuild_embed: bool, reason: str, stale_only: bool = False
+):
+    """Refresh saved instruction panels concurrently, paced and bounded.
 
     Serialized behind a lock so a startup pass and a trigger-file pass can't
     fight over the same messages.
     """
     async with instruction_refresh_lock:
-        panels = load_instruction_panels()
+        panels = load_instruction_panels(stale_only=stale_only)
         if not panels:
-            logger.info(f"No saved instruction panels to refresh ({reason}).")
+            logger.info(f"No instruction panels need refreshing ({reason}).")
             return
 
         started = time.monotonic()
@@ -1937,12 +2029,15 @@ async def on_ready():
     # Start periodic cleanup of expired pending verifications
     start_background_task("expired_pending_cleanup", expired_pending_cleanup_task())
 
-    # Reinitialize instruction messages across servers (with locale). Runs in the
-    # background so the bot starts serving commands immediately instead of waiting
-    # on one edit per guild.
+    # Panels already carrying the current custom_ids are handled by the
+    # persistent view registered in setup_hook, so this only has to re-edit the
+    # stragglers: panels posted before this version, and ones that failed
+    # earlier (revoked permissions, archived threads) and are retried each boot.
     start_background_task(
         "instruction_panel_refresh",
-        refresh_all_instruction_panels(rebuild_embed=False, reason="startup"),
+        refresh_all_instruction_panels(
+            rebuild_embed=False, reason="startup", stale_only=True
+        ),
         run_once=True,
     )
 

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -1,0 +1,220 @@
+"""Unit tests for on_ready background task supervision.
+
+on_ready fires again after every gateway reconnect. It used to call
+bot.loop.create_task() unconditionally, so a long-lived process accumulated a
+duplicate RabbitMQ consumer (and executor thread), a duplicate cleanup loop,
+and duplicate trigger-file watchers on every reconnect. These tests pin the
+guard: start once, restart only if dead, never repeat run_once work.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import discord
+import pytest
+
+import bot
+
+
+def run(coro):
+    """Run an async bot helper from a sync test (no pytest-asyncio needed)."""
+    return asyncio.run(coro)
+
+
+async def drain(tasks):
+    """Cancel tasks so the test loop closes without 'pending task' warnings."""
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.fixture(autouse=True)
+def clean_tasks(monkeypatch):
+    monkeypatch.setattr(bot, "background_tasks", {})
+
+
+@pytest.fixture
+def stub_startup(monkeypatch):
+    """Replace on_ready's four background coroutines with inert stand-ins."""
+    started = []
+
+    def make(name):
+        async def stub(*args, **kwargs):
+            started.append(name)
+            await asyncio.sleep(3600)
+
+        return stub
+
+    monkeypatch.setattr(discord.Client, "user", property(lambda self: SimpleNamespace(id=1)))
+    for attr, name in [
+        ("consume_results_queue", "results_consumer"),
+        ("expired_pending_cleanup_task", "expired_pending_cleanup"),
+        ("refresh_all_instruction_panels", "instruction_panel_refresh"),
+        ("watch_update_trigger_file", "instructions_trigger_watcher"),
+    ]:
+        monkeypatch.setattr(bot, attr, make(name))
+    return started
+
+
+# ---------------------------------------------------------------
+# start_background_task
+# ---------------------------------------------------------------
+class TestStartBackgroundTask:
+    def test_starts_and_registers_the_task(self):
+        ran = []
+
+        async def scenario():
+            async def work():
+                ran.append(1)
+                await asyncio.sleep(3600)
+
+            task = bot.start_background_task("worker", work())
+            await asyncio.sleep(0)
+            assert bot.background_tasks["worker"] is task
+            await drain([task])
+
+        run(scenario())
+        assert ran == [1]
+
+    def test_second_start_reuses_the_live_task(self):
+        ran = []
+
+        async def scenario():
+            async def work():
+                ran.append(1)
+                await asyncio.sleep(3600)
+
+            first = bot.start_background_task("worker", work())
+            await asyncio.sleep(0)
+            second = bot.start_background_task("worker", work())
+            await asyncio.sleep(0)
+            assert first is second
+            await drain([first])
+
+        run(scenario())
+        # The duplicate coroutine was closed, not executed.
+        assert ran == [1]
+
+    def test_dead_task_is_restarted(self):
+        ran = []
+
+        async def scenario():
+            async def work():
+                ran.append(1)
+
+            first = bot.start_background_task("worker", work())
+            await first
+            second = bot.start_background_task("worker", work())
+            await second
+            assert first is not second
+
+        run(scenario())
+        assert ran == [1, 1]
+
+    def test_run_once_task_never_restarts(self):
+        ran = []
+
+        async def scenario():
+            async def work():
+                ran.append(1)
+
+            first = bot.start_background_task("once", work(), run_once=True)
+            await first
+            second = bot.start_background_task("once", work(), run_once=True)
+            assert first is second
+
+        run(scenario())
+        assert ran == [1]
+
+    def test_crashed_task_is_reported_not_swallowed(self, caplog):
+        async def scenario():
+            async def boom():
+                raise RuntimeError("kaboom")
+
+            task = bot.start_background_task("worker", boom())
+            await asyncio.gather(task, return_exceptions=True)
+            await asyncio.sleep(0)
+
+        with caplog.at_level("ERROR"):
+            run(scenario())
+
+        assert "kaboom" in caplog.text
+
+    def test_tasks_are_named_for_debuggability(self):
+        async def scenario():
+            async def work():
+                await asyncio.sleep(3600)
+
+            task = bot.start_background_task("results_consumer", work())
+            assert task.get_name() == "results_consumer"
+            await drain([task])
+
+        run(scenario())
+
+
+# ---------------------------------------------------------------
+# on_ready re-entry (the reported bug)
+# ---------------------------------------------------------------
+class TestOnReadyReentry:
+    EXPECTED = {
+        "results_consumer",
+        "expired_pending_cleanup",
+        "instruction_panel_refresh",
+        "instructions_trigger_watcher",
+    }
+
+    def test_first_ready_starts_every_task(self, stub_startup):
+        async def scenario():
+            await bot.on_ready()
+            await asyncio.sleep(0)
+            await drain(list(bot.background_tasks.values()))
+
+        run(scenario())
+        assert set(bot.background_tasks) == self.EXPECTED
+        assert sorted(stub_startup) == sorted(self.EXPECTED)
+
+    def test_reconnect_does_not_duplicate_tasks(self, stub_startup):
+        async def scenario():
+            await bot.on_ready()
+            await asyncio.sleep(0)
+            first = dict(bot.background_tasks)
+
+            # Simulate three gateway reconnects.
+            for _ in range(3):
+                await bot.on_ready()
+                await asyncio.sleep(0)
+
+            second = dict(bot.background_tasks)
+            await drain(list(second.values()))
+            return first, second
+
+        first, second = run(scenario())
+
+        assert set(second) == self.EXPECTED
+        # Same task objects: nothing was started a second time.
+        assert all(first[name] is second[name] for name in self.EXPECTED)
+        # Each coroutine body executed exactly once across four on_ready calls.
+        assert sorted(stub_startup) == sorted(self.EXPECTED)
+
+    def test_reconnect_revives_a_dead_consumer(self, stub_startup, monkeypatch):
+        async def scenario():
+            await bot.on_ready()
+            await asyncio.sleep(0)
+            consumer = bot.background_tasks["results_consumer"]
+
+            # The consumer dies (e.g. an unrecoverable error escaped its loop).
+            consumer.cancel()
+            await asyncio.gather(consumer, return_exceptions=True)
+
+            await bot.on_ready()
+            await asyncio.sleep(0)
+            revived = bot.background_tasks["results_consumer"]
+            await drain(list(bot.background_tasks.values()))
+            return consumer, revived
+
+        dead, revived = run(scenario())
+
+        assert revived is not dead
+        assert stub_startup.count("results_consumer") == 2
+        # The one-shot panel refresh was not dragged along with the restart.
+        assert stub_startup.count("instruction_panel_refresh") == 1

--- a/tests/test_instruction_refresh.py
+++ b/tests/test_instruction_refresh.py
@@ -67,11 +67,16 @@ def entry(server_id=GUILD_ID, channel_id="222", message_id="111", locale="en-US"
 
 @pytest.fixture
 def clean_servers():
-    with bot.session_scope() as session:
-        session.query(bot.Server).delete()
+    def wipe():
+        with bot.session_scope() as session:
+            session.query(bot.Server).delete()
+            # Successful refreshes now record a view version; clear it too so
+            # stale_only tests can't inherit another test's bookkeeping.
+            session.query(bot.InstructionPanelView).delete()
+
+    wipe()
     yield
-    with bot.session_scope() as session:
-        session.query(bot.Server).delete()
+    wipe()
 
 
 @pytest.fixture(autouse=True)
@@ -324,6 +329,109 @@ class TestRefreshAllPanels:
         run(bot.update_all_instruction_messages())
 
         assert "embed" in rec.edits[0][2]
+
+
+# ---------------------------------------------------------------
+# Startup migration to the persistent view (tier 2)
+# ---------------------------------------------------------------
+class TestStartupMigration:
+    @staticmethod
+    def startup():
+        return bot.refresh_all_instruction_panels(
+            rebuild_embed=False, reason="startup", stale_only=True
+        )
+
+    def test_first_boot_migrates_and_records_every_panel(self, monkeypatch, clean_servers):
+        for i in range(5):
+            make_server(str(1000 + i), channel_id=str(2000 + i), message_id=str(3000 + i))
+        rec = Recorder().install(monkeypatch)
+
+        run(self.startup())
+
+        assert len(rec.edits) == 5
+        with bot.session_scope() as session:
+            assert session.query(bot.InstructionPanelView).count() == 5
+
+    def test_second_boot_touches_nothing(self, monkeypatch, clean_servers):
+        # This is the tier 2 payoff: a fully migrated fleet costs zero API calls.
+        for i in range(5):
+            make_server(str(1000 + i), channel_id=str(2000 + i), message_id=str(3000 + i))
+        rec = Recorder().install(monkeypatch)
+        run(self.startup())
+        assert len(rec.edits) == 5
+
+        second = Recorder().install(monkeypatch)
+        run(self.startup())
+
+        assert second.edits == []
+
+    def test_only_failed_panels_are_retried(self, monkeypatch, clean_servers):
+        for i in range(5):
+            make_server(str(1000 + i), channel_id=str(2000 + i), message_id=str(3000 + i))
+        # 3002 is forbidden, 3004 sits in an archived thread; neither migrates.
+        first = Recorder(
+            error_for={
+                3002: http_error(discord.Forbidden, 403),
+                3004: archived_thread_error(),
+            }
+        )
+        first.install(monkeypatch)
+        run(self.startup())
+        assert len(first.edits) == 3
+
+        second = Recorder().install(monkeypatch)
+        run(self.startup())
+
+        assert sorted(e[1] for e in second.edits) == [3002, 3004]
+
+    def test_a_recovered_panel_stops_being_retried(self, monkeypatch, clean_servers):
+        make_server(GUILD_ID)
+        Recorder(error_for={111: http_error(discord.Forbidden, 403)}).install(monkeypatch)
+        run(self.startup())
+
+        # Admin restores permissions; next boot succeeds and records the version.
+        recovered = Recorder().install(monkeypatch)
+        run(self.startup())
+        assert len(recovered.edits) == 1
+
+        quiet = Recorder().install(monkeypatch)
+        run(self.startup())
+        assert quiet.edits == []
+
+    def test_a_bumped_version_re_migrates_the_fleet(self, monkeypatch, clean_servers):
+        for i in range(3):
+            make_server(str(1000 + i), channel_id=str(2000 + i), message_id=str(3000 + i))
+        Recorder().install(monkeypatch)
+        run(self.startup())
+
+        monkeypatch.setattr(bot, "INSTRUCTIONS_VIEW_VERSION", bot.INSTRUCTIONS_VIEW_VERSION + 1)
+        rec = Recorder().install(monkeypatch)
+        run(self.startup())
+
+        assert len(rec.edits) == 3
+
+    def test_manual_trigger_still_refreshes_migrated_panels(self, monkeypatch, clean_servers):
+        for i in range(4):
+            make_server(str(1000 + i), channel_id=str(2000 + i), message_id=str(3000 + i))
+        Recorder().install(monkeypatch)
+        run(self.startup())
+
+        rec = Recorder().install(monkeypatch)
+        run(bot.update_all_instruction_messages())
+
+        # The trigger path exists to push copy/locale changes, so it must not
+        # skip panels merely because their buttons are current.
+        assert len(rec.edits) == 4
+
+    def test_404_during_migration_clears_both_records(self, monkeypatch, clean_servers):
+        make_server(GUILD_ID)
+        Recorder(error_for={111: http_error(discord.NotFound, 404)}).install(monkeypatch)
+
+        run(self.startup())
+
+        assert saved_panel(GUILD_ID) == (None, None)
+        with bot.session_scope() as session:
+            assert session.query(bot.InstructionPanelView).count() == 0
 
 
 # ---------------------------------------------------------------

--- a/tests/test_instruction_refresh.py
+++ b/tests/test_instruction_refresh.py
@@ -511,6 +511,47 @@ class TestFleetIsolation:
 
         assert "locale table is corrupt" in caplog.text
 
+    @staticmethod
+    def escaping_worker(monkeypatch, bad_server):
+        """Simulate an error raised outside refresh_instruction_panel's own guard.
+
+        Its internal try only wraps the edit; anything before that (id parsing,
+        pacing) escapes to the gather, which is what return_exceptions defends.
+        """
+        real = bot.refresh_instruction_panel
+
+        async def flaky(entry, rebuild_embed):
+            if entry["server_id"] == bad_server:
+                raise RuntimeError("escaped the worker guard")
+            return await real(entry, rebuild_embed)
+
+        monkeypatch.setattr(bot, "refresh_instruction_panel", flaky)
+
+    def test_an_escape_from_the_worker_does_not_abort_the_pass(
+        self, monkeypatch, clean_servers
+    ):
+        make_server("a", channel_id="1", message_id="10")
+        make_server("b", channel_id="2", message_id="20")
+        make_server("c", channel_id="3", message_id="30")
+        rec = Recorder().install(monkeypatch)
+        self.escaping_worker(monkeypatch, "a")
+
+        run(bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test"))
+
+        assert sorted(e[1] for e in rec.edits) == [20, 30]
+
+    def test_summary_survives_an_escaped_error(self, monkeypatch, clean_servers, caplog):
+        make_server("a", channel_id="1", message_id="10")
+        make_server("b", channel_id="2", message_id="20")
+        Recorder().install(monkeypatch)
+        self.escaping_worker(monkeypatch, "a")
+
+        with caplog.at_level("INFO"):
+            run(bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test"))
+
+        assert "1/2 updated" in caplog.text
+        assert "1 crashed" in caplog.text
+
     def test_cancellation_is_not_swallowed(self, monkeypatch, clean_servers):
         # return_exceptions=True captures CancelledError too; a shutdown must
         # still propagate rather than be logged as a per-panel failure.

--- a/tests/test_instruction_refresh.py
+++ b/tests/test_instruction_refresh.py
@@ -25,9 +25,15 @@ def run(coro):
     return asyncio.run(coro)
 
 
-def http_error(exc_type, status):
+def http_error(exc_type, status, code=0, message="test"):
     """Build a discord HTTPException subclass without a real aiohttp response."""
-    return exc_type(SimpleNamespace(status=status, reason="test"), "test")
+    payload = {"code": code, "message": message}
+    return exc_type(SimpleNamespace(status=status, reason="test"), payload)
+
+
+def archived_thread_error():
+    """The 400 Discord returns when a panel's thread has been archived."""
+    return http_error(discord.HTTPException, 400, code=50083, message="Thread is archived")
 
 
 def make_server(server_id, channel_id="222", message_id="111", **overrides):
@@ -72,6 +78,12 @@ def clean_servers():
 def fresh_lock(monkeypatch):
     """Each test gets its own loop via asyncio.run, so give it its own lock."""
     monkeypatch.setattr(bot, "instruction_refresh_lock", asyncio.Lock())
+
+
+@pytest.fixture(autouse=True)
+def unpaced(monkeypatch):
+    """Default to effectively no pacing; TestRequestPacing opts back in."""
+    monkeypatch.setattr(bot, "INSTRUCTIONS_REFRESH_RATE", 1_000_000)
 
 
 class Recorder:
@@ -200,6 +212,38 @@ class TestRefreshFailures:
         assert run(bot.refresh_instruction_panel(entry(), rebuild_embed=False)) is False
         assert saved_panel(GUILD_ID) == ("222", "111")
 
+    def test_archived_thread_keeps_saved_panel(self, monkeypatch, clean_servers):
+        # Unarchiving the thread revives the panel, so the reference is still good.
+        make_server(GUILD_ID)
+        Recorder(error_for={111: archived_thread_error()}).install(monkeypatch)
+
+        assert run(bot.refresh_instruction_panel(entry(), rebuild_embed=False)) is False
+        assert saved_panel(GUILD_ID) == ("222", "111")
+
+    def test_archived_thread_logs_one_line_not_a_traceback(
+        self, monkeypatch, clean_servers, caplog
+    ):
+        make_server(GUILD_ID)
+        Recorder(error_for={111: archived_thread_error()}).install(monkeypatch)
+
+        with caplog.at_level("WARNING"):
+            run(bot.refresh_instruction_panel(entry(), rebuild_embed=False))
+
+        assert "50083" in caplog.text
+        assert "Thread is archived" in caplog.text
+        assert "Traceback" not in caplog.text
+
+    def test_rejected_edit_does_not_stop_the_fleet(self, monkeypatch, clean_servers):
+        for i in range(4):
+            make_server(str(1000 + i), channel_id=str(2000 + i), message_id=str(3000 + i))
+        rec = Recorder(error_for={3001: archived_thread_error()})
+        rec.install(monkeypatch)
+
+        run(bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test"))
+
+        assert len(rec.edits) == 3
+        assert saved_panel("1001") == ("2001", "3001")
+
 
 # ---------------------------------------------------------------
 # Fleet-wide refresh
@@ -280,3 +324,83 @@ class TestRefreshAllPanels:
         run(bot.update_all_instruction_messages())
 
         assert "embed" in rec.edits[0][2]
+
+
+# ---------------------------------------------------------------
+# Request pacing (keeps us off Discord's global 50 req/s ceiling)
+# ---------------------------------------------------------------
+class TestRequestPacing:
+    """Slot arithmetic is asserted against recorded sleeps rather than a wall
+    clock: asyncio timers can fire up to one clock tick early (~15.6ms on
+    Windows), which makes direct elapsed-time thresholds flaky.
+    """
+
+    @staticmethod
+    def recorded_delays(monkeypatch, per_second, calls):
+        delays = []
+
+        async def fake_sleep(delay):
+            delays.append(delay)
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+        async def scenario():
+            pacer = bot.RequestPacer(per_second=per_second)
+            for _ in range(calls):
+                await pacer.wait()
+
+        run(scenario())
+        return delays
+
+    def test_first_call_does_not_wait(self, monkeypatch):
+        assert self.recorded_delays(monkeypatch, per_second=10, calls=1) == []
+
+    def test_each_further_call_waits_one_more_slot(self, monkeypatch):
+        delays = self.recorded_delays(monkeypatch, per_second=10, calls=5)
+
+        # 10/s == a 100ms slot; the clock barely moves because sleeps are faked,
+        # so the Nth caller waits roughly N slots.
+        assert len(delays) == 4
+        for i, delay in enumerate(delays, start=1):
+            assert abs(delay - i * 0.1) < 0.02, delays
+
+    def test_rate_sets_the_slot_width(self, monkeypatch):
+        assert bot.RequestPacer(per_second=25).min_interval == pytest.approx(0.04)
+        assert bot.RequestPacer(per_second=50).min_interval == pytest.approx(0.02)
+
+    def test_concurrent_waiters_each_get_their_own_slot(self, monkeypatch):
+        delays = []
+
+        async def fake_sleep(delay):
+            delays.append(delay)
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+        async def scenario():
+            pacer = bot.RequestPacer(per_second=100)
+            await asyncio.gather(*(pacer.wait() for _ in range(10)))
+
+        run(scenario())
+
+        # No two callers were handed the same slot.
+        assert len(delays) == 9
+        assert len(set(delays)) == 9
+
+    def test_fleet_refresh_is_paced(self, monkeypatch, clean_servers):
+        monkeypatch.setattr(bot, "INSTRUCTIONS_REFRESH_RATE", 100)
+        monkeypatch.setattr(bot, "INSTRUCTIONS_REFRESH_CONCURRENCY", 50)
+        for i in range(20):
+            make_server(str(1000 + i), channel_id=str(2000 + i), message_id=str(3000 + i))
+        rec = Recorder().install(monkeypatch)
+
+        async def scenario():
+            began = asyncio.get_running_loop().time()
+            await bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test")
+            return asyncio.get_running_loop().time() - began
+
+        elapsed = run(scenario())
+
+        assert len(rec.edits) == 20
+        # Unpaced, 20 instant edits finish in ~1ms. At 100/s they need ~190ms;
+        # the floor here is loose enough to absorb early-firing timers.
+        assert elapsed >= 0.1

--- a/tests/test_instruction_refresh.py
+++ b/tests/test_instruction_refresh.py
@@ -435,6 +435,145 @@ class TestStartupMigration:
 
 
 # ---------------------------------------------------------------
+# Blast radius: one bad guild must not take down the pass
+# ---------------------------------------------------------------
+class TestFleetIsolation:
+    """The startup pass is run_once, so anything escaping a single panel would
+    strand every remaining guild until the process restarts. Nothing may
+    propagate out of a worker.
+    """
+
+    @staticmethod
+    def exploding_view(fail_on_locale, monkeypatch):
+        real = bot.VRCVerifyInstructionView
+
+        def build(locale):
+            if locale == fail_on_locale:
+                raise RuntimeError("locale table is corrupt")
+            return real(locale)
+
+        monkeypatch.setattr(bot, "VRCVerifyInstructionView", build)
+
+    def test_view_construction_failure_does_not_abort_the_fleet(
+        self, monkeypatch, clean_servers
+    ):
+        make_server("a", channel_id="1", message_id="10")
+        make_server("b", channel_id="2", message_id="20", instructions_locale="de")
+        make_server("c", channel_id="3", message_id="30")
+        rec = Recorder().install(monkeypatch)
+        self.exploding_view("de", monkeypatch)
+
+        run(bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test"))
+
+        assert sorted(e[1] for e in rec.edits) == [10, 30]
+
+    def test_embed_construction_failure_is_contained(self, monkeypatch, clean_servers):
+        make_server("a", channel_id="1", message_id="10")
+        make_server("b", channel_id="2", message_id="20")
+        rec = Recorder().install(monkeypatch)
+        real = bot.build_instructions_embed
+        seen = []
+
+        def build(locale):
+            seen.append(locale)
+            if len(seen) == 1:
+                raise ValueError("bad embed")
+            return real(locale)
+
+        monkeypatch.setattr(bot, "build_instructions_embed", build)
+
+        run(bot.refresh_all_instruction_panels(rebuild_embed=True, reason="test"))
+
+        assert len(rec.edits) == 1
+
+    def test_summary_still_logs_when_a_worker_crashes(
+        self, monkeypatch, clean_servers, caplog
+    ):
+        make_server("a", channel_id="1", message_id="10")
+        make_server("b", channel_id="2", message_id="20", instructions_locale="de")
+        Recorder().install(monkeypatch)
+        self.exploding_view("de", monkeypatch)
+
+        with caplog.at_level("INFO"):
+            run(bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test"))
+
+        assert "Instruction panel refresh (test): 1/2" in caplog.text
+
+    def test_an_escaped_error_is_reported_not_silently_counted(
+        self, monkeypatch, clean_servers, caplog
+    ):
+        make_server("a", channel_id="1", message_id="10", instructions_locale="de")
+        Recorder().install(monkeypatch)
+        self.exploding_view("de", monkeypatch)
+
+        with caplog.at_level("ERROR"):
+            run(bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test"))
+
+        assert "locale table is corrupt" in caplog.text
+
+    def test_cancellation_is_not_swallowed(self, monkeypatch, clean_servers):
+        # return_exceptions=True captures CancelledError too; a shutdown must
+        # still propagate rather than be logged as a per-panel failure.
+        make_server("a", channel_id="1", message_id="10")
+        Recorder().install(monkeypatch)
+
+        async def cancel_one(entry, rebuild_embed):
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(bot, "refresh_instruction_panel", cancel_one)
+
+        with pytest.raises(asyncio.CancelledError):
+            run(bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test"))
+
+
+# ---------------------------------------------------------------
+# Release rollback
+# ---------------------------------------------------------------
+class TestVersionRollback:
+    def test_a_newer_recorded_panel_is_re_migrated(self, monkeypatch, clean_servers):
+        # Deploy v2, migrate, then roll back to v1. The panel carries v2
+        # custom_ids this process never registered, so skipping it would leave
+        # the buttons permanently dead.
+        make_server(GUILD_ID)
+        bot.record_panel_view_version(GUILD_ID, bot.INSTRUCTIONS_VIEW_VERSION + 1)
+        rec = Recorder().install(monkeypatch)
+
+        run(
+            bot.refresh_all_instruction_panels(
+                rebuild_embed=False, reason="rollback", stale_only=True
+            )
+        )
+
+        assert len(rec.edits) == 1
+
+    def test_rollback_rewrites_the_version_downwards(self, monkeypatch, clean_servers):
+        make_server(GUILD_ID)
+        bot.record_panel_view_version(GUILD_ID, bot.INSTRUCTIONS_VIEW_VERSION + 5)
+        Recorder().install(monkeypatch)
+
+        run(
+            bot.refresh_all_instruction_panels(
+                rebuild_embed=False, reason="rollback", stale_only=True
+            )
+        )
+
+        assert bot.load_instruction_panels()[0]["view_version"] == bot.INSTRUCTIONS_VIEW_VERSION
+
+    def test_exact_match_is_still_skipped(self, monkeypatch, clean_servers):
+        make_server(GUILD_ID)
+        bot.record_panel_view_version(GUILD_ID)
+        rec = Recorder().install(monkeypatch)
+
+        run(
+            bot.refresh_all_instruction_panels(
+                rebuild_embed=False, reason="test", stale_only=True
+            )
+        )
+
+        assert rec.edits == []
+
+
+# ---------------------------------------------------------------
 # Request pacing (keeps us off Discord's global 50 req/s ceiling)
 # ---------------------------------------------------------------
 class TestRequestPacing:

--- a/tests/test_instruction_refresh.py
+++ b/tests/test_instruction_refresh.py
@@ -1,0 +1,282 @@
+"""Unit tests for instruction panel refresh (issue #14).
+
+Startup used to re-post every guild's panel with two sequential API calls each
+(fetch_message + edit), which scaled badly past ~1000 servers. These tests pin
+the replacement behaviour:
+- one edit per panel, via a partial message (no channel/message fetch, no cache)
+- panels refresh concurrently, bounded by INSTRUCTIONS_REFRESH_CONCURRENCY
+- a 404 forgets the saved reference; a 403 leaves it alone
+- overlapping refreshes are serialized by the module lock
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import discord
+import pytest
+
+import bot
+
+GUILD_ID = "123456789"
+
+
+def run(coro):
+    """Run an async bot helper from a sync test (no pytest-asyncio needed)."""
+    return asyncio.run(coro)
+
+
+def http_error(exc_type, status):
+    """Build a discord HTTPException subclass without a real aiohttp response."""
+    return exc_type(SimpleNamespace(status=status, reason="test"), "test")
+
+
+def make_server(server_id, channel_id="222", message_id="111", **overrides):
+    fields = dict(
+        server_id=server_id,
+        owner_id="42",
+        role_id="1",
+        instructions_locale="en-US",
+        instructions_channel_id=channel_id,
+        instructions_message_id=message_id,
+    )
+    fields.update(overrides)
+    with bot.session_scope() as session:
+        session.add(bot.Server(**fields))
+
+
+def saved_panel(server_id):
+    with bot.session_scope() as session:
+        srv = session.query(bot.Server).filter_by(server_id=server_id).first()
+        return srv.instructions_channel_id, srv.instructions_message_id
+
+
+def entry(server_id=GUILD_ID, channel_id="222", message_id="111", locale="en-US"):
+    return {
+        "server_id": server_id,
+        "channel_id": channel_id,
+        "message_id": message_id,
+        "locale": locale,
+    }
+
+
+@pytest.fixture
+def clean_servers():
+    with bot.session_scope() as session:
+        session.query(bot.Server).delete()
+    yield
+    with bot.session_scope() as session:
+        session.query(bot.Server).delete()
+
+
+@pytest.fixture(autouse=True)
+def fresh_lock(monkeypatch):
+    """Each test gets its own loop via asyncio.run, so give it its own lock."""
+    monkeypatch.setattr(bot, "instruction_refresh_lock", asyncio.Lock())
+
+
+class Recorder:
+    """Stands in for the Discord HTTP layer and records every edit."""
+
+    def __init__(self, error_for=None, delay=0.0):
+        self.edits = []
+        self.error_for = error_for or {}
+        self.delay = delay
+        self.in_flight = 0
+        self.peak_in_flight = 0
+
+    def install(self, monkeypatch):
+        monkeypatch.setattr(bot.bot, "get_partial_messageable", self._messageable)
+        # The refresh path must not touch these; blow up loudly if it does.
+        for name in ("get_channel", "fetch_channel", "get_guild"):
+            monkeypatch.setattr(bot.bot, name, self._forbidden_call(name))
+        return self
+
+    def _forbidden_call(self, name):
+        def _fail(*args, **kwargs):
+            raise AssertionError(f"refresh must not call bot.{name}()")
+
+        return _fail
+
+    def _messageable(self, channel_id, **kwargs):
+        return SimpleNamespace(
+            get_partial_message=lambda message_id: self._message(channel_id, message_id)
+        )
+
+    def _message(self, channel_id, message_id):
+        async def edit(**payload):
+            self.in_flight += 1
+            self.peak_in_flight = max(self.peak_in_flight, self.in_flight)
+            try:
+                if self.delay:
+                    await asyncio.sleep(self.delay)
+                error = self.error_for.get(message_id)
+                if error:
+                    raise error
+                self.edits.append((channel_id, message_id, payload))
+            finally:
+                self.in_flight -= 1
+
+        return SimpleNamespace(edit=edit)
+
+
+# ---------------------------------------------------------------
+# Single panel: one edit, no fetches
+# ---------------------------------------------------------------
+class TestRefreshSinglePanel:
+    def test_edits_via_partial_message_without_fetching(self, monkeypatch):
+        rec = Recorder().install(monkeypatch)
+
+        assert run(bot.refresh_instruction_panel(entry(), rebuild_embed=False)) is True
+
+        assert len(rec.edits) == 1
+        channel_id, message_id, payload = rec.edits[0]
+        assert (channel_id, message_id) == (222, 111)
+        assert isinstance(payload["view"], bot.VRCVerifyInstructionView)
+
+    def test_startup_refresh_leaves_embed_untouched(self, monkeypatch):
+        rec = Recorder().install(monkeypatch)
+
+        run(bot.refresh_instruction_panel(entry(), rebuild_embed=False))
+
+        assert "embed" not in rec.edits[0][2]
+
+    def test_manual_refresh_rebuilds_localized_embed(self, monkeypatch):
+        rec = Recorder().install(monkeypatch)
+
+        run(bot.refresh_instruction_panel(entry(locale="de"), rebuild_embed=True))
+
+        embed = rec.edits[0][2]["embed"]
+        assert embed.title == bot.build_instructions_embed("de").title
+
+    def test_view_uses_stored_locale(self, monkeypatch):
+        rec = Recorder().install(monkeypatch)
+
+        run(bot.refresh_instruction_panel(entry(locale="de"), rebuild_embed=False))
+
+        assert rec.edits[0][2]["view"].locale == "de"
+
+    @pytest.mark.parametrize(
+        "bad", [{"channel_id": None}, {"message_id": None}, {"channel_id": ""}]
+    )
+    def test_incomplete_reference_is_skipped(self, monkeypatch, bad):
+        rec = Recorder().install(monkeypatch)
+
+        assert run(bot.refresh_instruction_panel(entry(**bad), rebuild_embed=False)) is False
+        assert rec.edits == []
+
+    def test_malformed_ids_do_not_raise(self, monkeypatch):
+        rec = Recorder().install(monkeypatch)
+
+        result = run(
+            bot.refresh_instruction_panel(entry(channel_id="not-an-id"), rebuild_embed=False)
+        )
+
+        assert result is False
+        assert rec.edits == []
+
+
+# ---------------------------------------------------------------
+# Failure handling
+# ---------------------------------------------------------------
+class TestRefreshFailures:
+    def test_404_forgets_saved_panel(self, monkeypatch, clean_servers):
+        make_server(GUILD_ID)
+        Recorder(error_for={111: http_error(discord.NotFound, 404)}).install(monkeypatch)
+
+        assert run(bot.refresh_instruction_panel(entry(), rebuild_embed=False)) is False
+        assert saved_panel(GUILD_ID) == (None, None)
+
+    def test_403_keeps_saved_panel(self, monkeypatch, clean_servers):
+        make_server(GUILD_ID)
+        Recorder(error_for={111: http_error(discord.Forbidden, 403)}).install(monkeypatch)
+
+        assert run(bot.refresh_instruction_panel(entry(), rebuild_embed=False)) is False
+        assert saved_panel(GUILD_ID) == ("222", "111")
+
+    def test_unexpected_error_keeps_saved_panel(self, monkeypatch, clean_servers):
+        make_server(GUILD_ID)
+        Recorder(error_for={111: RuntimeError("boom")}).install(monkeypatch)
+
+        assert run(bot.refresh_instruction_panel(entry(), rebuild_embed=False)) is False
+        assert saved_panel(GUILD_ID) == ("222", "111")
+
+
+# ---------------------------------------------------------------
+# Fleet-wide refresh
+# ---------------------------------------------------------------
+class TestRefreshAllPanels:
+    def test_refreshes_every_saved_panel(self, monkeypatch, clean_servers):
+        for i in range(25):
+            make_server(str(1000 + i), channel_id=str(2000 + i), message_id=str(3000 + i))
+        rec = Recorder().install(monkeypatch)
+
+        run(bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test"))
+
+        assert len(rec.edits) == 25
+
+    def test_servers_without_a_panel_are_ignored(self, monkeypatch, clean_servers):
+        make_server("1", channel_id="10", message_id="20")
+        make_server("2", channel_id=None, message_id=None)
+        rec = Recorder().install(monkeypatch)
+
+        run(bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test"))
+
+        assert [e[1] for e in rec.edits] == [20]
+
+    def test_edits_run_concurrently_up_to_the_cap(self, monkeypatch, clean_servers):
+        monkeypatch.setattr(bot, "INSTRUCTIONS_REFRESH_CONCURRENCY", 5)
+        for i in range(20):
+            make_server(str(1000 + i), channel_id=str(2000 + i), message_id=str(3000 + i))
+        rec = Recorder(delay=0.01).install(monkeypatch)
+
+        run(bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test"))
+
+        assert len(rec.edits) == 20
+        # The whole point of the change: more than one edit in flight at a time,
+        # but never more than the configured cap.
+        assert rec.peak_in_flight == 5
+
+    def test_one_bad_panel_does_not_stop_the_rest(self, monkeypatch, clean_servers):
+        for i in range(5):
+            make_server(str(1000 + i), channel_id=str(2000 + i), message_id=str(3000 + i))
+        rec = Recorder(error_for={3002: http_error(discord.NotFound, 404)})
+        rec.install(monkeypatch)
+
+        run(bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test"))
+
+        assert len(rec.edits) == 4
+        assert saved_panel("1002") == (None, None)
+
+    def test_empty_fleet_is_a_no_op(self, monkeypatch, clean_servers):
+        rec = Recorder().install(monkeypatch)
+
+        run(bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test"))
+
+        assert rec.edits == []
+
+    def test_overlapping_refreshes_are_serialized(self, monkeypatch, clean_servers):
+        monkeypatch.setattr(bot, "INSTRUCTIONS_REFRESH_CONCURRENCY", 10)
+        for i in range(4):
+            make_server(str(1000 + i), channel_id=str(2000 + i), message_id=str(3000 + i))
+        rec = Recorder(delay=0.01).install(monkeypatch)
+
+        async def both():
+            await asyncio.gather(
+                bot.refresh_all_instruction_panels(rebuild_embed=False, reason="a"),
+                bot.refresh_all_instruction_panels(rebuild_embed=True, reason="b"),
+            )
+
+        run(both())
+
+        assert len(rec.edits) == 8
+        # Serialized: the second pass never overlaps the first, so in-flight
+        # edits stay within a single pass's worth of work.
+        assert rec.peak_in_flight == 4
+
+    def test_manual_trigger_rebuilds_embeds(self, monkeypatch, clean_servers):
+        make_server(GUILD_ID)
+        rec = Recorder().install(monkeypatch)
+
+        run(bot.update_all_instruction_messages())
+
+        assert "embed" in rec.edits[0][2]

--- a/tests/test_persistent_panel_view.py
+++ b/tests/test_persistent_panel_view.py
@@ -1,0 +1,174 @@
+"""Unit tests for the persistent instruction panel view (issue #14, tier 2).
+
+Panel buttons used to get a random custom_id per process, so every posted panel
+had to be re-edited on boot just to hand out ids the new process recognised.
+They now carry fixed, versioned ids and are registered once via add_view(), so
+a restart only has to touch panels that predate the current version.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import discord
+import pytest
+
+import bot
+
+GUILD_ID = "123456789"
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def interactive_buttons(view):
+    """The two dispatchable buttons (the donate button is a link, so it isn't)."""
+    return [c for c in view.children if c.style is not discord.ButtonStyle.link]
+
+
+def make_server(server_id=GUILD_ID, channel_id="222", message_id="111", **overrides):
+    fields = dict(
+        server_id=server_id,
+        owner_id="42",
+        role_id="1",
+        instructions_locale="en-US",
+        instructions_channel_id=channel_id,
+        instructions_message_id=message_id,
+    )
+    fields.update(overrides)
+    with bot.session_scope() as session:
+        session.add(bot.Server(**fields))
+
+
+def mark_migrated(server_id, version=None):
+    bot.record_panel_view_version(
+        server_id, bot.INSTRUCTIONS_VIEW_VERSION if version is None else version
+    )
+
+
+@pytest.fixture
+def clean_db():
+    def wipe():
+        with bot.session_scope() as session:
+            session.query(bot.Server).delete()
+            session.query(bot.InstructionPanelView).delete()
+
+    wipe()
+    yield
+    wipe()
+
+
+# ---------------------------------------------------------------
+# The view itself
+# ---------------------------------------------------------------
+class TestPersistentView:
+    def test_view_is_persistent(self):
+        assert bot.VRCVerifyInstructionView(locale="en-US").is_persistent()
+
+    def test_buttons_carry_the_versioned_custom_ids(self):
+        ids = [b.custom_id for b in interactive_buttons(bot.VRCVerifyInstructionView("en-US"))]
+        assert ids == [
+            bot.BEGIN_VERIFICATION_CUSTOM_ID,
+            bot.UPDATE_NICKNAME_CUSTOM_ID,
+        ]
+
+    def test_custom_ids_embed_the_version(self):
+        suffix = f"v{bot.INSTRUCTIONS_VIEW_VERSION}"
+        assert bot.BEGIN_VERIFICATION_CUSTOM_ID.endswith(suffix)
+        assert bot.UPDATE_NICKNAME_CUSTOM_ID.endswith(suffix)
+
+    def test_ids_are_identical_across_instances(self):
+        # This is the whole point: a new process must produce the same ids as
+        # the one that originally posted the panel.
+        first = [b.custom_id for b in interactive_buttons(bot.VRCVerifyInstructionView("en-US"))]
+        second = [b.custom_id for b in interactive_buttons(bot.VRCVerifyInstructionView("en-US"))]
+        assert first == second
+
+    def test_ids_do_not_vary_by_locale(self):
+        en = [b.custom_id for b in interactive_buttons(bot.VRCVerifyInstructionView("en-US"))]
+        de = [b.custom_id for b in interactive_buttons(bot.VRCVerifyInstructionView("de"))]
+        assert en == de
+
+    def test_labels_still_localize(self):
+        en = [b.label for b in interactive_buttons(bot.VRCVerifyInstructionView("en-US"))]
+        de = [b.label for b in interactive_buttons(bot.VRCVerifyInstructionView("de"))]
+        assert en != de
+
+    def test_donate_link_button_has_no_custom_id(self):
+        # Discord rejects custom_id on link buttons; it must stay unset.
+        link = [c for c in bot.VRCVerifyInstructionView("en-US").children
+                if c.style is discord.ButtonStyle.link]
+        assert len(link) == 1
+        assert link[0].custom_id is None
+
+    def test_add_view_accepts_it(self):
+        client = discord.Client(intents=discord.Intents.none())
+        client.add_view(bot.VRCVerifyInstructionView(locale="en-US"))
+        store = client._connection._view_store._views
+        # Registered under the None key, which dispatch falls back to for any
+        # message id — that is what makes one registration cover every panel.
+        assert (2, bot.BEGIN_VERIFICATION_CUSTOM_ID) in store[None]
+        assert (2, bot.UPDATE_NICKNAME_CUSTOM_ID) in store[None]
+
+    def test_a_never_seen_message_resolves_to_the_view(self):
+        client = discord.Client(intents=discord.Intents.none())
+        client.add_view(bot.VRCVerifyInstructionView(locale="en-US"))
+        store = client._connection._view_store
+        assert store._views.get(999999999) is None  # no per-message registration
+        item = store._views[None][(2, bot.BEGIN_VERIFICATION_CUSTOM_ID)]
+        assert item.view is not None
+
+
+# ---------------------------------------------------------------
+# Version bookkeeping
+# ---------------------------------------------------------------
+class TestVersionRecording:
+    def test_unrecorded_panel_is_version_zero(self, clean_db):
+        make_server()
+        panel = bot.load_instruction_panels()[0]
+        assert panel["view_version"] == 0
+
+    def test_recording_marks_the_current_version(self, clean_db):
+        make_server()
+        mark_migrated(GUILD_ID)
+        assert bot.load_instruction_panels()[0]["view_version"] == bot.INSTRUCTIONS_VIEW_VERSION
+
+    def test_recording_is_idempotent(self, clean_db):
+        make_server()
+        mark_migrated(GUILD_ID)
+        mark_migrated(GUILD_ID)
+        with bot.session_scope() as session:
+            assert session.query(bot.InstructionPanelView).count() == 1
+
+    def test_forgetting_a_panel_clears_its_version(self, clean_db):
+        make_server()
+        mark_migrated(GUILD_ID)
+
+        bot.forget_instruction_panel(GUILD_ID)
+
+        with bot.session_scope() as session:
+            assert session.query(bot.InstructionPanelView).count() == 0
+
+    def test_stale_only_skips_current_panels(self, clean_db):
+        make_server("a", channel_id="1", message_id="10")
+        make_server("b", channel_id="2", message_id="20")
+        mark_migrated("a")
+
+        stale = bot.load_instruction_panels(stale_only=True)
+
+        assert [p["server_id"] for p in stale] == ["b"]
+
+    def test_stale_only_includes_older_versions(self, clean_db):
+        make_server()
+        mark_migrated(GUILD_ID, version=bot.INSTRUCTIONS_VIEW_VERSION - 1)
+
+        stale = bot.load_instruction_panels(stale_only=True)
+
+        assert [p["server_id"] for p in stale] == [GUILD_ID]
+
+    def test_full_load_ignores_version(self, clean_db):
+        make_server("a", channel_id="1", message_id="10")
+        make_server("b", channel_id="2", message_id="20")
+        mark_migrated("a")
+
+        assert len(bot.load_instruction_panels()) == 2

--- a/tests/test_persistent_panel_view.py
+++ b/tests/test_persistent_panel_view.py
@@ -172,3 +172,72 @@ class TestVersionRecording:
         mark_migrated("a")
 
         assert len(bot.load_instruction_panels()) == 2
+
+
+# ---------------------------------------------------------------
+# Guild id type coercion
+# ---------------------------------------------------------------
+class TestServerIdCoercion:
+    """`servers.server_id` is declared String but the deployed Postgres column
+    is an integer type, so SQLAlchemy hands back ints. Against the text column
+    in instruction_panel_views that made Postgres reject `varchar = bigint` on
+    write, and made the version lookup silently miss on read. Everything
+    touching that table has to normalise first.
+    """
+
+    def test_key_normalises_ints(self):
+        assert bot.panel_view_key(123) == "123"
+        assert bot.panel_view_key("123") == "123"
+
+    def test_recording_with_an_int_is_found_by_a_str_lookup(self, clean_db):
+        make_server(GUILD_ID)  # stored as str, as the model declares
+
+        bot.record_panel_view_version(int(GUILD_ID))
+
+        # The read side must match despite the write coming in as an int.
+        assert bot.load_instruction_panels(stale_only=True) == []
+
+    def test_recording_with_a_str_is_forgotten_by_an_int(self, clean_db):
+        make_server(GUILD_ID)
+        bot.record_panel_view_version(GUILD_ID)
+
+        bot.forget_panel_view_version(int(GUILD_ID))
+
+        with bot.session_scope() as session:
+            assert session.query(bot.InstructionPanelView).count() == 0
+
+    def test_int_and_str_never_create_two_rows(self, clean_db):
+        bot.record_panel_view_version(int(GUILD_ID))
+        bot.record_panel_view_version(GUILD_ID)
+
+        with bot.session_scope() as session:
+            assert session.query(bot.InstructionPanelView).count() == 1
+
+    def test_version_is_visible_when_ids_differ_in_type(self, clean_db):
+        make_server(GUILD_ID)
+        bot.record_panel_view_version(int(GUILD_ID))
+
+        panel = bot.load_instruction_panels()[0]
+
+        assert panel["view_version"] == bot.INSTRUCTIONS_VIEW_VERSION
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            pytest.param(lambda: bot.record_panel_view_version(GUILD_ID), id="record"),
+            pytest.param(lambda: bot.forget_panel_view_version(GUILD_ID), id="forget"),
+            pytest.param(lambda: bot.load_instruction_panels(), id="load"),
+        ],
+    )
+    def test_every_table_access_normalises_first(self, clean_db, monkeypatch, call):
+        # The round-trip tests above cannot fail on SQLite, whose TEXT affinity
+        # quietly coerces ints on the way in. Postgres does not, so the real
+        # invariant to protect is that nothing reaches this table un-normalised.
+        make_server(GUILD_ID)
+        seen = []
+        real = bot.panel_view_key
+        monkeypatch.setattr(bot, "panel_view_key", lambda v: (seen.append(v), real(v))[1])
+
+        call()
+
+        assert seen, "guild id reached instruction_panel_views without normalising"


### PR DESCRIPTION
Closes #14.

## Problem

On startup, `on_ready` re-edited every guild's instruction panel one at a time — a `fetch_message` + `edit` per guild, fully sequential. At ~1000 servers this took minutes and blocked the bot from feeling responsive right after connecting. Every restart also had to touch every panel just to hand out fresh button `custom_id`s, since those were randomly generated per process.

## What changed

**Tier 1 — make the existing refresh fast:**
- Edit via `channel.get_partial_message(id).edit(...)` instead of fetch-then-edit — halves the API calls and needs nothing in the gateway cache.
- Refresh panels concurrently (bounded semaphore) instead of one at a time, paced under a configurable rate (`INSTRUCTIONS_REFRESH_RATE`, default 25/s) to stay under Discord's ~50 req/s global ceiling — exceeding it throttles verification traffic too, not just this loop.
- Run the whole pass as a background task so the bot doesn't block on it.
- Handle archived-thread edits (`50083`) as a one-line warning instead of a full traceback; a 404 clears the stale DB reference so it stops being retried.

**Tier 2 — stop needing to touch most panels at all:**
- Panel buttons now carry fixed, versioned `custom_id`s (`vrcverify:begin:v1`, `vrcverify:nickname:v1`) instead of random ones, and are registered once via `bot.add_view()` in `setup_hook`. Discord routes clicks by `custom_id` globally, so this one registration covers every panel ever posted — no per-message state needed.
- A new `instruction_panel_views` table (auto-created, no manual migration — see below) tracks which version each guild's panel carries. Startup only re-edits panels that predate the current version or previously failed; everything else is already live through the persistent view registration.
- Failed panels (permission revoked, thread archived) retry every boot so they self-heal once an admin fixes the channel.

**Also fixed, found along the way:**
- `on_ready` fires on every gateway reconnect, not just at startup, and was unconditionally spawning new background tasks each time — leaking a RabbitMQ consumer + executor thread, a cleanup loop, and a trigger-file watcher per reconnect. Long-lived tasks now restart only if dead; the one-shot panel refresh never repeats in the same process.
- Adversarial testing surfaced two real bugs before they could bite in production: a single guild with a bad locale/embed could abort the entire fleet pass with no summary logged (payload construction was outside the try, and `gather` had no `return_exceptions`); and a rollback to an older release would permanently skip panels recorded with a newer version's custom_ids (`>=` vs `==` in the staleness check).

## Why a new table instead of a column on `servers`

`Base.metadata.create_all()` creates missing tables automatically but never adds columns to an existing one, and a column present in the SQLAlchemy model but absent in the deployed table breaks *every* query against that model, not just the code touching the new field. A separate table sidesteps that: zero manual DDL, works identically on Postgres and SQLite.

That same investigation surfaced a real footgun: `servers.server_id` is declared `String` in the model, but the deployed Postgres column is an integer type, so SQLAlchemy returns raw `int`s from it. That mismatch broke the first version of the new table (`character varying = bigint`) both on write and on the read-side lookup. Fixed via a `panel_view_key()` normalizer at every access point — verified against a live run's logs, not just tests (SQLite's loose typing can't reproduce Postgres's strict behavior here).

## Verified live

Ran against the production bot (~1000 guilds, 350 with a posted panel) across three restarts:
1. Pre-fix: 235/350 succeeded but the version table writes were silently failing (Postgres type error), so tier 2 wasn't actually taking effect.
2. Post-fix: same run, zero write errors — versions now persist.
3. Following restart: `0/115 updated in 5.2s` — the 235 healthy panels were skipped entirely (already routed through the persistent view), only the known-broken 115 (permissions/archived threads) were retried, exactly matching the log's own failure count from the run before.

## Test plan
- [x] 313 tests passing (`pytest`)
- [x] Three rounds of adversarial probing against the changed surfaces (fleet isolation, rollback safety, cancellation, env parsing, double registration, lock release under error/cancel) — two real bugs found and fixed, verified via mutation testing (revert the fix, confirm the new test fails)
- [x] Verified against the live production bot across three restarts (see above)