### PR TITLE
Stop retrying instruction panels in guilds we've left

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -3447,6 +3447,36 @@ async def refresh_instruction_panel(entry, rebuild_embed: bool) -> bool:
     return await probe_instruction_panel(entry, rebuild_embed) == "ok"
 
 
+def partition_reachable_panels(panels):
+    """Split saved panels into ones we can still edit and ones we cannot.
+
+    A panel in a guild the bot has been removed from can never be edited: the
+    edit comes back 403, and probe_instruction_panel deliberately keeps the
+    saved reference on Forbidden because a revoked permission can be restored.
+    A kick cannot, so without this those rows are retried on every single boot
+    forever, and the count only grows as more servers remove the bot.
+
+    The cost is not really the wasted calls, it is that a genuine permission
+    problem in an active server ends up as one line among a hundred identical
+    ones — the exact signal this refresh exists to produce.
+
+    Skipping is deliberately non-destructive. If the guild cache were somehow
+    cold, the worst case is that a refresh waits for the next boot.
+    """
+    reachable, departed = [], []
+    for entry in panels:
+        try:
+            guild = bot.get_guild(int(entry["server_id"]))
+        except (TypeError, ValueError):
+            # An id we cannot parse is not evidence that we left the guild.
+            # Let it through so probe_instruction_panel reports it as
+            # malformed, rather than silently skipping it forever on a guess.
+            reachable.append(entry)
+            continue
+        (reachable if guild is not None else departed).append(entry)
+    return reachable, departed
+
+
 async def refresh_all_instruction_panels(
     rebuild_embed: bool, reason: str, stale_only: bool = False
 ):
