### PR TITLE
Serve premium servers first in the verification queue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,13 @@ RABBITMQ_PASSWORD=guest
 RABBITMQ_VHOST=/
 RABBITMQ_QUEUE_NAME=verification_requests
 RABBITMQ_RESULT_QUEUE=verification_results
+# NOTE: the request queue is declared with x-max-priority so premium servers are
+# served first when a backlog forms. The priority ceiling is a constant in both
+# src/bot.py and src/vrc_online_checker.py, NOT an env var — the two must match
+# exactly or every declare fails with 406 and both services stop.
+# Upgrading from a build without it requires deleting and recreating the queue
+# named by RABBITMQ_QUEUE_NAME above (whatever you have set it to — not the
+# placeholder here). See "Upgrading to a build with queue priority" in the README.
 # Connection tuning, so a stale connection is detected instead of hanging.
 # RABBITMQ_HEARTBEAT=60
 # RABBITMQ_BLOCKED_TIMEOUT=60

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ unlocks the automation around it:
 | Custom post-verification DM | — | ✅ | ✅ |
 | Reduced verification cooldown | — | — | ✅ |
 | Verification activity log channel | — | — | ✅ |
+| Priority placement in the verification queue | — | — | ✅ |
 
 Auto-verify-on-join is free for everyone and is deliberately not gated at all —
 `on_member_join` never so much as reads an entitlement. Users read "the bot
@@ -133,6 +134,51 @@ outage can't silently disable a paying server's automation.
 The one-time cutover announcement to existing servers is manually triggered:
 `touch` the file at `PREMIUM_CUTOVER_TRIGGER_PATH` and it trickles out under a
 per-sweep cap, then stops on its own.
+
+### Queue priority
+
+Premium servers' verification requests are published at a higher RabbitMQ priority than
+free ones. Every verification goes through a single shared VRChat account and a checker
+consuming with `prefetch_count=1`, so this decides who is served first **when a backlog
+exists** — RabbitMQ only reorders messages already waiting, so nothing changes while the
+queue is empty.
+
+`QUEUE_MAX_PRIORITY` is a hardcoded constant in **both** `src/bot.py` and
+`src/vrc_online_checker.py`, deliberately not an environment variable. Both services
+declare the same queue and the arguments must match exactly, or every declare fails with
+406 `PRECONDITION_FAILED` and takes down publishing and consuming at once. Changing the
+value is a migration, not a config change. `tests/test_priority_queue.py` pins that the
+two services agree and that each actually passes the arguments.
+
+> #### ⚠️ Upgrading to a build with queue priority
+>
+> The pre-existing request queue has no `x-max-priority` argument, and RabbitMQ will not
+> let it be re-declared with one. **It must be deleted and recreated.**
+>
+> The queue is the one named by **`RABBITMQ_QUEUE_NAME`** in your `.env` — check it
+> rather than assuming, since the deployed name is not the placeholder in
+> `.env.example`. Only the *request* queue changes; `RABBITMQ_RESULT_QUEUE` is untouched.
+>
+> This sequence loses nothing:
+>
+> 1. Stop **the bot only**. No new requests are published.
+> 2. In the RabbitMQ UI, watch that queue until **Ready = 0 and Unacked = 0** — the
+>    checker finishes the backlog normally.
+> 3. Stop the checker.
+> 4. Delete the (now empty) queue.
+> 5. Deploy both new images and start them.
+>
+> Deleting the queue while it still holds messages discards them, and each one is
+> somebody who pressed Verify and will never hear back — hence draining first.
+>
+> Do not delete it while the old containers are still running: the bot re-declares the
+> queue on every publish and the checker on every reconnect, so it would reappear within
+> seconds, still without priority. The delete has to land in the gap between stopping the
+> old containers and starting the new ones.
+>
+> If step 4 is skipped, both services log an explicit error naming the queue and the fix.
+> The bot stops publishing (rather than retrying something that can never succeed) and
+> the checker backs off; verification is stopped until the queue is deleted.
 
 ### Verification activity log
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -68,6 +68,60 @@ RABBITMQ_USERNAME = os.getenv("RABBITMQ_USERNAME")
 RABBITMQ_PASSWORD = os.getenv("RABBITMQ_PASSWORD")
 RABBITMQ_VHOST = os.getenv("RABBITMQ_VHOST")
 
