### PR TITLE
Capture the grandfather line at launch so no server loses features silently

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,8 +58,15 @@ GMAIL_APP_PASSWORD=your-gmail-app-password
 # PREMIUM_VERIFICATION_COOLDOWN_SECONDS=3
 # The grandfather line: servers whose `servers.id` is <= this keep
 # unverified-role removal, nickname sync and the custom DM for free, forever.
-# Default 820 — where the autoincrementing key stood at the start of July 2026.
 # (Auto-verify-on-join is free for every server and isn't affected by this.)
+#
+# Set this to `SELECT max(id) FROM servers;` immediately before launching the
+# tier. The 820 default is only a floor for a fresh deployment.
+#
+# This same value picks the audience for the cutover DM below, which is what
+# makes that message's "nothing about your server changes" true for everyone
+# who gets it. Launch order matters — line, then campaign, then SKU. See
+# "Launch order" in the README.
 # PREMIUM_GRANDFATHER_MAX_ID=820
 # One-time cutover announcement to every server that predates the tier.
 # Nothing is sent until this file appears; `touch` it when you're ready, and

--- a/.env.example
+++ b/.env.example
@@ -56,18 +56,20 @@ GMAIL_APP_PASSWORD=your-gmail-app-password
 # PREMIUM_STATUS_TTL=900
 # Per-user cooldown for subscribed servers (default 3). 0 removes the wait.
 # PREMIUM_VERIFICATION_COOLDOWN_SECONDS=3
-# The grandfather line: servers whose `servers.id` is <= this keep
-# unverified-role removal, nickname sync and the custom DM for free, forever.
-# (Auto-verify-on-join is free for every server and isn't affected by this.)
+# The grandfather line: servers whose `servers.id` is <= it keep unverified-role
+# removal, nickname sync and the custom DM for free, forever. (Auto-verify-on-
+# join is free for every server and isn't affected by this.)
 #
-# Set this to `SELECT max(id) FROM servers;` immediately before launching the
-# tier. The 820 default is only a floor for a fresh deployment.
+# LEAVE THIS UNSET. The line is not configured — it is captured automatically
+# into the premium_grandfather_line table on the first startup that finds
+# PREMIUM_SKU_ID set, and holds MAX(servers.id) as of that moment. So every
+# server installed before you switch the tier on is grandfathered, and only
+# servers added afterwards are ever asked to pay for those three features.
+# Nobody can lose automation they already had.
 #
-# This same value picks the audience for the cutover DM below, which is what
-# makes that message's "nothing about your server changes" true for everyone
-# who gets it. Launch order matters — line, then campaign, then SKU. See
-# "Launch order" in the README.
-# PREMIUM_GRANDFATHER_MAX_ID=820
+# Setting this overrides that capture, which is almost never what you want.
+# It exists as an escape hatch if a capture goes wrong.
+# PREMIUM_GRANDFATHER_MAX_ID=
 # One-time cutover announcement to every server that predates the tier.
 # Nothing is sent until this file appears; `touch` it when you're ready, and
 # the campaign trickles out and then stops on its own.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ See the sections below for details and configuration.
   - **Server:** Holds configuration for each Discord server (guild), including role assignments. (Its `subscription_status` / `email` / `last_renewal_date` columns are dormant leftovers from a removed Stripe integration and are not used by anything — premium keys off Discord entitlements instead.)
   - **User:** Stores individual user verification statuses and VRChat IDs.
   - **PendingVerification:** Temporarily holds verification requests until they are processed.