@@ -3456,9 +3486,18 @@ async def refresh_all_instruction_panels(
     fight over the same messages.
     """
     async with instruction_refresh_lock:
-        panels = load_instruction_panels(stale_only=stale_only)
+        panels, departed = partition_reachable_panels(
+            load_instruction_panels(stale_only=stale_only)
+        )
+        departed_note = (
+            f", {len(departed)} skipped (bot no longer in the guild)"
+            if departed
+            else ""
+        )
         if not panels:
-            logger.info(f"No instruction panels need refreshing ({reason}).")
+            logger.info(
+                f"No instruction panels need refreshing ({reason}){departed_note}."
+            )
             return
 
         started = time.monotonic()
@@ -3494,7 +3533,7 @@ async def refresh_all_instruction_panels(
         crashed_note = f", {crashed} crashed" if crashed else ""
         logger.info(
             f"Instruction panel refresh ({reason}): {updated}/{len(panels)} "
-            f"updated in {elapsed:.1f}s{crashed_note}"
+            f"updated in {elapsed:.1f}s{crashed_note}{departed_note}"
         )
 
 
@@ -3634,6 +3673,27 @@ async def on_guild_join(guild: discord.Guild):
             await dm_localized(owner, guild, "guild_join_welcome_dm", server=guild.name)
     except Exception:
         logger.exception(f"Failed to send welcome DM for guild {guild.id}")
+
+
+@bot.event
+async def on_guild_remove(guild: discord.Guild):
+    """Drop the state that can only ever be wrong once we're out of a guild.
+
+    The saved panel points at a message in a channel we can no longer touch,
+    and the onboarding nudge has nobody left to nudge. Neither becomes valid
+    again on its own, so keeping them means retrying them forever.
+
+    The `servers` row and its role configuration are deliberately kept. Being
+    removed is frequently temporary — a permissions cleanup, a server rebuild,
+    an accidental kick — and forcing an admin back through /vrcverify_setup on
+    re-invite costs them far more than a stale row costs us.
+    """
+    logger.info(f"Removed from guild {guild.id} ({guild.name})")
+    try:
+        forget_instruction_panel(str(guild.id))
+        forget_guild_onboarding(str(guild.id))
+    except Exception:
+        logger.exception(f"Failed to clean up state for departed guild {guild.id}")
 
 
 def _note_entitlement_change(entitlement: discord.Entitlement, event: str) -> None:

--- a/tests/test_instruction_refresh.py
+++ b/tests/test_instruction_refresh.py
@@ -91,6 +91,19 @@ def unpaced(monkeypatch):
     monkeypatch.setattr(bot, "INSTRUCTIONS_REFRESH_RATE", 1_000_000)
 
 
+@pytest.fixture(autouse=True)
+def still_in_every_guild(monkeypatch):
+    """Default to the bot still being a member of each guild.
+
+    Every test in this file predates the departed-guild filter and implicitly
+    assumed it; without a guild in the cache they would all now be skipped
+    before any edit is attempted. TestDepartedGuilds opts back out.
+    """
+    monkeypatch.setattr(
+        bot.bot, "get_guild", lambda gid: SimpleNamespace(id=gid, name="Test Guild")
+    )
+
+
 class Recorder:
     """Stands in for the Discord HTTP layer and records every edit."""
 
@@ -104,7 +117,14 @@ class Recorder:
     def install(self, monkeypatch):
         monkeypatch.setattr(bot.bot, "get_partial_messageable", self._messageable)
         # The refresh path must not touch these; blow up loudly if it does.
-        for name in ("get_channel", "fetch_channel", "get_guild"):
+        #
+        # get_guild used to be in this list and deliberately is not any more.
+        # The invariant worth protecting is "no API call and no dependency on
+        # a cached channel or message" — that is what makes one edit per panel
+        # possible. get_guild is neither: it is a dict lookup on a cache that
+        # is fully populated before on_ready fires, and the refresh now needs
+        # it to avoid retrying panels in guilds the bot has been removed from.
+        for name in ("get_channel", "fetch_channel"):
             monkeypatch.setattr(bot.bot, name, self._forbidden_call(name))
         return self
 
@@ -692,3 +712,124 @@ class TestRequestPacing:
         # Unpaced, 20 instant edits finish in ~1ms. At 100/s they need ~190ms;
         # the floor here is loose enough to absorb early-firing timers.
         assert elapsed >= 0.1
+
+
+# ---------------------------------------------------------------
+# Guilds the bot has been removed from (issue #62)
+# ---------------------------------------------------------------
+class TestDepartedGuilds:
+    """Panels in guilds we've left can never be edited.
+
+    probe_instruction_panel deliberately keeps the saved reference on 403,
+    because a revoked permission can be restored. A kick cannot, so without a
+    filter those rows are retried on every boot forever and the count only
+    grows. In production this was 114 of them, and the noise buried the real
+    permission failures the refresh exists to surface.
+    """
+
+    def only_in(self, monkeypatch, *guild_ids):
+        present = {str(g) for g in guild_ids}
+
+        def get_guild(gid):
+            if str(gid) in present:
+                return SimpleNamespace(id=gid, name="Test Guild")
+            return None
+
+        monkeypatch.setattr(bot.bot, "get_guild", get_guild)
+
+    def test_departed_guilds_are_never_edited(self, monkeypatch, clean_servers):
+        make_server("111", channel_id="1", message_id="10")
+        make_server("222", channel_id="2", message_id="20")
+        rec = Recorder().install(monkeypatch)
+        self.only_in(monkeypatch, "111")
+
+        run(bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test"))
+
+        # Not merely "failed gracefully" — no API call was made at all.
+        assert [e[1] for e in rec.edits] == [10]
+
+    def test_the_skipped_count_is_reported(self, monkeypatch, clean_servers, caplog):
+        make_server("111", channel_id="1", message_id="10")
+        make_server("222", channel_id="2", message_id="20")
+        Recorder().install(monkeypatch)
+        self.only_in(monkeypatch, "111")
+
+        with caplog.at_level("INFO"):
+            run(bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test"))
+
+        assert "1/1" in caplog.text
+        assert "1 skipped" in caplog.text
+
+    def test_all_departed_still_logs_the_count(
+        self, monkeypatch, clean_servers, caplog
+    ):
+        # The 0/114 case: nothing to refresh, but the number must stay visible
+        # rather than vanishing into "nothing needs refreshing".
+        make_server("111", channel_id="1", message_id="10")
+        Recorder().install(monkeypatch)
+        self.only_in(monkeypatch)
+
+        with caplog.at_level("INFO"):
+            run(bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test"))
+
+        assert "1 skipped" in caplog.text
+
+    def test_saved_reference_is_left_alone(self, monkeypatch, clean_servers):
+        # Skipping is not deleting: a re-invite should find its panel intact,
+        # and a cold cache must not cost anyone their configuration.
+        make_server("111", channel_id="1", message_id="10")
+        Recorder().install(monkeypatch)
+        self.only_in(monkeypatch)
+
+        run(bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test"))
+
+        assert saved_panel("111") == ("1", "10")
+
+    def test_unparseable_ids_are_not_assumed_departed(self, monkeypatch, clean_servers):
+        # "I couldn't tell" is not "we left". Let it through so the existing
+        # malformed-id handling reports it instead of skipping it silently.
+        make_server("not-a-guild-id", channel_id="1", message_id="10")
+        rec = Recorder().install(monkeypatch)
+        self.only_in(monkeypatch)
+
+        run(bot.refresh_all_instruction_panels(rebuild_embed=False, reason="test"))
+
+        assert [e[1] for e in rec.edits] == [10]
+
+
+class TestGuildRemoveCleanup:
+    def test_panel_and_onboarding_are_cleared(self, clean_servers):
+        make_server("111", channel_id="1", message_id="10")
+        bot.record_panel_view_version("111")
+        bot.record_guild_onboarding("111")
+
+        run(bot.on_guild_remove(SimpleNamespace(id=111, name="Gone")))
+
+        assert saved_panel("111") == (None, None)
+        with bot.session_scope() as session:
+            assert (
+                session.query(bot.GuildOnboarding).filter_by(server_id="111").first()
+                is None
+            )
+
+    def test_the_server_row_and_role_config_survive(self, clean_servers):
+        """Being removed is often temporary.
+
+        Forcing an admin back through /vrcverify_setup on re-invite costs them
+        far more than a stale row costs us.
+        """
+        make_server("111", channel_id="1", message_id="10", role_id="999")
+
+        run(bot.on_guild_remove(SimpleNamespace(id=111, name="Gone")))
+
+        with bot.session_scope() as session:
+            srv = session.query(bot.Server).filter_by(server_id="111").first()
+            assert srv is not None
+            assert srv.role_id == "999"
+
+    def test_failure_is_swallowed(self, monkeypatch, clean_servers):
+        def boom(_):
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(bot, "forget_instruction_panel", boom)
+        run(bot.on_guild_remove(SimpleNamespace(id=111, name="Gone")))  # must not raise


### PR DESCRIPTION
Closes #62.

## The problem

`load_instruction_panels` queues every saved panel for the startup refresh with no check that the bot is still in the guild. `probe_instruction_panel` deliberately keeps the saved reference on a 403 — a revoked permission can be restored — but a kick cannot be, so a departed guild's panel is retried forever, and the count only grows as more servers remove the bot.

In production this reached **114**, all logged as `⚠️ No permission to edit instruction panel ... skipping`, indistinguishable from a real permission problem in an active server. The cost isn't the wasted calls, it's that the one signal this refresh exists to produce — "here's a panel you can no longer maintain" — is buried under noise that can never be actionable.

## Fix

- `partition_reachable_panels` splits saved panels by `bot.get_guild(...)` before any edit is attempted. Departed guilds cost zero API calls, not "fails gracefully" — never attempted.
- An id that fails to parse is **not** treated as departed. "I couldn't tell" and "we left" are different claims; unparseable ids fall through to the existing malformed-id handling instead of being silently skipped on a guess.
- The skipped count is reported in the summary, including when every panel is skipped, so the number stays visible instead of disappearing into "nothing needs refreshing."
- `on_guild_remove` (new — there was no handler at all) clears the panel and onboarding state. It deliberately **keeps** the `servers` row and role config: removal is often temporary, and forcing an admin back through `/vrcverify_setup` on re-invite costs them more than a stale row costs us.

## Test guard adjusted

`test_instruction_refresh.py` asserted the refresh must never call `get_channel`, `fetch_channel`, or `get_guild`. The first two are REST calls; `get_guild` is a dict lookup on a cache that's fully populated before `on_ready` fires. Removed only `get_guild` from that list, with a comment on why — the invariant worth protecting (one edit per panel, no fetches) is unchanged.

## Tests

562 passing; the 554 pre-existing are untouched (an autouse fixture now defaults every test in the file to "bot is still in the guild", matching what they all implicitly assumed before this change existed). New coverage: departed guilds never edited, the skipped count reported in both the normal and all-skipped cases, unparseable ids not mistaken for departure, the saved reference surviving a skip, and `on_guild_remove` clearing panel/onboarding state while leaving the server row and role config intact.

Seven guards mutation-tested — each reverted in turn to confirm the protecting test goes red.