+# Priority levels on the request queue, so premium servers are served ahead of
+# free ones when a backlog forms. RabbitMQ only reorders messages already
+# waiting, so this changes nothing while the queue is empty — which is the
+# normal case — and everything when the single shared VRChat account falls
+# behind, which is the case worth paying for.
+#
+# NOT an env var, deliberately. vrc_online_checker.py declares the same queue
+# and the arguments must match exactly or every declare fails with 406
+# PRECONDITION_FAILED, taking down both services at once. Changing this value
+# is itself a migration — the queue has to be deleted and recreated — so it
+# must not look like something that can be tuned from config.
+# tests/test_priority_queue.py pins that both services agree.
+QUEUE_MAX_PRIORITY = 5
+PREMIUM_REQUEST_PRIORITY = QUEUE_MAX_PRIORITY
+DEFAULT_REQUEST_PRIORITY = 0
+
+# RabbitMQ's reply code for "this queue already exists with other arguments".
+QUEUE_ARGUMENT_MISMATCH_CODE = 406
+
+
+def request_queue_arguments() -> dict:
+    """Declaration arguments for the verification request queue.
+
+    Both services build them here-shaped so a mismatch is a test failure rather
+    than a production 406.
+    """
+    return {"x-max-priority": QUEUE_MAX_PRIORITY}
+
+
+def is_queue_argument_mismatch(error: Exception) -> bool:
+    """Is this the 406 you get from re-declaring a queue with new arguments?"""
+    return getattr(error, "reply_code", None) == QUEUE_ARGUMENT_MISMATCH_CODE
+
+
+def log_queue_argument_mismatch(queue_name: str) -> None:
+    """Say exactly what is wrong and exactly how to fix it.
+
+    Without this the failure is invisible: ChannelClosedByBroker subclasses
+    AMQPError, so the publisher swallows it in its generic retry loop and the
+    consumer reconnects forever, neither explaining why. That turns a one-line
+    operator fix into a mysterious outage across both services.
+    """
+    logger.error(
+        "Queue '%s' already exists with different arguments, so it cannot be "
+        "declared with priority support (x-max-priority=%s). Verification is "
+        "STOPPED until this is fixed. Stop the bot, let the checker drain the "
+        "queue to zero, stop the checker, delete the '%s' queue in RabbitMQ, "
+        "then start both again.",
+        queue_name,
+        QUEUE_MAX_PRIORITY,
+        queue_name,
+    )
+
+
 # Donation link surfaced on the instruction panel, admin confirmations,
 # and the one-time milestone DM.
 KOFI_URL = "https://ko-fi.com/italiandogs"
@@ -512,6 +566,7 @@ FEATURE_NICKNAME_SYNC = "nickname_sync"
 FEATURE_CUSTOM_DM = "custom_dm"
 FEATURE_REDUCED_COOLDOWN = "reduced_cooldown"
 FEATURE_ACTIVITY_LOG = "activity_log"
+FEATURE_PRIORITY_QUEUE = "priority_queue"
 
 # Servers configured before the cutover keep these three for free, forever.
 # The reduced cooldown and the activity log are new, so nobody is losing them.
@@ -766,6 +821,12 @@ class PremiumFlags:
         if self.allows(FEATURE_REDUCED_COOLDOWN):
             return PREMIUM_VERIFICATION_COOLDOWN_SECONDS
         return None
+
+    def request_priority(self) -> int:
+        """Where this guild's requests sit in the queue when there's a backlog."""
+        if self.allows(FEATURE_PRIORITY_QUEUE):
+            return PREMIUM_REQUEST_PRIORITY
+        return DEFAULT_REQUEST_PRIORITY
 
 
 async def resolve_premium_flags(guild_id) -> PremiumFlags:
@@ -1176,11 +1237,11 @@ class VRCVerifyInstructionView(View):
 
         user_id = str(interaction.user.id)
 