-  - **PremiumCutoverNotice:** Which guilds have already had the one-time premium announcement DM. (Whether a server is *grandfathered* is not stored — it's `servers.id <= PREMIUM_GRANDFATHER_MAX_ID`.)
+  - **PremiumCutoverNotice:** Which guilds have already had the one-time premium announcement DM.
+  - **PremiumGrandfatherLine:** Single row holding `MAX(servers.id)` as of the moment the premium tier was switched on. Servers at or below it keep the grandfathered features free, permanently. Captured once, never moved.
   - **VerificationLogChannel:** Where a guild posts its verification activity log.
 
 - **Messaging with RabbitMQ:**  
@@ -115,17 +116,26 @@ also the only gated feature a *member* could perceive, and members move between
 servers. `tests/test_premium.py::TestAutoVerifyOnJoinIsFree` pins this so it
 can't drift back behind the paywall.
 
-\* Servers configured before the tier launched — defined as
-`servers.id <= PREMIUM_GRANDFATHER_MAX_ID`. Using the existing primary key
-means there is nothing to backfill and no way for the line to drift; a restored
-database draws it in exactly the same place.
+\* Servers installed before the tier went live. The line is **captured, not
+configured**: on the first startup that finds `PREMIUM_SKU_ID` set, the bot
+records `MAX(servers.id)` into `premium_grandfather_line` and never moves it.
 
-Set that variable to `MAX(servers.id)` immediately before launching, so every
-server already installed keeps what it has and only genuinely new servers ever
-pay for those three features. The 820 default is just a floor for a fresh
-deployment. Grandfathering costs less revenue than it looks like: the activity
-log, queue priority and everything built after them are premium for *every*
-server regardless, so the line only governs three features.
+That ordering is what makes switching the tier on safe — every server that
+already exists is grandfathered by construction, so no server can lose
+automation it was already using. Only servers added *after* launch are ever
+asked to pay for those three features. It also means the cutover DM is purely
+informational and can go out whenever, since it isn't warning anyone about a
+loss.
+
+The line lives in the database rather than an env var so a restore carries it
+alongside the servers it describes. Recomputing it after a restore would
+re-draw it wherever the restore landed, retroactively grandfathering everyone
+who signed up since. `PREMIUM_GRANDFATHER_MAX_ID` overrides the captured value
+and exists only as an escape hatch.
+
+Grandfathering costs less revenue than it looks like: the activity log, queue
+priority and everything built after them are premium for *every* server
+regardless, so the line only governs three features.
 
 **The tier is off until `PREMIUM_SKU_ID` is set.** With it unset every gate
 answers "allowed", so this code runs identically to the free bot — the SKU can
@@ -141,26 +151,24 @@ The one-time cutover announcement to existing servers is manually triggered:
 `touch` the file at `PREMIUM_CUTOVER_TRIGGER_PATH` and it trickles out under a
 per-sweep cap, then stops on its own.
 
-#### Launch order
+#### Launching
 
-`PREMIUM_GRANDFATHER_MAX_ID` decides both who keeps their features *and* who
-gets the announcement — it is the same predicate in both places, which is what
-makes the DM's "nothing about your server changes" true for everyone who
-receives it. So the steps have to happen in this order:
+1. Set `PREMIUM_SKU_ID` and restart. On that startup the grandfather line is
+   captured at `MAX(servers.id)`, which the bot logs. Every server that exists
+   at this moment keeps the three grandfathered features permanently.
+2. `touch` the trigger whenever you like afterwards. The campaign DMs those
+   servers to say the tier launched and nothing changed for them, trickling at
+   roughly 240 servers/hour (20 per sweep, 300s apart), then stops on its own.
 
-1. `SELECT max(id) FROM servers;` and set `PREMIUM_GRANDFATHER_MAX_ID` to it.
-   Restart. Nothing changes yet — the tier is still off.
-2. `touch` the trigger and let the campaign run to completion. At the default
-   pacing (20 per sweep, 300s apart) that is roughly 240 servers/hour.
-3. Re-run step 1 and re-trigger. Servers that installed *during* step 2 are
-   past the old line; this pulls them in. The notice table means the second
-   run only DMs the newcomers, so nobody gets a duplicate.
-4. Only now set `PREMIUM_SKU_ID`.
+There is deliberately no ordering hazard here. An earlier design had the line
+hand-set in the environment, which meant forgetting to update it before
+flipping the switch silently stripped automation from servers that had it
+([#59](https://github.com/PhillipDiCarlo/VRCVerify/issues/59)). Capturing the
+line at switch-on removes that failure entirely rather than detecting it.
 
-Doing step 4 early is the one genuinely bad outcome: servers lose working
-automation and find out by noticing it stopped. On startup the bot counts
-grandfathered servers with no notice row and warns if the tier is live while
-any remain, so getting the order wrong is at least visible in the logs.
+The bot logs a one-time reminder if the tier is live and the announcement is
+still outstanding. That is a courtesy nudge, not a safety check — those servers
+keep their features either way.
 
 ### Queue priority
 

--- a/README.md
+++ b/README.md
@@ -116,10 +116,16 @@ servers. `tests/test_premium.py::TestAutoVerifyOnJoinIsFree` pins this so it
 can't drift back behind the paywall.
 
 \* Servers configured before the tier launched — defined as
-`servers.id <= PREMIUM_GRANDFATHER_MAX_ID` (default 820, where the
-autoincrementing key stood at the start of July 2026). Using the existing
-primary key means there is nothing to backfill and no way for the line to
-drift; a restored database draws it in exactly the same place.
+`servers.id <= PREMIUM_GRANDFATHER_MAX_ID`. Using the existing primary key
+means there is nothing to backfill and no way for the line to drift; a restored
+database draws it in exactly the same place.
+
+Set that variable to `MAX(servers.id)` immediately before launching, so every
+server already installed keeps what it has and only genuinely new servers ever
+pay for those three features. The 820 default is just a floor for a fresh
+deployment. Grandfathering costs less revenue than it looks like: the activity
+log, queue priority and everything built after them are premium for *every*
+server regardless, so the line only governs three features.
 
 **The tier is off until `PREMIUM_SKU_ID` is set.** With it unset every gate
 answers "allowed", so this code runs identically to the free bot — the SKU can
@@ -134,6 +140,27 @@ outage can't silently disable a paying server's automation.
 The one-time cutover announcement to existing servers is manually triggered:
 `touch` the file at `PREMIUM_CUTOVER_TRIGGER_PATH` and it trickles out under a
 per-sweep cap, then stops on its own.
+
+#### Launch order
+
+`PREMIUM_GRANDFATHER_MAX_ID` decides both who keeps their features *and* who
+gets the announcement — it is the same predicate in both places, which is what
+makes the DM's "nothing about your server changes" true for everyone who
+receives it. So the steps have to happen in this order:
+
+1. `SELECT max(id) FROM servers;` and set `PREMIUM_GRANDFATHER_MAX_ID` to it.
+   Restart. Nothing changes yet — the tier is still off.
+2. `touch` the trigger and let the campaign run to completion. At the default
+   pacing (20 per sweep, 300s apart) that is roughly 240 servers/hour.
+3. Re-run step 1 and re-trigger. Servers that installed *during* step 2 are
+   past the old line; this pulls them in. The notice table means the second
+   run only DMs the newcomers, so nobody gets a duplicate.
+4. Only now set `PREMIUM_SKU_ID`.
+
+Doing step 4 early is the one genuinely bad outcome: servers lose working
+automation and find out by noticing it stopped. On startup the bot counts
+grandfathered servers with no notice row and warns if the tier is live while
+any remain, so getting the order wrong is at least visible in the logs.
 
 ### Queue priority
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -575,13 +575,25 @@ GRANDFATHERED_FEATURES = frozenset(
 )
 
 # The grandfather line, drawn on the servers table's autoincrementing primary
-# key. 820 is where it stood at the start of July 2026.
+# key: servers at or below it keep GRANDFATHERED_FEATURES for free, forever.
 #
 # The id is the cheapest honest answer to "was this server here first": it is
 # already recorded, strictly increasing, and needs no backfill, no marker table
 # and no date column that `servers` does not have. It also means the answer is
 # identical on a restored database — a snapshot-at-first-boot approach would
 # quietly re-draw the line wherever the restore happened to land.
+#
+# Set this to `MAX(servers.id)` immediately before launching the tier, so that
+# every server already installed is grandfathered and only genuinely new ones
+# ever pay for the three features they'd otherwise be losing. The default of
+# 820 (start of July 2026) is only a floor for a fresh deployment — a running
+# install is expected to override it in the environment.
+#
+# This value and the cutover DM audience are THE SAME PREDICATE (see
+# load_premium_cutover_candidates). That is deliberate: it is what makes
+# "nothing about your server changes" true for every server that gets the DM.
+# Moving one without the other is how servers end up silently losing features,
+# which is the failure count_pending_cutover_notices exists to catch.
 PREMIUM_GRANDFATHER_MAX_ID = _int_env("PREMIUM_GRANDFATHER_MAX_ID", 820, minimum=0)
 
 # The one-time DM telling existing servers the tier is launching. Manually
@@ -3119,6 +3131,64 @@ def load_premium_cutover_candidates(limit: int):
         return candidates
 
 
+def count_pending_cutover_notices() -> int:
+    """How many grandfathered servers still owe a cutover DM.
+
+    Deliberately the same audience as load_premium_cutover_candidates, minus
+    the limit — this answers "has the campaign finished?", so it has to count
+    the exact set that campaign would send to.
+
+    Returns 0 on error. This only drives a warning; a database hiccup at
+    startup must not invent an alarming number, and a real backlog will still
+    be reported on the next boot.
+    """
+    try:
+        with session_scope() as session:
+            notified = {
+                panel_view_key(row.server_id)
+                for row in session.query(PremiumCutoverNotice.server_id).all()
+            }
+            rows = (
+                session.query(Server.server_id)
+                .filter(Server.id <= PREMIUM_GRANDFATHER_MAX_ID)
+                .all()
+            )
+            return sum(
+                1 for row in rows if panel_view_key(row.server_id) not in notified
+            )
+    except Exception:
+        logger.warning("Could not count pending cutover notices", exc_info=True)
+        return 0
+
+
+def warn_if_cutover_incomplete() -> int:
+    """Say so, loudly, if the tier is live before everyone has been told.
+
+    The ordering that matters at launch is: set the grandfather line, run the
+    cutover campaign to completion, *then* set PREMIUM_SKU_ID. Getting it
+    backwards means servers find out they lost automation by noticing it
+    stopped working, which is issue #59 — the whole reason this exists.
+
+    Only meaningful while the campaign is outstanding, so it self-clears: once
+    every grandfathered server has its notice row, this is silent forever.
+    Servers created after launch are not counted, because they are past the
+    line and never had the features to lose.
+    """
+    if not PREMIUM_ENFORCED:
+        return 0
+    pending = count_pending_cutover_notices()
+    if pending:
+        logger.warning(
+            "PREMIUM_SKU_ID is set but %d grandfathered server(s) have not had "
+            "the cutover DM. They keep their features (they are inside the "
+            "grandfather line) but were never told the tier launched. Trigger "
+            "the campaign: touch %s",
+            pending,
+            PREMIUM_CUTOVER_TRIGGER_PATH,
+        )
+    return pending
+
+
 def complete_premium_cutover(server_id) -> None:
     """Record that this guild has had its announcement, once and for all."""
     key = panel_view_key(server_id)
@@ -3709,6 +3779,9 @@ async def on_ready():
     start_background_task(
         "premium_cutover_watcher", watch_premium_cutover_trigger()
     )
+
+    # Silent unless the tier was switched on before the announcement finished.
+    warn_if_cutover_incomplete()
 
     # Panels already carrying the current custom_ids are handled by the
     # persistent view registered in setup_hook, so this only has to re-edit the

--- a/src/bot.py
+++ b/src/bot.py
@@ -27,6 +27,7 @@ from sqlalchemy import (
     DateTime,
     text,
     inspect,
+    func,
 )
 from sqlalchemy.orm import sessionmaker, declarative_base
 from sqlalchemy.exc import IntegrityError
@@ -307,14 +308,44 @@ class PremiumCutoverNotice(Base):
     there is no boolean to get out of sync, and mark-before-send is a plain
     insert.
 
-    Note this is only the DM ledger. Whether a server is *grandfathered* is not
-    stored anywhere: it is `servers.id <= PREMIUM_GRANDFATHER_MAX_ID`, which
-    needs no backfill, no marker, and survives a database restore unchanged.
+    Note this is only the DM ledger. Whether a server is *grandfathered* is
+    PremiumGrandfatherLine's job.
     """
 
     __tablename__ = "premium_cutover_notice"
     server_id = Column(String, primary_key=True)
     sent_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+
+
+class PremiumGrandfatherLine(Base):
+    """Where the grandfather line was drawn, captured once and never moved.
+
+    Written on the first startup that finds the tier switched on, holding
+    MAX(servers.id) as of that moment. Every server already installed is
+    therefore grandfathered, and only servers added afterwards can ever be
+    asked to pay for GRANDFATHERED_FEATURES.
+
+    That ordering is the entire point: it makes "a server loses automation it
+    already had" impossible by construction rather than something we detect
+    afterwards and apologise for (issue #59). It also means the cutover DM can
+    go out after the switch without harm, since it is now purely informational.
+
+    Captured rather than configured because a hand-set line is a number someone
+    has to remember to update at exactly the right moment, and the cost of
+    forgetting is silently charging existing servers for what they already had.
+
+    Stored in the database, not a file or an env var, so a restore carries the
+    line with the servers it describes — recomputing it after a restore would
+    re-draw it wherever the restore happened to land, retroactively
+    grandfathering everyone who signed up since.
+    """
+
+    __tablename__ = "premium_grandfather_line"
+    # Single row, always id=1. A table rather than a column so create_all()
+    # brings it into being on its own, like the three above.
+    id = Column(Integer, primary_key=True)
+    max_server_id = Column(Integer, nullable=False)
+    captured_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
 
 class VerificationLogChannel(Base):
@@ -574,27 +605,19 @@ GRANDFATHERED_FEATURES = frozenset(
     {FEATURE_UNVERIFIED_ROLE_REMOVAL, FEATURE_NICKNAME_SYNC, FEATURE_CUSTOM_DM}
 )
 
-# The grandfather line, drawn on the servers table's autoincrementing primary
+# The grandfather line is drawn on the servers table's autoincrementing primary
 # key: servers at or below it keep GRANDFATHERED_FEATURES for free, forever.
 #
 # The id is the cheapest honest answer to "was this server here first": it is
-# already recorded, strictly increasing, and needs no backfill, no marker table
-# and no date column that `servers` does not have. It also means the answer is
-# identical on a restored database — a snapshot-at-first-boot approach would
-# quietly re-draw the line wherever the restore happened to land.
+# already recorded, strictly increasing, and needs no backfill and no date
+# column that `servers` does not have.
 #
-# Set this to `MAX(servers.id)` immediately before launching the tier, so that
-# every server already installed is grandfathered and only genuinely new ones
-# ever pay for the three features they'd otherwise be losing. The default of
-# 820 (start of July 2026) is only a floor for a fresh deployment — a running
-# install is expected to override it in the environment.
-#
-# This value and the cutover DM audience are THE SAME PREDICATE (see
-# load_premium_cutover_candidates). That is deliberate: it is what makes
-# "nothing about your server changes" true for every server that gets the DM.
-# Moving one without the other is how servers end up silently losing features,
-# which is the failure count_pending_cutover_notices exists to catch.
-PREMIUM_GRANDFATHER_MAX_ID = _int_env("PREMIUM_GRANDFATHER_MAX_ID", 820, minimum=0)
+# The value itself is NOT configured here — it is captured into
+# premium_grandfather_line on the first startup that finds the tier switched
+# on. See that model for why. This override exists only as an escape hatch for
+# a capture that went wrong (and for tests); leave it unset in normal operation
+# so the line stays whatever was true at launch.
+PREMIUM_GRANDFATHER_MAX_ID_OVERRIDE = _optional_int_env("PREMIUM_GRANDFATHER_MAX_ID")
 
 # The one-time DM telling existing servers the tier is launching. Manually
 # triggered rather than automatic: this is a one-shot announcement to every
@@ -780,15 +803,83 @@ async def guild_has_premium(guild_id) -> bool:
         return answer
 
 
-def is_grandfathered(guild_id) -> bool:
-    """Was this guild configured before the premium cutover?
+def capture_grandfather_line() -> int | None:
+    """Freeze the grandfather line at today's MAX(servers.id), once, forever.
 
-    Read straight off the `servers` primary key, so nothing has to be written
-    at cutover time and the answer can never drift.
+    Called at startup and does nothing at all unless the tier is switched on
+    and no line has been captured yet, so it is a no-op on every boot but one.
+
+    Runs before the tier can gate anything because it happens in on_ready and
+    gating happens on interactions. If it fails, no row is written and
+    grandfather_line() keeps returning None, which fails open — an outage
+    during the one boot that matters must not decide that nobody is
+    grandfathered.
+    """
+    if not PREMIUM_ENFORCED:
+        return None
+    try:
+        with session_scope() as session:
+            existing = session.query(PremiumGrandfatherLine).filter_by(id=1).first()
+            if existing is not None:
+                return existing.max_server_id
+            # No servers yet (a brand-new deployment) draws the line at 0:
+            # nobody is grandfathered, which is correct — nobody has anything
+            # to lose.
+            highest = session.query(func.max(Server.id)).scalar() or 0
+            session.add(PremiumGrandfatherLine(id=1, max_server_id=highest))
+        logger.warning(
+            "Premium tier is live. Grandfather line captured at servers.id <= %d: "
+            "every server installed before now keeps %s free, permanently. "
+            "This is recorded once and will not move.",
+            highest,
+            ", ".join(sorted(GRANDFATHERED_FEATURES)),
+        )
+        return highest
+    except IntegrityError:
+        # Another writer got there first; theirs is as good as ours.
+        return grandfather_line()
+    except Exception:
+        logger.exception(
+            "Could not capture the grandfather line; every server will be "
+            "treated as grandfathered until this succeeds."
+        )
+        return None
+
+
+def grandfather_line() -> int | None:
+    """The captured line, or None if it has not been drawn yet.
+
+    None means "we cannot say", and every caller treats that as grandfathered.
+    Being wrong in that direction costs a subscription; being wrong the other
+    way takes working automation away from someone who had it.
+    """
+    if PREMIUM_GRANDFATHER_MAX_ID_OVERRIDE is not None:
+        return PREMIUM_GRANDFATHER_MAX_ID_OVERRIDE
+    try:
+        with session_scope() as session:
+            row = session.query(PremiumGrandfatherLine.max_server_id).filter_by(id=1).first()
+            return None if row is None else row.max_server_id
+    except Exception:
+        logger.warning("Could not read the grandfather line", exc_info=True)
+        return None
+
+
+def is_grandfathered(guild_id) -> bool:
+    """Was this guild installed before the tier went live?
+
+    Compares the server's primary key against the line captured at launch, so
+    the answer is fixed the moment the tier is switched on and cannot drift
+    afterwards.
     """
     if guild_id is None:
         return False
     try:
+        line = grandfather_line()
+        if line is None:
+            # Not captured (or unreadable). Same fail-open reasoning as the
+            # entitlement lookup: don't be the reason a server loses
+            # automation it already had.
+            return True
         with session_scope() as session:
             row = (
                 session.query(Server.id)
@@ -799,7 +890,7 @@ def is_grandfathered(guild_id) -> bool:
             # is no automation to preserve.
             if row is None or row.id is None:
                 return False
-            return row.id <= PREMIUM_GRANDFATHER_MAX_ID
+            return row.id <= line
     except Exception:
         # Same reasoning as the entitlement fail-open: if we can't tell, don't
         # be the reason an existing server loses automation it already had.
@@ -3107,7 +3198,15 @@ def load_premium_cutover_candidates(limit: int):
     nudge there is no way for an unreachable row to sit at the front of every
     sweep eating a slot — send_premium_cutover_dm marks before it sends, which
     removes a row from this query whether the DM lands or not.
+
+    Bounded by the captured grandfather line so the message only reaches the
+    servers it is true for: it says nothing changes for you, which is only
+    accurate for servers that predate the launch. An uncaptured line means the
+    tier has never been switched on, so there is nothing to announce yet.
     """
+    line = grandfather_line()
+    if line is None:
+        return []
     with session_scope() as session:
         notified = {
             panel_view_key(row.server_id)
@@ -3115,7 +3214,7 @@ def load_premium_cutover_candidates(limit: int):
         }
         rows = (
             session.query(Server)
-            .filter(Server.id <= PREMIUM_GRANDFATHER_MAX_ID)
+            .filter(Server.id <= line)
             .order_by(Server.id)
             .all()
         )
@@ -3134,25 +3233,31 @@ def load_premium_cutover_candidates(limit: int):
 def count_pending_cutover_notices() -> int:
     """How many grandfathered servers still owe a cutover DM.
 
-    Deliberately the same audience as load_premium_cutover_candidates, minus
-    the limit — this answers "has the campaign finished?", so it has to count
-    the exact set that campaign would send to.
+    The same audience as load_premium_cutover_candidates, minus the limit —
+    this answers "has the campaign finished?", so it has to count the exact
+    set that campaign would send to.
+
+    The "already notified" half is matched in Python, not with a SQL IN, and
+    must stay that way: `servers.server_id` is an integer column on the
+    deployed database while `premium_cutover_notice.server_id` really is text,
+    so the comparison becomes `bigint = character varying` — which Postgres
+    rejects outright. See panel_view_key. SQLite types both as text, so a SQL
+    IN passes every test here and fails only in production.
 
     Returns 0 on error. This only drives a warning; a database hiccup at
     startup must not invent an alarming number, and a real backlog will still
     be reported on the next boot.
     """
+    line = grandfather_line()
+    if line is None:
+        return 0
     try:
         with session_scope() as session:
             notified = {
                 panel_view_key(row.server_id)
                 for row in session.query(PremiumCutoverNotice.server_id).all()
             }
-            rows = (
-                session.query(Server.server_id)
-                .filter(Server.id <= PREMIUM_GRANDFATHER_MAX_ID)
-                .all()
-            )
+            rows = session.query(Server.server_id).filter(Server.id <= line).all()
             return sum(
                 1 for row in rows if panel_view_key(row.server_id) not in notified
             )
@@ -3161,28 +3266,41 @@ def count_pending_cutover_notices() -> int:
         return 0
 
 
+# on_ready fires on every reconnect, so anything called from it that is not
+# idempotent has to say so itself — the same reasoning as start_background_task
+# below. This is a reminder, not a correctness guard: re-announcing an
+# outstanding campaign on every gateway blip is noise, and it would re-run two
+# queries on the event loop each time.
+_cutover_reminder_logged = False
+
+
 def warn_if_cutover_incomplete() -> int:
-    """Say so, loudly, if the tier is live before everyone has been told.
+    """Remind us, once, if the tier is live and servers still owe a DM.
 
-    The ordering that matters at launch is: set the grandfather line, run the
-    cutover campaign to completion, *then* set PREMIUM_SKU_ID. Getting it
-    backwards means servers find out they lost automation by noticing it
-    stopped working, which is issue #59 — the whole reason this exists.
+    Purely a courtesy check now. Under the captured-line model nobody can lose
+    a feature they already had, so an un-run campaign means existing servers
+    were never told the tier exists — untidy, not harmful. It no longer guards
+    a correctness property, and deliberately does not pretend to: what makes
+    issue #59 impossible is PremiumGrandfatherLine, not this.
 
-    Only meaningful while the campaign is outstanding, so it self-clears: once
-    every grandfathered server has its notice row, this is silent forever.
-    Servers created after launch are not counted, because they are past the
-    line and never had the features to lose.
+    Self-clearing: once every grandfathered server has its notice row this is
+    silent forever. Servers added after launch are past the line and are never
+    counted, so it cannot decay into a permanent warning.
     """
-    if not PREMIUM_ENFORCED:
+    global _cutover_reminder_logged
+    if not PREMIUM_ENFORCED or _cutover_reminder_logged:
         return 0
     pending = count_pending_cutover_notices()
+    # Set regardless of the outcome: the backlog can only shrink (the line is
+    # fixed, so no new server can fall inside it), which makes a second look
+    # pointless whether it found work or not. The cost of a database blip here
+    # is one missed reminder in one process lifetime, and a restart re-checks.
+    _cutover_reminder_logged = True
     if pending:
         logger.warning(
-            "PREMIUM_SKU_ID is set but %d grandfathered server(s) have not had "
-            "the cutover DM. They keep their features (they are inside the "
-            "grandfather line) but were never told the tier launched. Trigger "
-            "the campaign: touch %s",
+            "%d server(s) predating the premium tier have not had the cutover "
+            "DM. They keep their grandfathered features either way; this is "
+            "just to say they were never told. Trigger the campaign: touch %s",
             pending,
             PREMIUM_CUTOVER_TRIGGER_PATH,
         )
@@ -3775,12 +3893,17 @@ async def on_ready():
         "verification_log_flush", verification_log_flush_task()
     )
 
+    # Draws the grandfather line on the first boot after the tier goes live,
+    # then never again. Must happen before the campaign watcher, which uses
+    # the line to pick its audience.
+    capture_grandfather_line()
+
     # Waits for its trigger file; sends nothing on its own.
     start_background_task(
         "premium_cutover_watcher", watch_premium_cutover_trigger()
     )
 
-    # Silent unless the tier was switched on before the announcement finished.
+    # A once-per-process reminder if the announcement is still outstanding.
     warn_if_cutover_incomplete()
 
     # Panels already carrying the current custom_ids are handled by the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,4 +29,12 @@ TEST_ENV = {
 
 os.environ.update(TEST_ENV)
 
+# The grandfather line is captured into the database at launch, and the env var
+# is only an escape hatch. A developer's local .env setting it would silently
+# override that capture for the whole suite -- tests would then pass or fail
+# depending on an untracked file. Set it empty rather than deleting it: an
+# absent variable is one load_dotenv() would happily fill in from .env, while
+# an empty one it leaves alone and _optional_int_env reads as "not set".
+os.environ["PREMIUM_GRANDFATHER_MAX_ID"] = ""
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/tests/test_premium.py
+++ b/tests/test_premium.py
@@ -16,6 +16,7 @@ path:
 
 import asyncio
 import logging
+from contextlib import contextmanager
 from types import SimpleNamespace
 
 import discord
@@ -103,10 +104,21 @@ def make_interaction(entitlements=(), guild_id=GUILD_ID, locale="en-US"):
     )
 
 
-# Grandfathering is `servers.id <= PREMIUM_GRANDFATHER_MAX_ID`, so tests pick
-# a row id on the side of the line they mean.
+# Grandfathering is `servers.id <= the captured line`, so tests pick a row id
+# on the side of the line they mean. The line itself is drawn by the autouse
+# fixture below.
+LINE = 820
 OLD_ID = 100  # comfortably before the cutover
 NEW_ID = 5000  # comfortably after it
+
+
+def draw_line(max_server_id=LINE):
+    """Capture the grandfather line, as the first enforced startup would."""
+    with bot.session_scope() as session:
+        session.query(bot.PremiumGrandfatherLine).delete()
+        session.add(
+            bot.PremiumGrandfatherLine(id=1, max_server_id=max_server_id)
+        )
 
 
 def make_server(server_id=GUILD_ID, row_id=OLD_ID, **overrides):
@@ -134,12 +146,19 @@ def clean_db():
             session.query(bot.Server).delete()
             session.query(bot.User).delete()
             session.query(bot.PremiumCutoverNotice).delete()
+            session.query(bot.PremiumGrandfatherLine).delete()
 
     wipe()
     bot.premium_status_cache.clear()
+    bot._cutover_reminder_logged = False
+    # Most tests care about which side of the line a server falls on, not about
+    # the capture itself, so start with the line already drawn. The tests that
+    # exercise capture clear it first.
+    draw_line()
     yield
     wipe()
     bot.premium_status_cache.clear()
+    bot._cutover_reminder_logged = False
 
 
 @pytest.fixture
@@ -396,15 +415,25 @@ class TestIsGrandfathered:
         make_server(row_id=NEW_ID)
         assert bot.is_grandfathered(GUILD_ID) is False
 
-    def test_the_boundary_id_is_included(self, monkeypatch):
-        monkeypatch.setattr(bot, "PREMIUM_GRANDFATHER_MAX_ID", 820)
-        make_server(row_id=820)
+    def test_the_boundary_id_is_included(self):
+        make_server(row_id=LINE)
         assert bot.is_grandfathered(GUILD_ID) is True
 
-    def test_one_past_the_boundary_is_not(self, monkeypatch):
-        monkeypatch.setattr(bot, "PREMIUM_GRANDFATHER_MAX_ID", 820)
-        make_server(row_id=821)
+    def test_one_past_the_boundary_is_not(self):
+        make_server(row_id=LINE + 1)
         assert bot.is_grandfathered(GUILD_ID) is False
+
+    def test_no_line_yet_means_grandfathered(self):
+        """Fail open: never take automation away because we couldn't tell."""
+        with bot.session_scope() as session:
+            session.query(bot.PremiumGrandfatherLine).delete()
+        make_server(row_id=NEW_ID)
+        assert bot.is_grandfathered(GUILD_ID) is True
+
+    def test_an_unreadable_line_also_fails_open(self, monkeypatch):
+        make_server(row_id=NEW_ID)
+        monkeypatch.setattr(bot, "grandfather_line", lambda: None)
+        assert bot.is_grandfathered(GUILD_ID) is True
 
     def test_unconfigured_guild(self):
         # No servers row means nothing was ever configured here, so there is no
@@ -724,6 +753,19 @@ class TestCutoverCampaign:
         run(bot.premium_cutover_sweep_task())
         assert cutover_harness.dms == []
 
+    def test_no_line_means_nothing_to_announce(self, cutover_harness):
+        """No captured line means the tier has never been switched on.
+
+        The DM says the tier launched and nothing changed for you; sending it
+        before either is true would be a lie to every server we have.
+        """
+        with bot.session_scope() as session:
+            session.query(bot.PremiumGrandfatherLine).delete()
+        make_server(row_id=OLD_ID)
+        assert bot.load_premium_cutover_candidates(10) == []
+        run(bot.premium_cutover_sweep_task())
+        assert cutover_harness.dms == []
+
     def test_servers_added_after_the_cutover_are_not_told(self, cutover_harness):
         # They never had the grandfathered features, so there is nothing to
         # announce to them.
@@ -810,6 +852,72 @@ class TestCutoverCampaign:
         assert cutover_harness.dms == ["Test Server"]
 
 
+class TestGrandfatherLineCapture:
+    """Issue #59: nobody may lose a feature they already had.
+
+    The line is captured at the moment the tier goes live, so every server
+    installed before then is grandfathered by construction. These pin the
+    properties that guarantee it.
+    """
+
+    @pytest.fixture(autouse=True)
+    def no_line_yet(self):
+        with bot.session_scope() as session:
+            session.query(bot.PremiumGrandfatherLine).delete()
+
+    def test_does_nothing_while_the_tier_is_off(self):
+        make_server(row_id=NEW_ID)
+        assert bot.capture_grandfather_line() is None
+        assert bot.grandfather_line() is None
+
+    def test_captures_the_highest_server_id(self, enforced):
+        make_server("a", row_id=10)
+        make_server("b", row_id=NEW_ID)
+        make_server("c", row_id=50)
+        assert bot.capture_grandfather_line() == NEW_ID
+        assert bot.grandfather_line() == NEW_ID
+
+    def test_every_existing_server_ends_up_grandfathered(self, enforced):
+        """The whole point: switching the tier on takes nothing from anyone."""
+        for index in range(1, 6):
+            make_server(f"s{index}", row_id=index * 37)
+        bot.capture_grandfather_line()
+        assert all(bot.is_grandfathered(f"s{i}") for i in range(1, 6))
+
+    def test_a_server_added_later_is_not_grandfathered(self, enforced):
+        make_server("early", row_id=10)
+        bot.capture_grandfather_line()
+        make_server("late", row_id=11)
+        assert bot.is_grandfathered("early") is True
+        assert bot.is_grandfathered("late") is False
+
+    def test_the_line_never_moves_once_drawn(self, enforced):
+        make_server("early", row_id=10)
+        assert bot.capture_grandfather_line() == 10
+        # A later boot, with more servers, must not redraw it -- otherwise
+        # every restart would retroactively grandfather everyone since.
+        make_server("late", row_id=999)
+        assert bot.capture_grandfather_line() == 10
+        assert bot.grandfather_line() == 10
+
+    def test_no_servers_at_all_draws_the_line_at_zero(self, enforced):
+        assert bot.capture_grandfather_line() == 0
+        assert bot.grandfather_line() == 0
+
+    def test_a_failed_capture_leaves_no_line(self, enforced, monkeypatch):
+        def boom():
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(bot, "session_scope", boom)
+        assert bot.capture_grandfather_line() is None
+
+    def test_the_override_wins_when_set(self, enforced, monkeypatch):
+        make_server(row_id=NEW_ID)
+        bot.capture_grandfather_line()
+        monkeypatch.setattr(bot, "PREMIUM_GRANDFATHER_MAX_ID_OVERRIDE", 5)
+        assert bot.grandfather_line() == 5
+
+
 class TestCutoverCompletionWarning:
     """Issue #59: the tier must not go live before everyone has been told.
 
@@ -855,12 +963,89 @@ class TestCutoverCompletionWarning:
         # The fix has to be in the message, not just the complaint.
         assert bot.PREMIUM_CUTOVER_TRIGGER_PATH in caplog.text
 
+    def test_it_only_speaks_once_per_process(self, enforced, caplog):
+        """on_ready fires on every reconnect; this must not follow it."""
+        make_server(row_id=OLD_ID)
+        with caplog.at_level(logging.WARNING):
+            assert bot.warn_if_cutover_incomplete() == 1
+            caplog.clear()
+            # A reconnect, with the campaign still outstanding.
+            assert bot.warn_if_cutover_incomplete() == 0
+        assert caplog.text == ""
+
+    def test_the_repeat_guard_skips_the_query_entirely(self, enforced, monkeypatch):
+        make_server(row_id=OLD_ID)
+        bot.warn_if_cutover_incomplete()
+
+        def boom():
+            raise AssertionError("queried the database on a reconnect")
+
+        monkeypatch.setattr(bot, "count_pending_cutover_notices", boom)
+        assert bot.warn_if_cutover_incomplete() == 0
+
+    def test_a_finished_campaign_also_stops_re_querying(self, enforced, monkeypatch):
+        """Nothing to report is still a reason not to look again.
+
+        The line never moves, so no server can later fall inside it — a
+        completed campaign stays completed, and re-checking it on every
+        reconnect is pure waste on the event loop.
+        """
+        make_server(row_id=OLD_ID)
+        mark_notified()
+        assert bot.warn_if_cutover_incomplete() == 0
+
+        def boom():
+            raise AssertionError("queried the database on a reconnect")
+
+        monkeypatch.setattr(bot, "count_pending_cutover_notices", boom)
+        assert bot.warn_if_cutover_incomplete() == 0
+
     def test_silent_once_the_campaign_has_finished(self, enforced, caplog):
         make_server(row_id=OLD_ID)
         mark_notified()
         with caplog.at_level(logging.WARNING):
             assert bot.warn_if_cutover_incomplete() == 0
         assert "cutover DM" not in caplog.text
+
+    def test_an_integer_server_id_still_matches_its_notice(self, monkeypatch):
+        """servers.server_id comes back as an int on the deployed database.
+
+        The notice table's column is genuinely text, so the two halves must be
+        normalised in Python before they are compared. This cannot be set up
+        through the real session: SQLite coerces an int written to a String
+        column back to str, which is exactly why the mismatch is invisible
+        locally and only bites on Postgres (`bigint = character varying`).
+        So the row types are forced directly. See panel_view_key.
+        """
+
+        class FakeQuery:
+            def __init__(self, rows):
+                self.rows = rows
+
+            def filter(self, *args, **kwargs):
+                return self
+
+            def all(self):
+                return self.rows
+
+        class FakeSession:
+            def query(self, column):
+                if column is bot.PremiumCutoverNotice.server_id:
+                    # As complete_premium_cutover wrote it: text.
+                    return FakeQuery([SimpleNamespace(server_id="123456789")])
+                # As the deployed integer column returns it.
+                return FakeQuery([SimpleNamespace(server_id=123456789)])
+
+        @contextmanager
+        def fake_scope():
+            yield FakeSession()
+
+        # Via the override, so resolving the line does not go through the fake
+        # session -- otherwise it fails, the count short-circuits to 0, and
+        # this test passes without ever comparing an id.
+        monkeypatch.setattr(bot, "PREMIUM_GRANDFATHER_MAX_ID_OVERRIDE", 10**9)
+        monkeypatch.setattr(bot, "session_scope", fake_scope)
+        assert bot.count_pending_cutover_notices() == 0
 
     def test_a_database_failure_does_not_invent_a_number(self, monkeypatch):
         def boom():

--- a/tests/test_premium.py
+++ b/tests/test_premium.py
@@ -15,6 +15,7 @@ path:
 """
 
 import asyncio
+import logging
 from types import SimpleNamespace
 
 import discord
@@ -807,3 +808,63 @@ class TestCutoverCampaign:
 
         run(bot.premium_cutover_sweep_task())
         assert cutover_harness.dms == ["Test Server"]
+
+
+class TestCutoverCompletionWarning:
+    """Issue #59: the tier must not go live before everyone has been told.
+
+    The audience for the DM and the set of servers that keep their features are
+    the same predicate. These pin that they stay the same, and that flipping
+    the switch early is at least loud.
+    """
+
+    def test_counts_only_the_untold_inside_the_line(self):
+        make_server("told", row_id=OLD_ID)
+        make_server("untold", row_id=OLD_ID + 1)
+        mark_notified("told")
+        assert bot.count_pending_cutover_notices() == 1
+
+    def test_servers_past_the_line_are_not_counted(self):
+        # They never had the grandfathered features, so there is nothing to
+        # warn about — otherwise this would grow forever after launch and
+        # become noise instead of signal.
+        make_server("new", row_id=NEW_ID)
+        assert bot.count_pending_cutover_notices() == 0
+
+    def test_it_matches_the_campaign_audience(self):
+        """The count and the campaign must never disagree about who is owed."""
+        for index in range(4):
+            make_server(str(index), row_id=index + 1)
+        make_server("past", row_id=NEW_ID)
+        mark_notified("0")
+        assert bot.count_pending_cutover_notices() == len(
+            bot.load_premium_cutover_candidates(100)
+        )
+
+    def test_silent_while_the_tier_is_off(self, caplog):
+        make_server(row_id=OLD_ID)
+        with caplog.at_level(logging.WARNING):
+            assert bot.warn_if_cutover_incomplete() == 0
+        assert "cutover DM" not in caplog.text
+
+    def test_warns_when_enforced_with_sends_outstanding(self, enforced, caplog):
+        make_server(row_id=OLD_ID)
+        with caplog.at_level(logging.WARNING):
+            assert bot.warn_if_cutover_incomplete() == 1
+        assert "cutover DM" in caplog.text
+        # The fix has to be in the message, not just the complaint.
+        assert bot.PREMIUM_CUTOVER_TRIGGER_PATH in caplog.text
+
+    def test_silent_once_the_campaign_has_finished(self, enforced, caplog):
+        make_server(row_id=OLD_ID)
+        mark_notified()
+        with caplog.at_level(logging.WARNING):
+            assert bot.warn_if_cutover_incomplete() == 0
+        assert "cutover DM" not in caplog.text
+
+    def test_a_database_failure_does_not_invent_a_number(self, monkeypatch):
+        def boom():
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(bot, "session_scope", boom)
+        assert bot.count_pending_cutover_notices() == 0


### PR DESCRIPTION
Closes #59. Part of #46.

## The problem

The grandfather line and the cutover DM audience were the same predicate — `servers.id <= PREMIUM_GRANDFATHER_MAX_ID`. So the campaign only ever reached servers that lose nothing, while the ~100 servers past the line would lose unverified-role removal, nickname sync and the custom DM with no notice at all. They'd find out by noticing nicknames stopped syncing.

## The fix

Rather than notify people about a loss, stop the loss happening.

`PremiumGrandfatherLine` records `MAX(servers.id)` on the first startup that finds `PREMIUM_SKU_ID` set, and never moves it. Every server installed before launch is grandfathered **by construction**; only servers added afterwards are ever asked to pay for those three features.

This removes the failure mode instead of detecting it. It also means the cutover DM is now purely informational, so it can go out *after* the switch — there is no launch ordering left to get wrong.

The line lives in the database, not an env var, so a restore carries it alongside the servers it describes. Recomputing it after a restore would re-draw it wherever the restore landed, retroactively grandfathering everyone who signed up since. `PREMIUM_GRANDFATHER_MAX_ID` survives as an override for a capture that went wrong.

Capture happens at first *enforced* boot rather than first boot after deploy: capturing at deploy would leave every server installing between then and launch day unprotected, recreating the same bug in miniature.

### Launching is now

1. Set `PREMIUM_SKU_ID`, restart. The line is captured and logged.
2. `touch` the trigger whenever. The DM says the tier launched and nothing changed for you, which is now true for every recipient.

⚠️ **`PREMIUM_GRANDFATHER_MAX_ID` must be unset in production before launching** — it overrides the capture and would reinstate the original bug. Already removed from the deploy host.

## From adversarial review of the first commit

- `warn_if_cutover_incomplete` ran on **every reconnect**, since `on_ready` fires each time — two queries on the event loop plus a duplicate warning per gateway blip. Now once per process, and it stops querying once it has looked. This is the same hazard `start_background_task` exists to prevent, two lines above where I'd put the call.
- Reworded so it stops implying it guards correctness. It's a courtesy reminder now; `PremiumGrandfatherLine` is what makes the bug impossible.
- **Reverted my own optimisation.** Counting the pending set with a SQL `IN` compares `bigint = character varying` on Postgres — `servers.server_id` is an integer column in production while `premium_cutover_notice.server_id` is genuinely text (see `panel_view_key`). SQLite types both as text, so it passed every test and would have broken only on deploy. The Python-side normalisation is back, with the reason documented.
- `conftest` now clears `PREMIUM_GRANDFATHER_MAX_ID`. `load_dotenv()` was leaking it from a developer's local `.env` into the whole suite, so those grandfather tests were passing because of an untracked file and would behave differently on CI.

## Verification

607 tests pass (+22).

Mutation-tested, 9 guards, all caught:

| Reverted behaviour | Caught by |
| --- | --- |
| captures before the tier is live | `test_does_nothing_while_the_tier_is_off` |
| captures min instead of max | `test_captures_the_highest_server_id` |
| existing servers not all grandfathered | `test_every_existing_server_ends_up_grandfathered` |
| no line means nobody is grandfathered | `test_no_line_yet_means_grandfathered` |
| override ignored | `test_the_override_wins_when_set` |
| warning repeats on every reconnect | `test_it_only_speaks_once_per_process` |
| reconnect still hits the database | `test_the_repeat_guard_skips_the_query_entirely` |
| int/text ids compared without normalising | `test_an_integer_server_id_still_matches_its_notice` |
| campaign runs before any line exists | `test_no_line_means_nothing_to_announce` |

A tenth — removing the "already captured" early return — is a genuine equivalent mutant: the `id=1` primary key rejects the duplicate insert independently, so the line still cannot move. Verified empirically rather than assumed.

## Deployment

No migration to run: `create_all()` adds `premium_grandfather_line` on the next start. Behaviour is unchanged while `PREMIUM_SKU_ID` stays unset — nothing is captured, nothing is gated, no DM is sent.