+        # Resolved once and reused for the queue priority below, so this costs
+        # no extra entitlement read.
+        flags = resolve_premium_flags_from_interaction(interaction)
         remaining = check_verification_cooldown(
-            user_id,
-            window_seconds=resolve_premium_flags_from_interaction(
-                interaction
-            ).cooldown_window(),
+            user_id, window_seconds=flags.cooldown_window()
         )
         if remaining:
             return await interaction.response.send_message(
@@ -1204,7 +1265,8 @@ class VRCVerifyInstructionView(View):
             vrc_user_id=vrc_user_id,
             guild_id=str(interaction.guild_id),
             code=None,
-            update_nickname=True
+            update_nickname=True,
+            priority=flags.request_priority(),
         )
         # localized confirmation
         await interaction.response.send_message(
@@ -1658,11 +1720,9 @@ async def process_verification(interaction: discord.Interaction):
             await interaction.response.send_modal(VRCUsernameModal(interaction))
             return
 
+        flags = resolve_premium_flags_from_interaction(interaction)
         remaining = check_verification_cooldown(
-            user_id,
-            window_seconds=resolve_premium_flags_from_interaction(
-                interaction
-            ).cooldown_window(),
+            user_id, window_seconds=flags.cooldown_window()
         )
         if remaining:
             await interaction.response.send_message(
@@ -1676,7 +1736,8 @@ async def process_verification(interaction: discord.Interaction):
             discord_id=user_id,
             vrc_user_id=stored_vrc_user_id,
             guild_id=guild_id,
-            code=None  # No-code re-check
+            code=None,  # No-code re-check
+            priority=flags.request_priority(),
         )
         await interaction.followup.send(
             get_message("recheck_started", interaction), ephemeral=True
@@ -1799,7 +1860,8 @@ async def publish_to_vrc_checker(
     vrc_user_id: str,
     guild_id: str,
     code: str | None,
-    update_nickname: bool = False
+    update_nickname: bool = False,
+    priority: int = DEFAULT_REQUEST_PRIORITY,
 ):
     def _publish():
         message = {
@@ -1814,6 +1876,7 @@ async def publish_to_vrc_checker(
         properties = pika.BasicProperties(
             content_type="application/json",
             delivery_mode=2,  # persistent
+            priority=priority,
         )
 
         max_publish_tries = int(os.getenv("RABBITMQ_PUBLISH_TRIES", "3"))
@@ -1823,7 +1886,11 @@ async def publish_to_vrc_checker(
             try:
                 conn = _rabbitmq_connect_with_retry(max_tries=1)
                 channel = conn.channel()
-                channel.queue_declare(queue=RABBITMQ_REQUEST_QUEUE, durable=True)
+                channel.queue_declare(
+                    queue=RABBITMQ_REQUEST_QUEUE,
+                    durable=True,
+                    arguments=request_queue_arguments(),
+                )
                 channel.basic_publish(
                     exchange="",
                     routing_key=RABBITMQ_REQUEST_QUEUE,
@@ -1833,6 +1900,12 @@ async def publish_to_vrc_checker(
                 logger.info("📤 Sent to vrc_online_checker: %s", message)
                 return
             except AMQPError as e:
+                # Retrying this one is pointless: the queue's arguments will not
+                # change on their own, so every attempt fails identically and
+                # the real cause never reaches the log.
+                if is_queue_argument_mismatch(e):
+                    log_queue_argument_mismatch(RABBITMQ_REQUEST_QUEUE)
+                    return
                 last_exc = e
                 logger.warning(
                     "RabbitMQ publish failed (attempt %s/%s); retrying...",
@@ -2116,12 +2189,11 @@ class VRCVerificationButton(discord.ui.View):
         """
         discord_id = str(interaction.user.id)
 
+        flags = resolve_premium_flags_from_interaction(interaction)
         # Own scope: a prior re-check/nickname request must never block Verify.
         remaining = check_verification_cooldown(
             discord_id,
-            window_seconds=resolve_premium_flags_from_interaction(
-                interaction
-            ).cooldown_window(),
+            window_seconds=flags.cooldown_window(),
             scope="verify",
         )
         if remaining:
@@ -2148,7 +2220,11 @@ class VRCVerificationButton(discord.ui.View):
         await interaction.response.defer(ephemeral=True)
 
         await publish_to_vrc_checker(
-            discord_id, vrc_user_id, self.guild_id, verification_code
+            discord_id,
+            vrc_user_id,
+            self.guild_id,
+            verification_code,
+            priority=flags.request_priority(),
         )
 
         await interaction.followup.send(

--- a/src/vrc_online_checker.py
+++ b/src/vrc_online_checker.py
@@ -35,6 +35,33 @@ RABBITMQ_VHOST = os.getenv("RABBITMQ_VHOST")
 RABBITMQ_QUEUE_NAME = os.getenv("RABBITMQ_QUEUE_NAME")
 RESULT_QUEUE_NAME = os.getenv("RABBITMQ_RESULT_QUEUE")
 
+# Priority levels on the request queue, so premium servers are served ahead of
+# free ones when a backlog forms.
+#
+# NOT an env var, deliberately, and it MUST stay identical to bot.py's
+# QUEUE_MAX_PRIORITY. Both services declare this queue, and RabbitMQ rejects a
+# declare whose arguments differ from the existing queue's with 406
+# PRECONDITION_FAILED — which would take down publishing and consuming at the
+# same time. Changing the value is a migration (delete and recreate the queue),
+# not a config tweak. tests/test_priority_queue.py pins that they agree.
+QUEUE_MAX_PRIORITY = 5
+
+# RabbitMQ's reply code for "this queue already exists with other arguments".
+QUEUE_ARGUMENT_MISMATCH_CODE = 406
+
+
+def request_queue_arguments() -> dict:
+    """Declaration arguments for the verification request queue.
+
+    Must return exactly what bot.py's function of the same name returns.
+    """
+    return {"x-max-priority": QUEUE_MAX_PRIORITY}
+
+
+def is_queue_argument_mismatch(error: Exception) -> bool:
+    """Is this the 406 you get from re-declaring a queue with new arguments?"""
+    return getattr(error, "reply_code", None) == QUEUE_ARGUMENT_MISMATCH_CODE
+
 # Gmail IMAP Credentials
 GMAIL_USER = os.getenv("GMAIL_USER")
 GMAIL_APP_PASSWORD = os.getenv("GMAIL_APP_PASSWORD")
@@ -1036,7 +1063,11 @@ def listen_for_verifications():
         try:
             connection = _rabbitmq_connect_with_retry(max_tries=0)
             channel = connection.channel()
-            channel.queue_declare(queue=RABBITMQ_QUEUE_NAME, durable=True)
+            channel.queue_declare(
+                queue=RABBITMQ_QUEUE_NAME,
+                durable=True,
+                arguments=request_queue_arguments(),
+            )
             channel.basic_qos(prefetch_count=1)
             channel.basic_consume(
                 queue=RABBITMQ_QUEUE_NAME,
@@ -1045,6 +1076,24 @@ def listen_for_verifications():
             )
             logging.info("Listening for verification requests on '%s'...", RABBITMQ_QUEUE_NAME)
             channel.start_consuming()
+        except pika.exceptions.ChannelClosedByBroker as error:
+            if not is_queue_argument_mismatch(error):
+                raise
+            # Reconnecting cannot fix this — the queue's arguments will not
+            # change on their own — and the generic handler below would retry
+            # forever without ever explaining why. Say what is wrong and how to
+            # fix it, then back off hard so the log is readable.
+            logging.error(
+                "Queue '%s' already exists with different arguments, so it cannot be "
+                "declared with priority support (x-max-priority=%s). Verification is "
+                "STOPPED until this is fixed. Stop the bot, let this service drain the "
+                "queue to zero, stop it, delete the '%s' queue in RabbitMQ, then start "
+                "both again.",
+                RABBITMQ_QUEUE_NAME,
+                QUEUE_MAX_PRIORITY,
+                RABBITMQ_QUEUE_NAME,
+            )
+            time.sleep(60)
         except (pika.exceptions.AMQPConnectionError, pika.exceptions.StreamLostError, OSError):
             logging.warning("RabbitMQ consumer disconnected; reconnecting soon...", exc_info=True)
             time.sleep(3)

--- a/tests/test_priority_queue.py
+++ b/tests/test_priority_queue.py
@@ -1,0 +1,390 @@
+"""Unit tests for premium priority placement in the verification queue (#56).
+
+The dangerous part of this feature is not the ordering, it's the declaration.
+Both services declare the same queue, and RabbitMQ rejects a declare whose
+arguments differ from the existing queue's with 406 PRECONDITION_FAILED — which
+takes down publishing and consuming simultaneously. Most of what follows guards
+that, not the priority itself.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pika
+import pytest
+
+import bot
+import vrc_online_checker as checker
+
+GUILD_ID = "987654321"
+OWNER_ID = "77"
+SKU_ID = 555000111
+OLD_ID = 100
+NEW_ID = 5000
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class FakeEntitlement:
+    def __init__(self, sku_id=SKU_ID):
+        self.sku_id = sku_id
+        self.deleted = False
+        self.guild_id = int(GUILD_ID)
+
+    def is_expired(self):
+        return False
+
+
+def entitlements_api(*items):
+    def _entitlements(**kwargs):
+        async def generate():
+            for item in items:
+                yield item
+
+        return generate()
+
+    return _entitlements
+
+
+def make_server(server_id=GUILD_ID, row_id=OLD_ID, **overrides):
+    fields = dict(
+        id=row_id,
+        server_id=server_id,
+        owner_id=OWNER_ID,
+        role_id="1",
+        instructions_locale="en-US",
+    )
+    fields.update(overrides)
+    with bot.session_scope() as session:
+        session.add(bot.Server(**fields))
+
+
+@pytest.fixture(autouse=True)
+def clean_db():
+    def wipe():
+        with bot.session_scope() as session:
+            session.query(bot.Server).delete()
+            session.query(bot.User).delete()
+
+    wipe()
+    bot.premium_status_cache.clear()
+    yield
+    wipe()
+    bot.premium_status_cache.clear()
+
+
+@pytest.fixture
+def enforced(monkeypatch):
+    monkeypatch.setattr(bot, "PREMIUM_SKU_ID", SKU_ID)
+    monkeypatch.setattr(bot, "PREMIUM_ENFORCED", True)
+    bot.premium_status_cache.clear()
+
+
+# ---------------------------------------------------------------
+# The cross-service invariant
+# ---------------------------------------------------------------
+class TestQueueArgumentsMatch:
+    """If these two ever drift, production 406s on both services at once."""
+
+    def test_both_services_declare_identical_arguments(self):
+        assert bot.request_queue_arguments() == checker.request_queue_arguments()
+
+    def test_both_services_agree_on_the_priority_ceiling(self):
+        assert bot.QUEUE_MAX_PRIORITY == checker.QUEUE_MAX_PRIORITY
+
+    def test_arguments_carry_the_priority_ceiling(self):
+        assert bot.request_queue_arguments() == {
+            "x-max-priority": bot.QUEUE_MAX_PRIORITY
+        }
+
+    def test_priority_stays_within_the_declared_ceiling(self):
+        # Publishing above x-max-priority is silently clamped by RabbitMQ, which
+        # would make premium and free indistinguishable at the top end.
+        assert bot.PREMIUM_REQUEST_PRIORITY <= bot.QUEUE_MAX_PRIORITY
+        assert bot.DEFAULT_REQUEST_PRIORITY < bot.PREMIUM_REQUEST_PRIORITY
+
+    def test_the_ceiling_stays_small(self):
+        # RabbitMQ allocates per-level structures; its own guidance is to keep
+        # this in the 1-10 range rather than reaching for 255.
+        assert 1 <= bot.QUEUE_MAX_PRIORITY <= 10
+
+
+# ---------------------------------------------------------------
+# Gating
+# ---------------------------------------------------------------
+class TestRequestPriority:
+    def test_premium_gets_the_high_priority(self, enforced):
+        flags = bot.PremiumFlags(premium=True, grandfathered=False)
+        assert flags.request_priority() == bot.PREMIUM_REQUEST_PRIORITY
+
+    def test_free_gets_the_default(self, enforced):
+        flags = bot.PremiumFlags(premium=False, grandfathered=False)
+        assert flags.request_priority() == bot.DEFAULT_REQUEST_PRIORITY
+
+    def test_grandfathering_does_not_unlock_it(self, enforced):
+        # Brand new feature, so an old server has nothing to preserve.
+        flags = bot.PremiumFlags(premium=False, grandfathered=True)
+        assert flags.request_priority() == bot.DEFAULT_REQUEST_PRIORITY
+
+    def test_everyone_is_prioritised_while_the_tier_is_off(self):
+        # PREMIUM_SKU_ID unset: the whole premium system is inert, so nothing
+        # should be sorted below anything else.
+        flags = run(bot.resolve_premium_flags(GUILD_ID))
+        assert flags.request_priority() == bot.PREMIUM_REQUEST_PRIORITY
+
+
+# ---------------------------------------------------------------
+# Publishing
+# ---------------------------------------------------------------
+@pytest.fixture
+def publish_spy(monkeypatch):
+    """Capture what publish_to_vrc_checker hands to pika."""
+    calls = SimpleNamespace(declares=[], publishes=[])
+
+    class FakeChannel:
+        def queue_declare(self, queue, durable=False, arguments=None):
+            calls.declares.append(
+                {"queue": queue, "durable": durable, "arguments": arguments}
+            )
+
+        def basic_publish(self, exchange, routing_key, body, properties):
+            calls.publishes.append(
+                {"routing_key": routing_key, "body": body, "properties": properties}
+            )
+
+    class FakeConn:
+        is_open = True
+
+        def channel(self):
+            return FakeChannel()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(bot, "_rabbitmq_connect_with_retry", lambda **kw: FakeConn())
+    return calls
+
+
+class TestPublish:
+    def test_declares_with_priority_arguments(self, publish_spy):
+        run(bot.publish_to_vrc_checker("1", "usr_x", GUILD_ID, None))
+        assert publish_spy.declares[0]["arguments"] == bot.request_queue_arguments()
+        assert publish_spy.declares[0]["durable"] is True
+
+    def test_premium_priority_reaches_the_message(self, publish_spy):
+        run(
+            bot.publish_to_vrc_checker(
+                "1", "usr_x", GUILD_ID, None, priority=bot.PREMIUM_REQUEST_PRIORITY
+            )
+        )
+        assert (
+            publish_spy.publishes[0]["properties"].priority
+            == bot.PREMIUM_REQUEST_PRIORITY
+        )
+
+    def test_default_priority_when_unspecified(self, publish_spy):
+        run(bot.publish_to_vrc_checker("1", "usr_x", GUILD_ID, None))
+        assert (
+            publish_spy.publishes[0]["properties"].priority
+            == bot.DEFAULT_REQUEST_PRIORITY
+        )
+
+    def test_messages_stay_persistent(self, publish_spy):
+        # delivery_mode=2 predates this change and must survive it: a restart
+        # losing queued verifications would be a real regression.
+        run(bot.publish_to_vrc_checker("1", "usr_x", GUILD_ID, None))
+        assert publish_spy.publishes[0]["properties"].delivery_mode == 2
+
+
+class TestCheckerDeclare:
+    """The consumer side of the invariant.
+
+    TestQueueArgumentsMatch only proves the two helpers agree; it says nothing
+    about whether the checker actually calls its own. Dropping `arguments=`
+    here is exactly the change that produces the 406 in production, so it needs
+    asserting against the real consume loop.
+    """
+
+    def declares_from_listen(self, monkeypatch):
+        declares = []
+
+        class FakeChannel:
+            def queue_declare(self, queue, durable=False, arguments=None):
+                declares.append(
+                    {"queue": queue, "durable": durable, "arguments": arguments}
+                )
+                # BaseException, so the loop's `except Exception` handlers
+                # cannot swallow it and spin forever.
+                raise KeyboardInterrupt
+
+        class FakeConn:
+            is_open = False
+
+            def channel(self):
+                return FakeChannel()
+
+        monkeypatch.setattr(
+            checker, "_rabbitmq_connect_with_retry", lambda **kw: FakeConn()
+        )
+        try:
+            checker.listen_for_verifications()
+        except KeyboardInterrupt:
+            pass
+        return declares
+
+    def test_consume_declares_with_priority_arguments(self, monkeypatch):
+        declares = self.declares_from_listen(monkeypatch)
+        assert declares, "the consume loop never declared the queue"
+        assert declares[0]["arguments"] == checker.request_queue_arguments()
+
+    def test_consume_declares_durable(self, monkeypatch):
+        # Losing durability would drop every queued verification on a broker
+        # restart, which is a far worse regression than the priority itself.
+        declares = self.declares_from_listen(monkeypatch)
+        assert declares[0]["durable"] is True
+
+
+# ---------------------------------------------------------------
+# The 406
+# ---------------------------------------------------------------
+def channel_closed_406():
+    return pika.exceptions.ChannelClosedByBroker(
+        406, "PRECONDITION_FAILED - inequivalent arg 'x-max-priority'"
+    )
+
+
+class TestQueueArgumentMismatch:
+    def test_recognised_in_both_services(self):
+        error = channel_closed_406()
+        assert bot.is_queue_argument_mismatch(error) is True
+        assert checker.is_queue_argument_mismatch(error) is True
+
+    def test_other_channel_errors_are_not_mistaken_for_it(self):
+        other = pika.exceptions.ChannelClosedByBroker(404, "NOT_FOUND")
+        assert bot.is_queue_argument_mismatch(other) is False
+        assert checker.is_queue_argument_mismatch(other) is False
+
+    def test_unrelated_exceptions(self):
+        assert bot.is_queue_argument_mismatch(RuntimeError("boom")) is False
+
+    def test_publish_gives_up_immediately_rather_than_retrying(self, monkeypatch):
+        """Retrying a 406 is pointless and buries the cause.
+
+        The queue's arguments will not change between attempts, so each retry
+        fails identically and the operator sees only a generic "publish failed".
+        """
+        attempts = []
+
+        def connect(**kwargs):
+            attempts.append(1)
+            raise channel_closed_406()
+
+        monkeypatch.setattr(bot, "_rabbitmq_connect_with_retry", connect)
+        monkeypatch.setenv("RABBITMQ_PUBLISH_TRIES", "3")
+
+        run(bot.publish_to_vrc_checker("1", "usr_x", GUILD_ID, None))
+        assert len(attempts) == 1
+
+    def test_the_operator_is_told_how_to_fix_it(self, monkeypatch, caplog):
+        def connect(**kwargs):
+            raise channel_closed_406()
+
+        monkeypatch.setattr(bot, "_rabbitmq_connect_with_retry", connect)
+        with caplog.at_level("ERROR"):
+            run(bot.publish_to_vrc_checker("1", "usr_x", GUILD_ID, None))
+
+        message = " ".join(r.getMessage() for r in caplog.records).lower()
+        assert "delete" in message
+        assert "x-max-priority" in message
+
+    def test_ordinary_publish_failures_still_retry(self, monkeypatch):
+        # The early return must be specific to the 406, not swallow everything.
+        attempts = []
+
+        def connect(**kwargs):
+            attempts.append(1)
+            raise pika.exceptions.AMQPConnectionError("down")
+
+        monkeypatch.setattr(bot, "_rabbitmq_connect_with_retry", connect)
+        monkeypatch.setenv("RABBITMQ_PUBLISH_TRIES", "3")
+        monkeypatch.setattr(bot.time, "sleep", lambda s: None)
+
+        run(bot.publish_to_vrc_checker("1", "usr_x", GUILD_ID, None))
+        assert len(attempts) == 3
+
+
+# ---------------------------------------------------------------
+# Call-site wiring
+# ---------------------------------------------------------------
+class TestCallSiteWiring:
+    """The gates and the publisher are both correct in isolation.
+
+    What is easy to get wrong is joining them: a call site that forgets to
+    pass `priority` leaves every server on the default, and the feature simply
+    does not work while every unit test still passes. This exercises the
+    no-code re-check path end to end, which is the most testable of the three.
+    """
+
+    def interaction(self, entitlements):
+        replies = []
+
+        class Response:
+            def is_done(self):
+                return False
+
+            async def defer(self, ephemeral=False):
+                pass
+
+            async def send_message(self, *a, **kw):
+                replies.append(a)
+
+            async def send_modal(self, modal):
+                replies.append(("modal",))
+
+        class Followup:
+            async def send(self, *a, **kw):
+                replies.append(a)
+
+        return SimpleNamespace(
+            guild_id=int(GUILD_ID),
+            user=SimpleNamespace(id=42),
+            locale="en-US",
+            entitlements=list(entitlements),
+            response=Response(),
+            followup=Followup(),
+        )
+
+    def prepare(self, row_id=NEW_ID):
+        make_server(row_id=row_id)
+        with bot.session_scope() as session:
+            session.add(
+                bot.User(
+                    discord_id="42", verification_status=False, vrc_user_id="usr_x"
+                )
+            )
+
+    def published_priority(self, monkeypatch, entitlements):
+        captured = {}
+
+        async def fake_publish(*args, **kwargs):
+            captured.update(kwargs)
+
+        monkeypatch.setattr(bot, "publish_to_vrc_checker", fake_publish)
+        monkeypatch.setattr(bot, "_verification_cooldowns", {})
+        run(bot.process_verification(self.interaction(entitlements)))
+        return captured.get("priority")
+
+    def test_premium_guild_publishes_at_high_priority(self, enforced, monkeypatch):
+        self.prepare()
+        assert (
+            self.published_priority(monkeypatch, [FakeEntitlement()])
+            == bot.PREMIUM_REQUEST_PRIORITY
+        )
+
+    def test_free_guild_publishes_at_default_priority(self, enforced, monkeypatch):
+        self.prepare()
+        assert (
+            self.published_priority(monkeypatch, []) == bot.DEFAULT_REQUEST_PRIORITY
+        )


### PR DESCRIPTION
Closes #56. Part of #46. **Requires a queue migration — see below before deploying.**

Premium guilds' verification requests publish at a higher RabbitMQ priority. Every verification goes through one shared VRChat account and a checker consuming with `prefetch_count=1`, so the queue is where contention actually shows up. RabbitMQ only reorders messages already waiting, so this changes nothing while the queue is empty (the normal case) and everything when a backlog forms.

Also unblocks #57, which adds bulk background load to the same queue. Doing it now, while the tier is still switched off, means the migration costs nobody anything.

## ⚠️ Deploying this

The existing request queue was declared with no arguments and RabbitMQ will not let it be re-declared with `x-max-priority`. **It must be deleted and recreated.** The queue is the one named by `RABBITMQ_QUEUE_NAME` in your `.env` — check it rather than assuming, the deployed name is not the placeholder in `.env.example`.

1. Stop **the bot only** — no new requests are published
2. Watch that queue until **Ready 0, Unacked 0** — the checker drains the backlog normally
3. Stop the checker, and confirm **Consumers 0**
4. Delete the queue
5. Deploy both images and start

Draining first is what protects people: every message still in the queue is somebody who pressed Verify and is waiting on a DM.

Do not delete while the old containers run — the bot re-declares on every publish and the checker on every reconnect, so it would reappear within seconds, unchanged.

**Both images need rebuilding.** This is the first change to touch `vrc_online_checker.py`.

## The priority ceiling is a constant, not an env var

`QUEUE_MAX_PRIORITY = 5` is hardcoded in *both* services. That looks like a step backwards until you consider the failure mode: both declare the same queue, the arguments must match exactly, and a mismatch 406s publishing and consuming simultaneously. Changing the value is itself a migration — it requires deleting the queue again — so it must not look tunable from config.

Two tests pin that the services agree; two more pin that each actually *passes* the arguments. That second pair matters, because an agreement test alone still passes if someone drops `arguments=` from one declare, which is exactly the production 406.

## The 406 was invisible

`ChannelClosedByBroker` subclasses `AMQPError`, so today a mismatch is swallowed by the bot's generic retry loop (three pointless attempts, then "publish failed") and by the checker's catch-all, which reconnects forever. Neither explains why.

Both services now detect it explicitly and log the queue name plus the exact fix. The bot stops publishing rather than retrying something that can never succeed; the checker backs off hard so the log stays readable. This turns a mysterious dual-service outage into a log line with the remedy in it, and is the part of this PR I'd least want reverted.

## Gating

New `FEATURE_PRIORITY_QUEUE`, **not** grandfathered — new feature, nobody loses anything. While `PREMIUM_SKU_ID` is unset the premium system stays inert, so every guild publishes at the same priority and behaviour is unchanged.

All three publish call sites already resolved premium flags for the cooldown window, so the flags object is now assigned once and reused — no extra entitlement reads.

## Tests

577 passing; the 554 pre-existing are untouched. New: the cross-service arguments invariant, both declares carrying the arguments, premium vs free priority, the priority staying within the declared ceiling (RabbitMQ silently clamps above it), 406 recognition and non-retry, ordinary failures still retrying, and end-to-end call-site wiring so a site that forgets to pass `priority` fails the build.

Seven guards mutation-tested — each reverted in turn to confirm the protecting test goes red.