### PR TITLE
Let premium servers brand the instructions panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ VRChat Verify Bot is a Discord bot that automates the verification of VRChat use
   - Instructions language (per-server locale) used for embeds and button flows.
   - Auto-verify new members when they join (opt-in).
   - Optional removal of an "unverified" role once a user becomes verified.
+  - Instructions panel colour and server-icon thumbnail (premium).
 - Instructions posting command (/vrcverify_instructions) that publishes a localized, interactive instruction embed with buttons.
 - Robust request/result flow via RabbitMQ including a dedicated result consumer in the bot.
 - Improved RabbitMQ reliability: both services auto-reconnect after broker restarts/idle disconnects; publishes retry and use persistent delivery.
@@ -53,6 +54,7 @@ See the sections below for details and configuration.
   - **PendingVerification:** Temporarily holds verification requests until they are processed.
   - **PremiumCutoverNotice:** Which guilds have already had the one-time premium announcement DM.
   - **PremiumGrandfatherLine:** Single row holding `MAX(servers.id)` as of the moment the premium tier was switched on. Servers at or below it keep the grandfathered features free, permanently. Captured once, never moved.
+  - **InstructionPanelBranding:** A premium server's chosen embed colour and whether to show its server icon on the instructions panel. Both default to off, so the row existing does not by itself restyle anything.
   - **VerificationLogChannel:** Where a guild posts its verification activity log.
 
 - **Messaging with RabbitMQ:**  
@@ -82,6 +84,7 @@ See the sections below for details and configuration.
   - Auto nickname change (on successful verification, set Discord nickname to VRChat display name).
   - Instructions language (server-wide locale).
   - Auto-verify new members (attempt verification or initiate the flow when a member joins).
+  - Instructions panel appearance — premium. Embed colour and whether to show the server icon as the thumbnail. The instruction text is never customisable.
 - `/vrcverify_setrequestmessage` – Admin-only. Opens a modal to set or clear the custom DM shown after a successful verification role assignment.
 - `/vrcverify_logchannel` – Admin-only, premium. Chooses where verification activity is logged; run with no channel to turn it off.
 - `/vrcverify_support` – Anyone. Sends help/support information.
@@ -107,6 +110,7 @@ unlocks the automation around it:
 | Reduced verification cooldown | — | — | ✅ |
 | Verification activity log channel | — | — | ✅ |
 | Priority placement in the verification queue | — | — | ✅ |
+| Branded instructions panel (colour + icon) | — | — | ✅ |
 
 Auto-verify-on-join is free for everyone and is deliberately not gated at all —
 `on_member_join` never so much as reads an entitlement. Users read "the bot
@@ -214,6 +218,34 @@ two services agree and that each actually passes the arguments.
 > If step 4 is skipped, both services log an explicit error naming the queue and the fix.
 > The bot stops publishing (rather than retrying something that can never succeed) and
 > the checker backs off; verification is stopped until the queue is deleted.
+
+### Branded instructions panel
+
+Page 4 of `/vrcverify_settings` lets a premium server set its own embed colour
+and show its server icon as the panel thumbnail. Colour is entered as a hex
+value (`#5865F2`, or `#58F` shorthand); Discord has no colour-picker component
+of any kind, so a text field is the only way to express an exact brand colour.
+`#000000` is nudged to `#010101`, because Discord reads a colour of 0 as "no
+colour" and would render the default grey.
+
+**The instruction copy itself is not customisable, deliberately.** It is the
+part that actually gets people through verification correctly, and letting
+servers rewrite it means support requests about instructions nobody here wrote.
+
+Both settings default to off, so subscribing does not restyle a panel the admin
+never asked to restyle. The thumbnail is the guild's own icon rather than an
+arbitrary URL — nothing to validate, and no way for a server to put unrelated
+imagery inside an age-verification panel.
+
+Styling is resolved at edit time, never stored with the panel, which is what
+makes a lapse revert: `resolve_panel_style` returns the defaults once the
+entitlement is gone. Since the panel is a persisted Discord message, something
+still has to re-edit it, so the bot does that when an admin saves and whenever a
+guild's entitlements change. Guilds with no branding row skip the entitlement
+read entirely, so the fleet refresh doesn't become one lookup per panel.
+
+A server that changes its Discord icon keeps the old thumbnail until its panel
+is next refreshed — the URL is baked into the message.
 
 ### Verification activity log
 
@@ -477,7 +509,7 @@ Each component connects to RabbitMQ to exchange verification requests and result
   - `/vrcverify_subscription` – See this server's premium status, and subscribe if it isn't.
   - `/vrcverify_support` – Receive help and support information.
   - `/vrcverify_instructions` – Post instructions in an embed for server members.
-  - `/vrcverify_settings` – Configure auto nickname change, instructions language, and auto-verify-on-join. The auto-nickname page is shown locked with a purchase button (rather than hidden) on servers without premium.
+  - `/vrcverify_settings` – Configure auto nickname change, instructions language, auto-verify-on-join, and instructions panel appearance. The auto-nickname and appearance pages are shown locked with a purchase button (rather than hidden) on servers without premium.
   - `/vrcverify_setrequestmessage` – Configure the optional custom success DM sent after successful verification.
 
 ---

--- a/src/bot.py
+++ b/src/bot.py
@@ -3843,12 +3843,20 @@ def load_instruction_panel(guild_id) -> Optional[dict]:
             )
             if server is None or not server.instructions_message_id:
                 return None
+            # The real recorded version, not a placeholder: probe_instruction_panel
+            # re-records it whenever the entry disagrees, so hardcoding 0 would
+            # buy a redundant write on every restyle.
+            recorded = (
+                session.query(InstructionPanelView.view_version)
+                .filter_by(server_id=panel_view_key(guild_id))
+                .first()
+            )
             return {
                 "server_id": server.server_id,
                 "channel_id": server.instructions_channel_id,
                 "message_id": server.instructions_message_id,
                 "locale": server.instructions_locale or "en-US",
-                "view_version": 0,
+                "view_version": 0 if recorded is None else recorded.view_version,
             }
     except Exception:
         logger.warning(

--- a/src/bot.py
+++ b/src/bot.py
@@ -1200,12 +1200,20 @@ def parse_hex_color(raw: str) -> Optional[int]:
     return NEAREST_RENDERABLE_BLACK if value == 0 else value
 
 
-def load_panel_branding(guild_id) -> Optional[tuple[Optional[int], bool]]:
-    """This guild's stored (colour, show_icon), or None if it has never set any.
+# Returned when the branding table cannot be read at all. Distinct from None,
+# which is the definite answer "this guild has no branding". Collapsing the two
+# would mean a database blip during a fleet refresh actively re-editing a
+# paying server's panel back to the default look — taking something away
+# because we couldn't tell, which is the opposite of how is_grandfathered and
+# the entitlement cache behave.
+BRANDING_UNREADABLE = object()
 
-    None and (None, False) are deliberately different answers: the first means
-    no row exists and no entitlement read is needed, the second means a row
-    exists but currently asks for default styling.
+
+def load_panel_branding(guild_id):
+    """This guild's stored (colour, show_icon).
+
+    Returns None when the guild definitely has no branding, or
+    BRANDING_UNREADABLE when the question could not be answered.
     """
     try:
         with session_scope() as session:
@@ -1220,11 +1228,11 @@ def load_panel_branding(guild_id) -> Optional[tuple[Optional[int], bool]]:
             return None if row is None else (row.embed_color, bool(row.show_icon))
     except Exception:
         logger.warning(
-            "Could not read panel branding for guild %s; using defaults.",
+            "Could not read panel branding for guild %s; leaving its panel alone.",
             guild_id,
             exc_info=True,
         )
-        return None
+        return BRANDING_UNREADABLE
 
 
 def save_panel_branding(guild_id, embed_color: Optional[int], show_icon: bool) -> None:
@@ -1284,14 +1292,21 @@ def panel_style(
 
 async def resolve_panel_style(
     guild_id, guild: Optional[discord.Guild]
-) -> tuple[discord.Color, Optional[str]]:
+) -> Optional[tuple[discord.Color, Optional[str]]]:
     """The styling this guild's panel should currently use.
+
+    None means "we could not tell, leave the panel as it is" — the caller skips
+    rebuilding the embed rather than rewriting it to the default. Restyling a
+    paying server's panel because of a database hiccup would be worse than
+    doing nothing, and the next refresh puts it right.
 
     Short-circuits before the entitlement read when nothing is configured,
     which is the overwhelming majority of guilds — the fleet refresh would
     otherwise turn into one entitlement lookup per panel.
     """
     branding = load_panel_branding(guild_id)
+    if branding is BRANDING_UNREADABLE:
+        return None
     if branding is None:
         return DEFAULT_PANEL_COLOR, None
     flags = await resolve_premium_flags(guild_id)
@@ -2828,6 +2843,10 @@ async def vrcverify_instructions(interaction: discord.Interaction):
     # match. Styling comes from the interaction's own entitlements, which costs
     # nothing, rather than the REST lookup the refresh path has to use.
     branding = load_panel_branding(interaction.guild.id)
+    if branding is BRANDING_UNREADABLE:
+        # Nothing to preserve on a panel being posted for the first time, so
+        # the default look is the right answer rather than a refusal.
+        branding = None
     style_flags = resolve_premium_flags_from_interaction(interaction)
     panel_color, panel_icon = panel_style(
         branding, interaction.guild, style_flags.allows(FEATURE_BRANDED_PANEL)
@@ -2890,8 +2909,11 @@ async def vrcverify_settings(interaction: discord.Interaction):
             current_auto_verify = True
 
     # (None, False) when nothing has been configured, which is the same thing
-    # the branding page shows for "default blue, no icon".
-    stored_color, stored_icon = load_panel_branding(interaction.guild.id) or (None, False)
+    # the branding page shows for "default blue, no icon". An unreadable table
+    # lands here too: the Server read above shares the same session, so a real
+    # outage fails this command long before this line.
+    stored = load_panel_branding(interaction.guild.id)
+    stored_color, stored_icon = stored if isinstance(stored, tuple) else (None, False)
 
     view = PagedSettingsView(
         current_nick,
@@ -4059,12 +4081,14 @@ async def probe_instruction_panel(entry, rebuild_embed: bool) -> str:
                 # still gets its rebuilt embed, and the existing malformed-id
                 # handling above owns deciding what to do about the id itself.
                 guild = None
-            panel_color, panel_icon = await resolve_panel_style(
-                entry["server_id"], guild
-            )
-            payload["embed"] = build_instructions_embed(
-                entry["locale"], panel_color, panel_icon
-            )
+            style = await resolve_panel_style(entry["server_id"], guild)
+            # None means the branding table could not be read. Leave the embed
+            # off the payload so the panel keeps whatever it already has — the
+            # view still gets refreshed, which is what this pass is for.
+            if style is not None:
+                payload["embed"] = build_instructions_embed(
+                    entry["locale"], *style
+                )
         await message.edit(**payload)
         if entry.get("view_version") != INSTRUCTIONS_VIEW_VERSION:
             record_panel_view_version(entry["server_id"])
@@ -4385,7 +4409,9 @@ def _note_entitlement_change(entitlement: discord.Entitlement, event: str) -> No
     # Deliberately fired on renewals and cancellations alike: the event only
     # says "re-resolve", and resolve_panel_style decides the outcome. A
     # subscription cancelled but not yet expired therefore keeps its styling.
-    if load_panel_branding(guild_id) is not None:
+    # isinstance rather than `is not None`: an unreadable table must not buy a
+    # panel edit that resolve_panel_style would then decline to apply anyway.
+    if isinstance(load_panel_branding(guild_id), tuple):
         asyncio.create_task(restyle_instruction_panel(guild_id))
 
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -3859,6 +3859,29 @@ def load_instruction_panel(guild_id) -> Optional[dict]:
         return None
 
 
+# asyncio only holds a weak reference to a running task, so a fire-and-forget
+# create_task() can be garbage collected mid-flight and the panel edit silently
+# never happens. Keeping the task here until it finishes is what stops that.
+# Not start_background_task: that is keyed by name and these are per-guild.
+_restyle_tasks: set = set()
+
+
+def schedule_panel_restyle(guild_id) -> None:
+    """Restyle a panel in the background, keeping the task alive until done."""
+    coro = restyle_instruction_panel(guild_id)
+    try:
+        task = asyncio.create_task(coro)
+    except RuntimeError:
+        # No running loop (e.g. called from sync code). Close the coroutine we
+        # never awaited, exactly as start_background_task does, so Python does
+        # not warn about it. The next refresh picks the styling up anyway.
+        coro.close()
+        logger.debug("No event loop to restyle guild %s on.", guild_id)
+        return
+    _restyle_tasks.add(task)
+    task.add_done_callback(_restyle_tasks.discard)
+
+
 async def restyle_instruction_panel(guild_id) -> str:
     """Re-edit one guild's panel so a styling change is visible right away.
 
@@ -4412,7 +4435,7 @@ def _note_entitlement_change(entitlement: discord.Entitlement, event: str) -> No
     # isinstance rather than `is not None`: an unreadable table must not buy a
     # panel edit that resolve_panel_style would then decline to apply anyway.
     if isinstance(load_panel_branding(guild_id), tuple):
-        asyncio.create_task(restyle_instruction_panel(guild_id))
+        schedule_panel_restyle(guild_id)
 
 
 @bot.event

--- a/src/bot.py
+++ b/src/bot.py
@@ -1228,13 +1228,26 @@ def load_panel_branding(guild_id) -> Optional[tuple[Optional[int], bool]]:
 
 
 def save_panel_branding(guild_id, embed_color: Optional[int], show_icon: bool) -> None:
-    """Store this guild's panel styling, creating the row on first use."""
+    """Store this guild's panel styling, creating the row on first use.
+
+    Styling that asks for nothing removes the row instead of storing it. The
+    settings view saves every page at once, so a premium server that only
+    touched its nickname setting would otherwise get a row meaning "default
+    colour, no icon" — indistinguishable in effect from having none, but enough
+    to make resolve_panel_style do an entitlement lookup for that guild on
+    every fleet refresh. That short-circuit is the reason the refresh does not
+    cost one REST call per panel, so it is worth protecting.
+    """
     key = panel_view_key(guild_id)
     try:
         with session_scope() as session:
             row = (
                 session.query(InstructionPanelBranding).filter_by(server_id=key).first()
             )
+            if embed_color is None and not show_icon:
+                if row is not None:
+                    session.delete(row)
+                return
             if row is None:
                 row = InstructionPanelBranding(server_id=key)
                 session.add(row)

--- a/src/bot.py
+++ b/src/bot.py
@@ -1862,9 +1862,6 @@ class PagedSettingsView(View):
                 save_panel_branding(
                     interaction.guild.id, self.embed_color, self.show_icon
                 )
-                # Show the change on the actual panel now, not whenever a fleet
-                # refresh next happens to run.
-                await restyle_instruction_panel(interaction.guild.id)
 
             notes = ""
             if not self.auto_verify_available:
@@ -1884,6 +1881,14 @@ class PagedSettingsView(View):
                 + notes
             )
             await interaction.response.edit_message(content=msg, view=None)
+
+            # Only after replying. Editing the panel is a real HTTP call, and
+            # message edits are rate limited per channel — discord.py sleeps
+            # through a 429, which can push the reply past the three seconds
+            # Discord allows. The admin would then be told the interaction
+            # failed even though the save and the restyle both worked.
+            if branding_allowed:
+                await restyle_instruction_panel(interaction.guild.id)
 
         back_btn.callback = on_back
         next_btn.callback = on_next

--- a/src/bot.py
+++ b/src/bot.py
@@ -348,6 +348,35 @@ class PremiumGrandfatherLine(Base):
     captured_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
 
+class InstructionPanelBranding(Base):
+    """A premium server's own colour and thumbnail for its instructions panel.
+
+    A separate table for the same reason as the others: create_all() adds
+    missing tables but never columns.
+
+    Both settings default to "off", so the presence of a row does not by itself
+    change how a panel looks. That matters because subscribing should not
+    silently restyle a panel the admin never asked to restyle.
+
+    Only the styling is customisable. The instruction copy itself is not, and
+    deliberately: it is the part that actually gets people through verification
+    correctly, and letting servers rewrite it means support requests about
+    instructions nobody here wrote.
+
+    The row survives a lapsed subscription, like VerificationLogChannel above:
+    styling reverts to the default, but the admin's choices are theirs and come
+    back untouched if they resubscribe.
+    """
+
+    __tablename__ = "instruction_panel_branding"
+    server_id = Column(String, primary_key=True)
+    # Discord's native integer form. NULL means "use the default blue" rather
+    # than a sentinel colour, so "unset" and "deliberately dark" stay distinct.
+    embed_color = Column(Integer, nullable=True)
+    show_icon = Column(Boolean, nullable=False, default=False)
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+
+
 class VerificationLogChannel(Base):
     """Where a guild wants its verification activity posted.
 
@@ -598,6 +627,7 @@ FEATURE_CUSTOM_DM = "custom_dm"
 FEATURE_REDUCED_COOLDOWN = "reduced_cooldown"
 FEATURE_ACTIVITY_LOG = "activity_log"
 FEATURE_PRIORITY_QUEUE = "priority_queue"
+FEATURE_BRANDED_PANEL = "branded_panel"
 
 # Servers configured before the cutover keep these three for free, forever.
 # The reduced cooldown and the activity log are new, so nobody is losing them.
@@ -1135,6 +1165,126 @@ async def log_channel_if_allowed(guild_id, log_channel_id) -> Optional[str]:
     return log_channel_id if flags.allows(FEATURE_ACTIVITY_LOG) else None
 
 
+# -------------------------------------------------------------------
+# Premium: branded instructions panel (colour + thumbnail)
+# -------------------------------------------------------------------
+DEFAULT_PANEL_COLOR = discord.Color.blue()
+
+# Discord treats an embed colour of 0 as "no colour set" and renders the plain
+# grey sidebar, so a server asking for black would appear to have been ignored.
+# Nudge it to the darkest value that still registers as a colour.
+NEAREST_RENDERABLE_BLACK = 0x010101
+
+
+def parse_hex_color(raw: str) -> Optional[int]:
+    """Parse '#5865F2', '5865F2' or '0x5865F2' into Discord's integer form.
+
+    Returns None for anything else, so the caller can say so rather than
+    storing a colour the admin did not choose. Three-digit shorthand (#abc) is
+    accepted because people type it.
+    """
+    if not raw:
+        return None
+    text = raw.strip().lstrip("#")
+    if text[:2].lower() == "0x":
+        text = text[2:]
+    if len(text) == 3:
+        # #abc means #aabbcc.
+        text = "".join(char * 2 for char in text)
+    if len(text) != 6:
+        return None
+    try:
+        value = int(text, 16)
+    except ValueError:
+        return None
+    return NEAREST_RENDERABLE_BLACK if value == 0 else value
+
+
+def load_panel_branding(guild_id) -> Optional[tuple[Optional[int], bool]]:
+    """This guild's stored (colour, show_icon), or None if it has never set any.
+
+    None and (None, False) are deliberately different answers: the first means
+    no row exists and no entitlement read is needed, the second means a row
+    exists but currently asks for default styling.
+    """
+    try:
+        with session_scope() as session:
+            row = (
+                session.query(
+                    InstructionPanelBranding.embed_color,
+                    InstructionPanelBranding.show_icon,
+                )
+                .filter_by(server_id=panel_view_key(guild_id))
+                .first()
+            )
+            return None if row is None else (row.embed_color, bool(row.show_icon))
+    except Exception:
+        logger.warning(
+            "Could not read panel branding for guild %s; using defaults.",
+            guild_id,
+            exc_info=True,
+        )
+        return None
+
+
+def save_panel_branding(guild_id, embed_color: Optional[int], show_icon: bool) -> None:
+    """Store this guild's panel styling, creating the row on first use."""
+    key = panel_view_key(guild_id)
+    try:
+        with session_scope() as session:
+            row = (
+                session.query(InstructionPanelBranding).filter_by(server_id=key).first()
+            )
+            if row is None:
+                row = InstructionPanelBranding(server_id=key)
+                session.add(row)
+            row.embed_color = embed_color
+            row.show_icon = bool(show_icon)
+            row.updated_at = datetime.now(timezone.utc)
+    except Exception:
+        logger.exception(f"Failed to save panel branding for guild {guild_id}")
+
+
+def panel_style(
+    branding: Optional[tuple[Optional[int], bool]],
+    guild: Optional[discord.Guild],
+    allowed: bool,
+) -> tuple[discord.Color, Optional[str]]:
+    """Turn stored branding into the (colour, thumbnail_url) an embed needs.
+
+    Kept separate from the entitlement read so it can be exercised without a
+    database or a Discord connection, and so both call sites provably agree.
+
+    A guild with no icon yields no thumbnail even when show_icon is on: there
+    is nothing to show, and Discord rejects an empty URL.
+    """
+    if not allowed or branding is None:
+        return DEFAULT_PANEL_COLOR, None
+    stored_color, show_icon = branding
+    color = DEFAULT_PANEL_COLOR if stored_color is None else discord.Color(stored_color)
+    icon_url = None
+    if show_icon and guild is not None:
+        icon = getattr(guild, "icon", None)
+        icon_url = str(icon.url) if icon else None
+    return color, icon_url
+
+
+async def resolve_panel_style(
+    guild_id, guild: Optional[discord.Guild]
+) -> tuple[discord.Color, Optional[str]]:
+    """The styling this guild's panel should currently use.
+
+    Short-circuits before the entitlement read when nothing is configured,
+    which is the overwhelming majority of guilds — the fleet refresh would
+    otherwise turn into one entitlement lookup per panel.
+    """
+    branding = load_panel_branding(guild_id)
+    if branding is None:
+        return DEFAULT_PANEL_COLOR, None
+    flags = await resolve_premium_flags(guild_id)
+    return panel_style(branding, guild, flags.allows(FEATURE_BRANDED_PANEL))
+
+
 def chunk_log_lines(lines: list[str], limit: int = DISCORD_MESSAGE_MAX_LEN) -> list[str]:
     """Pack lines into as few messages as Discord's length limit allows."""
     messages: list[str] = []
@@ -1384,7 +1534,51 @@ class VRCVerifyInstructionView(View):
 # 2 (language) are free, so they are absent.
 SETTINGS_PAGE_FEATURE = {
     0: FEATURE_NICKNAME_SYNC,
+    3: FEATURE_BRANDED_PANEL,
 }
+
+# The last page index. Derived so adding a page means touching one constant
+# instead of hunting for the Next button's disabled check.
+SETTINGS_LAST_PAGE = 3
+
+
+class PanelColorModal(discord.ui.Modal, title="Instructions panel colour"):
+    """Collect a hex colour for the instructions panel.
+
+    A modal because Discord has no colour-picker component — the full component
+    set is buttons, selects, text inputs and layout containers, none of which
+    can express a wheel or a gradient. A Select could only offer a fixed
+    palette, which is no use to a server with an actual brand colour.
+    """
+
+    hex_value = discord.ui.TextInput(
+        label="Hex colour",
+        placeholder="#5865F2",
+        required=True,
+        min_length=3,
+        max_length=9,
+    )
+
+    def __init__(self, view: "PagedSettingsView"):
+        super().__init__()
+        self.settings_view = view
+        if view.embed_color is not None:
+            self.hex_value.default = f"#{view.embed_color:06X}"
+
+    async def on_submit(self, interaction: discord.Interaction):
+        parsed = parse_hex_color(str(self.hex_value.value))
+        if parsed is None:
+            await interaction.response.send_message(
+                get_message("panel_color_invalid", interaction), ephemeral=True
+            )
+            return
+        self.settings_view.embed_color = parsed
+        # Edits the settings message the modal was launched from, so the new
+        # value is visible immediately instead of only after a page flip.
+        refreshed = self.settings_view._rebuilt(self.settings_view.page)
+        await interaction.response.edit_message(
+            content=refreshed.render_content(), view=refreshed
+        )
 
 
 class PagedSettingsView(View):
@@ -1396,6 +1590,8 @@ class PagedSettingsView(View):
         auto_verify_available: bool = True,
         page_index: int = 0,
         premium: Optional["PremiumFlags"] = None,
+        embed_color: Optional[int] = None,
+        show_icon: bool = False,
     ):
         super().__init__(timeout=None)
         # Current values (mutated by selects)
@@ -1403,7 +1599,11 @@ class PagedSettingsView(View):
         self.instr_locale: str = instr_locale
         self.auto_verify: bool = auto_verify
         self.auto_verify_available: bool = auto_verify_available
-        self.page: int = page_index  # 0: nick, 1: auto-verify, 2: locale
+        # Panel branding. None colour means "the default blue", which is a
+        # different thing from any particular stored colour.
+        self.embed_color: Optional[int] = embed_color
+        self.show_icon: bool = show_icon
+        self.page: int = page_index  # 0: nick, 1: auto-verify, 2: locale, 3: branding
         # Resolved once by the command and threaded through every Back/Next
         # rebuild, so paging around can't re-ask Discord on each click.
         self.premium: PremiumFlags = premium or PremiumFlags(
@@ -1428,6 +1628,8 @@ class PagedSettingsView(View):
             self.auto_verify_available,
             page_index=page_index,
             premium=self.premium,
+            embed_color=self.embed_color,
+            show_icon=self.show_icon,
         )
 
     def _page_title_and_desc(self) -> tuple[str, str, str]:
@@ -1444,10 +1646,23 @@ class PagedSettingsView(View):
                 current = "Current: Yes (unavailable - DB column missing)"
             else:
                 current = f"Current: {'Yes' if self.auto_verify else 'No'}"
-        else:
+        elif self.page == 2:
             title = "3.) Instructions message language"
             desc = "Choose the language used for the instructions message/buttons."
             current = f"Current: {self.instr_locale}"
+        else:
+            title = "4.) Instructions panel appearance"
+            desc = (
+                "Put your server's own colour and icon on the instructions panel. "
+                "The instruction text itself never changes."
+            )
+            color_text = (
+                f"#{self.embed_color:06X}" if self.embed_color is not None else "Default blue"
+            )
+            current = (
+                f"Current colour: {color_text}\n"
+                f"Show server icon: {'Yes' if self.show_icon else 'No'}"
+            )
 
         if locked:
             current += "\n(Premium feature — not active on this server.)"
@@ -1517,6 +1732,58 @@ class PagedSettingsView(View):
             av_dropdown.callback = on_auto_verify_select
             self.add_item(av_dropdown)
 
+        elif self.page == SETTINGS_LAST_PAGE:
+            icon_locked = self._page_locked()
+            icon_options = [
+                discord.SelectOption(label="Yes", value="yes", default=self.show_icon),
+                discord.SelectOption(label="No", value="no", default=not self.show_icon),
+            ]
+            icon_dropdown = Select(
+                placeholder="Show your server icon on the panel?",
+                min_values=1,
+                max_values=1,
+                options=icon_options,
+                disabled=icon_locked,
+            )
+
+            async def on_icon_select(interaction: discord.Interaction):
+                if not icon_locked:
+                    self.show_icon = interaction.data["values"][0] == "yes"
+                await interaction.response.defer(ephemeral=True)
+
+            icon_dropdown.callback = on_icon_select
+            self.add_item(icon_dropdown)
+
+            # A modal rather than a Select: Discord has no colour picker
+            # component of any kind, and a dropdown could only ever offer a
+            # fixed palette rather than a server's actual brand colour.
+            color_btn = Button(
+                label="Set colour",
+                style=discord.ButtonStyle.secondary,
+                disabled=icon_locked,
+            )
+
+            async def on_color_button(interaction: discord.Interaction):
+                await interaction.response.send_modal(PanelColorModal(self))
+
+            color_btn.callback = on_color_button
+            self.add_item(color_btn)
+
+            if self.embed_color is not None and not icon_locked:
+                clear_btn = Button(
+                    label="Use default colour", style=discord.ButtonStyle.secondary
+                )
+
+                async def on_clear_color(interaction: discord.Interaction):
+                    self.embed_color = None
+                    refreshed = self._rebuilt(self.page)
+                    await interaction.response.edit_message(
+                        content=refreshed.render_content(), view=refreshed
+                    )
+
+                clear_btn.callback = on_clear_color
+                self.add_item(clear_btn)
+
         else:
             locale_options = [
                 discord.SelectOption(label=code, value=code, default=(code == self.instr_locale))
@@ -1538,7 +1805,11 @@ class PagedSettingsView(View):
 
         # Nav buttons
         back_btn = Button(label="Back", style=discord.ButtonStyle.secondary, disabled=(self.page == 0))
-        next_btn = Button(label="Next", style=discord.ButtonStyle.secondary, disabled=(self.page == 2))
+        next_btn = Button(
+            label="Next",
+            style=discord.ButtonStyle.secondary,
+            disabled=(self.page == SETTINGS_LAST_PAGE),
+        )
         save_btn = Button(label="Save", style=discord.ButtonStyle.primary)
 
         async def on_back(interaction: discord.Interaction):
@@ -1560,6 +1831,7 @@ class PagedSettingsView(View):
             # gets their original choice back instead of whatever this view
             # happened to be holding.
             nick_allowed = self.premium.allows(FEATURE_NICKNAME_SYNC)
+            branding_allowed = self.premium.allows(FEATURE_BRANDED_PANEL)
 
             # persist into your servers table
             with session_scope() as session:
@@ -1573,11 +1845,21 @@ class PagedSettingsView(View):
                 if self.auto_verify_available:
                     setattr(srv, "auto_verify_new_members", bool(self.auto_verify))
 
+            if branding_allowed:
+                save_panel_branding(
+                    interaction.guild.id, self.embed_color, self.show_icon
+                )
+                # Show the change on the actual panel now, not whenever a fleet
+                # refresh next happens to run.
+                await restyle_instruction_panel(interaction.guild.id)
+
             notes = ""
             if not self.auto_verify_available:
                 notes += "\n(Note: 'Auto verify new members' not saved; DB column missing.)"
             if not nick_allowed:
                 notes += "\n(Note: 'Auto nickname change' is a premium feature and was not changed.)"
+            if not branding_allowed:
+                notes += "\n(Note: 'Instructions panel appearance' is a premium feature and was not changed.)"
 
             msg = (
                 get_message(
@@ -2524,8 +2806,15 @@ async def vrcverify_instructions(interaction: discord.Interaction):
             if srv and srv.instructions_locale
             else get_locale(interaction)
         )
-    # Same builder the refresh path uses, so a posted panel and a refreshed one match.
-    embed = build_instructions_embed(instr_locale)
+    # Same builder the refresh path uses, so a posted panel and a refreshed one
+    # match. Styling comes from the interaction's own entitlements, which costs
+    # nothing, rather than the REST lookup the refresh path has to use.
+    branding = load_panel_branding(interaction.guild.id)
+    style_flags = resolve_premium_flags_from_interaction(interaction)
+    panel_color, panel_icon = panel_style(
+        branding, interaction.guild, style_flags.allows(FEATURE_BRANDED_PANEL)
+    )
+    embed = build_instructions_embed(instr_locale, panel_color, panel_icon)
 
     view = VRCVerifyInstructionView(locale=instr_locale)
     # Send the initial response and then fetch the message
@@ -2582,6 +2871,10 @@ async def vrcverify_settings(interaction: discord.Interaction):
             current_locale = "en-US"
             current_auto_verify = True
 
+    # (None, False) when nothing has been configured, which is the same thing
+    # the branding page shows for "default blue, no icon".
+    stored_color, stored_icon = load_panel_branding(interaction.guild.id) or (None, False)
+
     view = PagedSettingsView(
         current_nick,
         current_locale,
@@ -2589,6 +2882,8 @@ async def vrcverify_settings(interaction: discord.Interaction):
         auto_verify_available=has_av_col,
         page_index=0,
         premium=resolve_premium_flags_from_interaction(interaction),
+        embed_color=stored_color,
+        show_icon=stored_icon,
     )
     await interaction.response.send_message(
         content=view.render_content(), view=view, ephemeral=True
@@ -3497,6 +3792,57 @@ def panel_view_key(server_id) -> str:
     return str(server_id)
 
 
+def load_instruction_panel(guild_id) -> Optional[dict]:
+    """One guild's saved panel, in the same shape load_instruction_panels uses."""
+    try:
+        with session_scope() as session:
+            server = (
+                session.query(Server)
+                .filter_by(server_id=panel_view_key(guild_id))
+                .first()
+            )
+            if server is None or not server.instructions_message_id:
+                return None
+            return {
+                "server_id": server.server_id,
+                "channel_id": server.instructions_channel_id,
+                "message_id": server.instructions_message_id,
+                "locale": server.instructions_locale or "en-US",
+                "view_version": 0,
+            }
+    except Exception:
+        logger.warning(
+            "Could not load the instruction panel for guild %s.",
+            guild_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def restyle_instruction_panel(guild_id) -> str:
+    """Re-edit one guild's panel so a styling change is visible right away.
+
+    The startup fleet refresh runs with rebuild_embed=False, so without this a
+    colour change would not show up until an operator triggered a full refresh
+    — potentially months. Called after an admin saves, and when a guild's
+    entitlements change.
+
+    Never raises: this is a nicety on top of a save that has already succeeded.
+    """
+    entry = load_instruction_panel(guild_id)
+    if entry is None:
+        return "no_panel"
+    try:
+        return await probe_instruction_panel(entry, rebuild_embed=True)
+    except Exception:
+        logger.warning(
+            "Could not restyle the instruction panel for guild %s.",
+            guild_id,
+            exc_info=True,
+        )
+        return "error"
+
+
 def load_instruction_panels(stale_only: bool = False):
     """Snapshot saved instruction panels from the DB.
 
@@ -3626,16 +3972,31 @@ def forget_instruction_panel(server_id: str):
     forget_panel_view_version(server_id)
 
 
-def build_instructions_embed(locale: str) -> Embed:
-    """Build the localized instruction panel embed."""
+def build_instructions_embed(
+    locale: str,
+    color: Optional[discord.Color] = None,
+    icon_url: Optional[str] = None,
+) -> Embed:
+    """Build the localized instruction panel embed.
+
+    Styling arrives as arguments rather than being looked up here, so this stays
+    a pure function of its inputs: no database, no entitlement read, and no way
+    for the posted panel and the refreshed panel to disagree. Both call sites
+    resolve the style the same way and hand it in.
+
+    The instruction copy itself is never customisable — see
+    InstructionPanelBranding for why.
+    """
     strings = localizations.get(locale, localizations["en-US"])
     embed = Embed(
         title=strings.get("instructions_title", ""),
         description=strings.get("instructions_desc", ""),
-        color=discord.Color.blue(),
+        color=color if color is not None else DEFAULT_PANEL_COLOR,
     )
     usage_example = "**Example Usage**:\n" "```bash\n" "/vrcverify\n" "```"
     embed.add_field(name="Example Command", value=usage_example, inline=False)
+    if icon_url:
+        embed.set_thumbnail(url=icon_url)
     return embed
 
 
@@ -3670,7 +4031,22 @@ async def probe_instruction_panel(entry, rebuild_embed: bool) -> str:
         # abort the whole fleet pass, it only costs this one guild.
         payload = {"view": VRCVerifyInstructionView(locale=entry["locale"])}
         if rebuild_embed:
-            payload["embed"] = build_instructions_embed(entry["locale"])
+            # Resolving the style is what reverts a lapsed server to the default
+            # look, so it happens here rather than being cached with the panel.
+            # Guilds with no branding row skip the entitlement read entirely.
+            try:
+                guild = bot.get_guild(int(entry["server_id"]))
+            except (TypeError, ValueError):
+                # An unparseable id costs the thumbnail, nothing else. The panel
+                # still gets its rebuilt embed, and the existing malformed-id
+                # handling above owns deciding what to do about the id itself.
+                guild = None
+            panel_color, panel_icon = await resolve_panel_style(
+                entry["server_id"], guild
+            )
+            payload["embed"] = build_instructions_embed(
+                entry["locale"], panel_color, panel_icon
+            )
         await message.edit(**payload)
         if entry.get("view_version") != INSTRUCTIONS_VIEW_VERSION:
             record_panel_view_version(entry["server_id"])
@@ -3982,6 +4358,17 @@ def _note_entitlement_change(entitlement: discord.Entitlement, event: str) -> No
         return
     premium_status_cache.invalidate(str(guild_id))
     logger.info("Entitlement %s for guild %s; premium status will re-resolve.", event, guild_id)
+
+    # A branded panel has to be re-edited for its styling to change, so a lapse
+    # would otherwise leave premium styling in place until an operator ran a
+    # fleet refresh. Only guilds that configured branding are touched; for
+    # everyone else there is nothing to change and no reason to spend an edit.
+    #
+    # Deliberately fired on renewals and cancellations alike: the event only
+    # says "re-resolve", and resolve_panel_style decides the outcome. A
+    # subscription cancelled but not yet expired therefore keeps its styling.
+    if load_panel_branding(guild_id) is not None:
+        asyncio.create_task(restyle_instruction_panel(guild_id))
 
 
 @bot.event

--- a/src/locales.py
+++ b/src/locales.py
@@ -85,6 +85,7 @@ localizations: dict[str, dict[str, str]] = {
         "log_channel_premium_only":  "The verification activity log is a VRCVerify Premium feature. Core 18+ verification stays free for everyone.",
         "log_channel_no_permission": "I can't post in {channel}. Give the bot **View Channel** and **Send Messages** there, then run this command again.",
         "log_channel_announcement": "{channel} is an announcement channel. Other servers can follow it, which would republish your members' 18+ status outside this server, so it can't be used as a verification log. Please pick a normal text channel.",
+        "panel_color_invalid": "That doesn't look like a hex colour. Use something like `#5865F2` (or `#58F` for short).",
     },
 
     "es-ES": {
@@ -164,6 +165,7 @@ localizations: dict[str, dict[str, str]] = {
         "log_channel_premium_only":  "El registro de actividad de verificación es una función de VRCVerify Premium. La verificación 18+ sigue siendo gratuita para todos.",
         "log_channel_no_permission": "No puedo publicar en {channel}. Dale al bot **Ver canal** y **Enviar mensajes** ahí y vuelve a ejecutar este comando.",
         "log_channel_announcement": "{channel} es un canal de anuncios. Otros servidores pueden seguirlo, lo que republicaría el estado 18+ de tus miembros fuera de este servidor, así que no puede usarse como registro de verificación. Elige un canal de texto normal.",
+        "panel_color_invalid": "Eso no parece un color hexadecimal. Usa algo como `#5865F2` (o `#58F` en forma corta).",
     },
 
     "zh-CN": {
@@ -243,6 +245,7 @@ localizations: dict[str, dict[str, str]] = {
         "log_channel_premium_only":  "验证活动日志是 VRCVerify 高级版功能。核心的 18+ 验证对所有人始终免费。",
         "log_channel_no_permission": "我无法在 {channel} 中发言。请授予机器人该频道的**查看频道**和**发送消息**权限，然后重新运行此命令。",
         "log_channel_announcement": "{channel} 是公告频道。其他服务器可以关注它，这会把你成员的 18+ 状态转发到本服务器之外，因此不能用作验证日志。请选择一个普通文字频道。",
+        "panel_color_invalid": "这看起来不是十六进制颜色。请使用类似 `#5865F2` 的格式（也可以简写为 `#58F`）。",
     },
 
     "ja": {
@@ -322,6 +325,7 @@ localizations: dict[str, dict[str, str]] = {
         "log_channel_premium_only":  "認証アクティビティログは VRCVerify Premium の機能です。中心となる 18+ 認証は誰でも無料のままです。",
         "log_channel_no_permission": "{channel} に投稿できません。そのチャンネルで Bot に**チャンネルを見る**と**メッセージを送信**の権限を与えてから、もう一度実行してください。",
         "log_channel_announcement": "{channel} はアナウンスチャンネルです。他のサーバーがフォローできるため、メンバーの 18+ 状態がこのサーバーの外に再配信されてしまいます。認証ログには使えませんので、通常のテキストチャンネルを選んでください。",
+        "panel_color_invalid": "16進数のカラーコードではないようです。`#5865F2` のような形式（短縮形は `#58F`）で入力してください。",
     },
 
     "de": {
@@ -401,6 +405,7 @@ localizations: dict[str, dict[str, str]] = {
         "log_channel_premium_only":  "Das Verifizierungsprotokoll ist eine Funktion von VRCVerify Premium. Die eigentliche 18+-Verifizierung bleibt für alle kostenlos.",
         "log_channel_no_permission": "Ich kann in {channel} nichts posten. Gib dem Bot dort **Kanal ansehen** und **Nachrichten senden** und führe den Befehl erneut aus.",
         "log_channel_announcement": "{channel} ist ein Ankündigungskanal. Andere Server können ihm folgen, wodurch der 18+-Status deiner Mitglieder außerhalb dieses Servers erneut veröffentlicht würde. Er kann daher nicht als Verifizierungsprotokoll dienen. Bitte wähle einen normalen Textkanal.",
+        "panel_color_invalid": "Das sieht nicht nach einer Hex-Farbe aus. Verwende etwas wie `#5865F2` (oder kurz `#58F`).",
     },
 
     "nl": {
@@ -480,6 +485,7 @@ localizations: dict[str, dict[str, str]] = {
         "log_channel_premium_only":  "Het verificatielogboek is een functie van VRCVerify Premium. De 18+-verificatie zelf blijft voor iedereen gratis.",
         "log_channel_no_permission": "Ik kan niets plaatsen in {channel}. Geef de bot daar **Kanaal bekijken** en **Berichten versturen** en voer dit commando opnieuw uit.",
         "log_channel_announcement": "{channel} is een aankondigingskanaal. Andere servers kunnen het volgen, waardoor de 18+-status van je leden buiten deze server opnieuw wordt gepubliceerd. Het kan dus niet als verificatielogboek worden gebruikt. Kies een gewoon tekstkanaal.",
+        "panel_color_invalid": "Dat lijkt geen hexkleur te zijn. Gebruik iets als `#5865F2` (of kort `#58F`).",
     },
 
     "hi-IN": {
@@ -559,6 +565,7 @@ localizations: dict[str, dict[str, str]] = {
         "log_channel_premium_only":  "सत्यापन गतिविधि लॉग VRCVerify Premium की सुविधा है। मुख्य 18+ सत्यापन सबके लिए निःशुल्क रहता है।",
         "log_channel_no_permission": "मैं {channel} में पोस्ट नहीं कर सकता। वहाँ बॉट को **चैनल देखें** और **संदेश भेजें** अनुमति दें, फिर यह कमांड दोबारा चलाएँ।",
         "log_channel_announcement": "{channel} एक घोषणा चैनल है। दूसरे सर्वर इसे फ़ॉलो कर सकते हैं, जिससे आपके सदस्यों की 18+ स्थिति इस सर्वर के बाहर दोबारा प्रकाशित हो जाएगी, इसलिए इसे सत्यापन लॉग के रूप में इस्तेमाल नहीं किया जा सकता। कृपया एक सामान्य टेक्स्ट चैनल चुनें।",
+        "panel_color_invalid": "यह हेक्स रंग जैसा नहीं लगता। `#5865F2` जैसा कुछ इस्तेमाल करें (या संक्षेप में `#58F`)।",
     },
 
     "ar": {
@@ -638,6 +645,7 @@ localizations: dict[str, dict[str, str]] = {
         "log_channel_premium_only":  "سجل نشاط التحقق ميزة في VRCVerify Premium. أما التحقق من عمر 18+ نفسه فيبقى مجانيًا للجميع.",
         "log_channel_no_permission": "لا أستطيع النشر في {channel}. امنح البوت صلاحيتي **عرض القناة** و**إرسال الرسائل** هناك ثم نفّذ الأمر مرة أخرى.",
         "log_channel_announcement": "{channel} قناة إعلانات. يمكن لخوادم أخرى متابعتها، ما يعيد نشر حالة 18+ لأعضائك خارج هذا الخادم، لذا لا يمكن استخدامها كسجل تحقق. من فضلك اختر قناة نصية عادية.",
+        "panel_color_invalid": "لا يبدو هذا لونًا سِتّ عشريًا. استخدم شيئًا مثل `#5865F2` (أو `#58F` للاختصار).",
     },
 
     "bn": {
@@ -717,6 +725,7 @@ localizations: dict[str, dict[str, str]] = {
         "log_channel_premium_only":  "যাচাই কার্যক্রমের লগ VRCVerify Premium-এর সুবিধা। মূল 18+ যাচাই সবার জন্য বিনামূল্যেই থাকে।",
         "log_channel_no_permission": "আমি {channel}-এ পোস্ট করতে পারছি না। সেখানে বটকে **চ্যানেল দেখুন** ও **বার্তা পাঠান** অনুমতি দিন, তারপর আবার এই কমান্ড চালান।",
         "log_channel_announcement": "{channel} একটি ঘোষণা চ্যানেল। অন্য সার্ভার এটি ফলো করতে পারে, ফলে আপনার সদস্যদের 18+ অবস্থা এই সার্ভারের বাইরে পুনঃপ্রকাশিত হবে, তাই এটি যাচাই লগ হিসেবে ব্যবহার করা যাবে না। অনুগ্রহ করে একটি সাধারণ টেক্সট চ্যানেল বেছে নিন।",
+        "panel_color_invalid": "এটি হেক্স রঙ বলে মনে হচ্ছে না। `#5865F2` এর মতো কিছু ব্যবহার করুন (বা সংক্ষেপে `#58F`)।",
     },
 
     "pt-BR": {
@@ -796,6 +805,7 @@ localizations: dict[str, dict[str, str]] = {
         "log_channel_premium_only":  "O registro de atividade de verificação é um recurso do VRCVerify Premium. A verificação 18+ em si continua gratuita para todos.",
         "log_channel_no_permission": "Não consigo publicar em {channel}. Dê ao bot **Ver canal** e **Enviar mensagens** ali e execute este comando novamente.",
         "log_channel_announcement": "{channel} é um canal de anúncios. Outros servidores podem segui-lo, o que republicaria o status 18+ dos seus membros fora deste servidor, então ele não pode ser usado como registro de verificação. Escolha um canal de texto normal.",
+        "panel_color_invalid": "Isso não parece uma cor hexadecimal. Use algo como `#5865F2` (ou `#58F` de forma abreviada).",
     },
 
     "ru": {
@@ -875,6 +885,7 @@ localizations: dict[str, dict[str, str]] = {
         "log_channel_premium_only":  "Журнал активности проверок — возможность VRCVerify Premium. Сама проверка 18+ остаётся бесплатной для всех.",
         "log_channel_no_permission": "Я не могу писать в {channel}. Выдайте боту там права **Просмотр канала** и **Отправка сообщений** и выполните команду ещё раз.",
         "log_channel_announcement": "{channel} — канал объявлений. Другие серверы могут на него подписаться, и статус 18+ ваших участников будет переопубликован за пределами этого сервера, поэтому он не может служить журналом проверок. Выберите обычный текстовый канал.",
+        "panel_color_invalid": "Это не похоже на HEX-цвет. Используйте что-то вроде `#5865F2` (или `#58F` сокращённо).",
     },
 
     "pa-IN": {
@@ -954,5 +965,6 @@ localizations: dict[str, dict[str, str]] = {
         "log_channel_premium_only":  "ਤਸਦੀਕ ਗਤੀਵਿਧੀ ਲਾਗ VRCVerify Premium ਦੀ ਸਹੂਲਤ ਹੈ। ਮੁੱਖ 18+ ਤਸਦੀਕ ਸਾਰਿਆਂ ਲਈ ਮੁਫ਼ਤ ਰਹਿੰਦੀ ਹੈ।",
         "log_channel_no_permission": "ਮੈਂ {channel} ਵਿੱਚ ਪੋਸਟ ਨਹੀਂ ਕਰ ਸਕਦਾ। ਉੱਥੇ ਬੋਟ ਨੂੰ **ਚੈਨਲ ਵੇਖੋ** ਅਤੇ **ਸੁਨੇਹੇ ਭੇਜੋ** ਦੀ ਇਜਾਜ਼ਤ ਦਿਓ, ਫਿਰ ਇਹ ਕਮਾਂਡ ਦੁਬਾਰਾ ਚਲਾਓ।",
         "log_channel_announcement": "{channel} ਇੱਕ ਐਲਾਨ ਚੈਨਲ ਹੈ। ਹੋਰ ਸਰਵਰ ਇਸਨੂੰ ਫਾਲੋ ਕਰ ਸਕਦੇ ਹਨ, ਜਿਸ ਨਾਲ ਤੁਹਾਡੇ ਮੈਂਬਰਾਂ ਦੀ 18+ ਸਥਿਤੀ ਇਸ ਸਰਵਰ ਤੋਂ ਬਾਹਰ ਦੁਬਾਰਾ ਪ੍ਰਕਾਸ਼ਿਤ ਹੋ ਜਾਵੇਗੀ, ਇਸ ਲਈ ਇਸਨੂੰ ਤਸਦੀਕ ਲਾਗ ਵਜੋਂ ਨਹੀਂ ਵਰਤਿਆ ਜਾ ਸਕਦਾ। ਕਿਰਪਾ ਕਰਕੇ ਆਮ ਟੈਕਸਟ ਚੈਨਲ ਚੁਣੋ।",
+        "panel_color_invalid": "ਇਹ ਹੈਕਸ ਰੰਗ ਵਰਗਾ ਨਹੀਂ ਲੱਗਦਾ। `#5865F2` ਵਰਗਾ ਕੁਝ ਵਰਤੋ (ਜਾਂ ਛੋਟੇ ਰੂਪ ਵਿੱਚ `#58F`)।",
     }
 }

--- a/tests/test_branding.py
+++ b/tests/test_branding.py
@@ -184,11 +184,30 @@ class TestBuildInstructionsEmbed:
 # Storage
 # ---------------------------------------------------------------
 class TestStorage:
-    def test_no_row_is_distinct_from_a_default_row(self):
+    def test_styling_that_asks_for_nothing_stores_no_row(self):
+        """The settings view saves every page at once.
+
+        A premium server that only changed its nickname setting must not end up
+        with a row, because a row's existence costs an entitlement lookup on
+        every fleet refresh for styling that is the default anyway.
+        """
         make_server()
-        assert bot.load_panel_branding(GUILD_ID) is None
         set_branding(embed_color=None, show_icon=False)
-        assert bot.load_panel_branding(GUILD_ID) == (None, False)
+        assert bot.load_panel_branding(GUILD_ID) is None
+        with bot.session_scope() as session:
+            assert session.query(bot.InstructionPanelBranding).count() == 0
+
+    def test_clearing_a_colour_removes_the_row(self):
+        make_server()
+        set_branding(embed_color=BRAND, show_icon=False)
+        assert bot.load_panel_branding(GUILD_ID) == (BRAND, False)
+        set_branding(embed_color=None, show_icon=False)
+        assert bot.load_panel_branding(GUILD_ID) is None
+
+    def test_icon_alone_is_still_worth_a_row(self):
+        make_server()
+        set_branding(embed_color=None, show_icon=True)
+        assert bot.load_panel_branding(GUILD_ID) == (None, True)
 
     def test_saving_twice_updates_rather_than_duplicates(self):
         make_server()

--- a/tests/test_branding.py
+++ b/tests/test_branding.py
@@ -1,0 +1,547 @@
+"""Unit tests for the premium branded instructions panel (issue #58).
+
+Two properties carry most of the weight here.
+
+The first is that the posted panel and the refreshed panel must never disagree.
+They are built by the same function from the same resolved style, and the embed
+builder is a pure function of its arguments so that stays provable rather than
+merely intended.
+
+The second is that a lapsed subscription reverts to the default look. The panel
+is a persisted Discord message, so "revert" means something has to re-edit it —
+the styling is resolved at edit time, never cached alongside the panel.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import discord
+import pytest
+
+import bot
+
+GUILD_ID = "987654321"
+OWNER_ID = "77"
+CHANNEL_ID = "555000222"
+MESSAGE_ID = "555000333"
+SKU_ID = 555000111
+OLD_ID = 100
+NEW_ID = 5000
+LINE = 820
+
+BRAND = 0x5865F2
+ICON_URL = "https://cdn.discordapp.com/icons/987654321/abc.png"
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def make_server(server_id=GUILD_ID, row_id=OLD_ID, with_panel=True, **overrides):
+    fields = dict(
+        id=row_id,
+        server_id=server_id,
+        owner_id=OWNER_ID,
+        role_id="1",
+        instructions_locale="en-US",
+    )
+    if with_panel:
+        fields["instructions_channel_id"] = CHANNEL_ID
+        fields["instructions_message_id"] = MESSAGE_ID
+    fields.update(overrides)
+    with bot.session_scope() as session:
+        session.add(bot.Server(**fields))
+
+
+def set_branding(server_id=GUILD_ID, embed_color=BRAND, show_icon=True):
+    bot.save_panel_branding(server_id, embed_color, show_icon)
+
+
+def draw_line(max_server_id=LINE):
+    with bot.session_scope() as session:
+        session.query(bot.PremiumGrandfatherLine).delete()
+        session.add(bot.PremiumGrandfatherLine(id=1, max_server_id=max_server_id))
+
+
+class FakeGuild:
+    """Just enough guild for the thumbnail lookup."""
+
+    def __init__(self, icon_url=ICON_URL):
+        self.id = int(GUILD_ID)
+        self.icon = SimpleNamespace(url=icon_url) if icon_url else None
+
+
+@pytest.fixture(autouse=True)
+def clean_db():
+    def wipe():
+        with bot.session_scope() as session:
+            session.query(bot.Server).delete()
+            session.query(bot.User).delete()
+            session.query(bot.InstructionPanelBranding).delete()
+            session.query(bot.PremiumGrandfatherLine).delete()
+
+    wipe()
+    bot.premium_status_cache.clear()
+    draw_line()
+    yield
+    wipe()
+    bot.premium_status_cache.clear()
+
+
+@pytest.fixture
+def enforced(monkeypatch):
+    monkeypatch.setattr(bot, "PREMIUM_SKU_ID", SKU_ID)
+    monkeypatch.setattr(bot, "PREMIUM_ENFORCED", True)
+    bot.premium_status_cache.clear()
+
+
+@pytest.fixture
+def premium(monkeypatch, enforced):
+    """Guild resolves as subscribed without any Discord round trip."""
+
+    async def yes(guild_id):
+        return True
+
+    monkeypatch.setattr(bot, "guild_has_premium", yes)
+    bot.premium_status_cache.clear()
+
+
+# ---------------------------------------------------------------
+# Hex parsing
+# ---------------------------------------------------------------
+class TestParseHexColor:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("#5865F2", 0x5865F2),
+            ("5865F2", 0x5865F2),
+            ("0x5865F2", 0x5865F2),
+            ("#5865f2", 0x5865F2),
+            ("  #5865F2  ", 0x5865F2),
+            ("#58F", 0x5588FF),
+            ("#FFFFFF", 0xFFFFFF),
+        ],
+    )
+    def test_accepted_forms(self, raw, expected):
+        assert bot.parse_hex_color(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["", "   ", "#12345", "#1234567", "nope", "#GGGGGG", "12 34 56", None],
+    )
+    def test_rejected_forms(self, raw):
+        assert bot.parse_hex_color(raw) is None
+
+    def test_black_is_nudged_so_discord_renders_it(self):
+        """Discord treats 0 as "no colour" and shows the default grey sidebar.
+
+        A server asking for black would look like it had been ignored, so the
+        value is moved to the darkest colour Discord will actually render.
+        """
+        assert bot.parse_hex_color("#000000") == bot.NEAREST_RENDERABLE_BLACK
+        assert bot.parse_hex_color("#000000") != 0
+
+
+# ---------------------------------------------------------------
+# The embed builder stays a pure function
+# ---------------------------------------------------------------
+class TestBuildInstructionsEmbed:
+    def test_defaults_to_blue_with_no_thumbnail(self):
+        embed = bot.build_instructions_embed("en-US")
+        assert embed.color == bot.DEFAULT_PANEL_COLOR
+        assert embed.thumbnail.url is None
+
+    def test_applies_colour_and_thumbnail(self):
+        embed = bot.build_instructions_embed(
+            "en-US", discord.Color(BRAND), ICON_URL
+        )
+        assert embed.color == discord.Color(BRAND)
+        assert embed.thumbnail.url == ICON_URL
+
+    def test_the_instruction_copy_never_changes(self):
+        """Styling is customisable; the wording is not, deliberately."""
+        plain = bot.build_instructions_embed("en-US")
+        styled = bot.build_instructions_embed(
+            "en-US", discord.Color(BRAND), ICON_URL
+        )
+        assert styled.title == plain.title
+        assert styled.description == plain.description
+        assert [(f.name, f.value) for f in styled.fields] == [
+            (f.name, f.value) for f in plain.fields
+        ]
+
+    def test_it_reads_no_database(self, monkeypatch):
+        """A pure builder is what keeps the two call sites honest."""
+
+        def boom():
+            raise AssertionError("build_instructions_embed touched the database")
+
+        monkeypatch.setattr(bot, "session_scope", boom)
+        bot.build_instructions_embed("en-US", discord.Color(BRAND), ICON_URL)
+
+
+# ---------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------
+class TestStorage:
+    def test_no_row_is_distinct_from_a_default_row(self):
+        make_server()
+        assert bot.load_panel_branding(GUILD_ID) is None
+        set_branding(embed_color=None, show_icon=False)
+        assert bot.load_panel_branding(GUILD_ID) == (None, False)
+
+    def test_saving_twice_updates_rather_than_duplicates(self):
+        make_server()
+        set_branding(embed_color=BRAND, show_icon=True)
+        set_branding(embed_color=0x00FF00, show_icon=False)
+        assert bot.load_panel_branding(GUILD_ID) == (0x00FF00, False)
+        with bot.session_scope() as session:
+            assert session.query(bot.InstructionPanelBranding).count() == 1
+
+    def test_a_read_failure_falls_back_to_defaults(self, monkeypatch):
+        def boom():
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(bot, "session_scope", boom)
+        assert bot.load_panel_branding(GUILD_ID) is None
+
+
+# ---------------------------------------------------------------
+# Style resolution and gating
+# ---------------------------------------------------------------
+class TestPanelStyle:
+    def test_premium_gets_its_colour_and_icon(self):
+        style = bot.panel_style((BRAND, True), FakeGuild(), allowed=True)
+        assert style == (discord.Color(BRAND), ICON_URL)
+
+    def test_not_allowed_reverts_to_the_default_look(self):
+        style = bot.panel_style((BRAND, True), FakeGuild(), allowed=False)
+        assert style == (bot.DEFAULT_PANEL_COLOR, None)
+
+    def test_no_branding_row_is_the_default_look(self):
+        style = bot.panel_style(None, FakeGuild(), allowed=True)
+        assert style == (bot.DEFAULT_PANEL_COLOR, None)
+
+    def test_icon_off_keeps_the_colour(self):
+        style = bot.panel_style((BRAND, False), FakeGuild(), allowed=True)
+        assert style == (discord.Color(BRAND), None)
+
+    def test_a_guild_with_no_icon_yields_no_thumbnail(self):
+        """Discord rejects an empty thumbnail url, so this must not be set."""
+        style = bot.panel_style((BRAND, True), FakeGuild(icon_url=None), allowed=True)
+        assert style == (discord.Color(BRAND), None)
+
+    def test_a_missing_guild_yields_no_thumbnail(self):
+        style = bot.panel_style((BRAND, True), None, allowed=True)
+        assert style == (discord.Color(BRAND), None)
+
+    def test_no_stored_colour_keeps_the_default_blue(self):
+        style = bot.panel_style((None, True), FakeGuild(), allowed=True)
+        assert style == (bot.DEFAULT_PANEL_COLOR, ICON_URL)
+
+
+class TestResolvePanelStyle:
+    def test_ungated_while_the_tier_is_off(self):
+        make_server()
+        set_branding()
+        style = run(bot.resolve_panel_style(GUILD_ID, FakeGuild()))
+        assert style == (discord.Color(BRAND), ICON_URL)
+
+    def test_premium_guild_keeps_its_branding(self, premium):
+        make_server(row_id=NEW_ID)
+        set_branding()
+        style = run(bot.resolve_panel_style(GUILD_ID, FakeGuild()))
+        assert style == (discord.Color(BRAND), ICON_URL)
+
+    def test_free_guild_reverts(self, enforced, monkeypatch):
+        async def no(guild_id):
+            return False
+
+        monkeypatch.setattr(bot, "guild_has_premium", no)
+        make_server(row_id=NEW_ID)
+        set_branding()
+        style = run(bot.resolve_panel_style(GUILD_ID, FakeGuild()))
+        assert style == (bot.DEFAULT_PANEL_COLOR, None)
+
+    def test_grandfathered_does_not_get_it(self, enforced, monkeypatch):
+        """New feature, so nobody is losing anything by not being included."""
+
+        async def no(guild_id):
+            return False
+
+        monkeypatch.setattr(bot, "guild_has_premium", no)
+        make_server(row_id=OLD_ID)  # inside the grandfather line
+        set_branding()
+        assert bot.is_grandfathered(GUILD_ID) is True
+        style = run(bot.resolve_panel_style(GUILD_ID, FakeGuild()))
+        assert style == (bot.DEFAULT_PANEL_COLOR, None)
+
+    def test_it_is_not_a_grandfathered_feature(self):
+        assert bot.FEATURE_BRANDED_PANEL not in bot.GRANDFATHERED_FEATURES
+
+    def test_no_branding_row_skips_the_entitlement_read(self, enforced, monkeypatch):
+        """The fleet refresh would otherwise be one lookup per panel."""
+
+        async def boom(guild_id):
+            raise AssertionError("resolved entitlements for an unbranded guild")
+
+        monkeypatch.setattr(bot, "guild_has_premium", boom)
+        make_server(row_id=NEW_ID)
+        style = run(bot.resolve_panel_style(GUILD_ID, FakeGuild()))
+        assert style == (bot.DEFAULT_PANEL_COLOR, None)
+
+
+# ---------------------------------------------------------------
+# The panel is a persisted message, so styling has to be re-applied
+# ---------------------------------------------------------------
+class PanelRecorder:
+    """Stands in for the Discord HTTP layer and records panel edits."""
+
+    def __init__(self):
+        self.edits = []
+
+    def install(self, monkeypatch):
+        monkeypatch.setattr(
+            bot.bot, "get_partial_messageable", self._messageable
+        )
+        monkeypatch.setattr(bot.bot, "get_guild", lambda gid: FakeGuild())
+        return self
+
+    def _messageable(self, channel_id, **kwargs):
+        return SimpleNamespace(
+            get_partial_message=lambda message_id: SimpleNamespace(edit=self._edit)
+        )
+
+    async def _edit(self, **payload):
+        self.edits.append(payload)
+
+    @property
+    def last_embed(self):
+        return self.edits[-1]["embed"]
+
+
+class TestRestylePanel:
+    def test_it_re_edits_the_panel_with_current_styling(self, monkeypatch, premium):
+        make_server(row_id=NEW_ID)
+        set_branding()
+        rec = PanelRecorder().install(monkeypatch)
+
+        assert run(bot.restyle_instruction_panel(GUILD_ID)) == "ok"
+
+        assert len(rec.edits) == 1
+        assert rec.last_embed.color == discord.Color(BRAND)
+        assert rec.last_embed.thumbnail.url == ICON_URL
+
+    def test_a_lapse_reverts_the_live_panel(self, monkeypatch, enforced):
+        """The whole point of resolving style at edit time."""
+
+        async def no(guild_id):
+            return False
+
+        monkeypatch.setattr(bot, "guild_has_premium", no)
+        make_server(row_id=NEW_ID)
+        set_branding()
+        rec = PanelRecorder().install(monkeypatch)
+
+        run(bot.restyle_instruction_panel(GUILD_ID))
+
+        assert rec.last_embed.color == bot.DEFAULT_PANEL_COLOR
+        assert rec.last_embed.thumbnail.url is None
+
+    def test_the_stored_choice_survives_the_lapse(self, monkeypatch, enforced):
+        """Reverting the look must not discard what the admin picked."""
+
+        async def no(guild_id):
+            return False
+
+        monkeypatch.setattr(bot, "guild_has_premium", no)
+        make_server(row_id=NEW_ID)
+        set_branding()
+        PanelRecorder().install(monkeypatch)
+
+        run(bot.restyle_instruction_panel(GUILD_ID))
+
+        assert bot.load_panel_branding(GUILD_ID) == (BRAND, True)
+
+    def test_a_guild_with_no_panel_is_a_no_op(self, monkeypatch, premium):
+        make_server(row_id=NEW_ID, with_panel=False)
+        set_branding()
+        rec = PanelRecorder().install(monkeypatch)
+
+        assert run(bot.restyle_instruction_panel(GUILD_ID)) == "no_panel"
+        assert rec.edits == []
+
+    def test_it_never_raises(self, monkeypatch, premium):
+        """It runs after a save that already succeeded; it must not undo that."""
+        make_server(row_id=NEW_ID)
+        set_branding()
+
+        async def boom(entry, rebuild_embed):
+            raise RuntimeError("discord is down")
+
+        monkeypatch.setattr(bot, "probe_instruction_panel", boom)
+        assert run(bot.restyle_instruction_panel(GUILD_ID)) == "error"
+
+
+class TestBothCallSitesAgree:
+    def test_posted_and_refreshed_panels_match(self, monkeypatch, premium):
+        """A refreshed panel must look exactly like a freshly posted one.
+
+        They go through one builder from one resolved style, so this is the
+        test that the issue's "keep it that way" requirement still holds.
+        """
+        make_server(row_id=NEW_ID)
+        set_branding()
+        rec = PanelRecorder().install(monkeypatch)
+
+        run(bot.restyle_instruction_panel(GUILD_ID))
+        refreshed = rec.last_embed
+
+        # What /vrcverify_instructions builds, with the same resolved style.
+        branding = bot.load_panel_branding(GUILD_ID)
+        color, icon = bot.panel_style(branding, FakeGuild(), allowed=True)
+        posted = bot.build_instructions_embed("en-US", color, icon)
+
+        assert refreshed.to_dict() == posted.to_dict()
+
+
+# ---------------------------------------------------------------
+# Settings page
+# ---------------------------------------------------------------
+class TestSettingsBrandingPage:
+    PAGE = bot.SETTINGS_LAST_PAGE
+
+    def build(self, premium_flag, grandfathered, page=None, **kwargs):
+        return bot.PagedSettingsView(
+            True,
+            "en-US",
+            True,
+            auto_verify_available=True,
+            page_index=self.PAGE if page is None else page,
+            premium=bot.PremiumFlags(
+                premium=premium_flag, grandfathered=grandfathered
+            ),
+            **kwargs,
+        )
+
+    def test_free_server_sees_it_locked_with_an_upgrade_button(self, enforced):
+        view = self.build(False, False)
+        assert view._page_locked() is True
+        select = next(i for i in view.children if isinstance(i, discord.ui.Select))
+        assert select.disabled is True
+        assert any(getattr(i, "sku_id", None) == SKU_ID for i in view.children)
+
+    def test_grandfathered_does_not_unlock_it(self, enforced):
+        """Not in GRANDFATHERED_FEATURES, so being old is not enough."""
+        assert self.build(False, True)._page_locked() is True
+
+    def test_premium_unlocks_it(self, enforced):
+        view = self.build(True, False)
+        assert view._page_locked() is False
+        select = next(i for i in view.children if isinstance(i, discord.ui.Select))
+        assert select.disabled is False
+
+    def test_the_colour_button_is_disabled_when_locked(self, enforced):
+        view = self.build(False, False)
+        buttons = [
+            i
+            for i in view.children
+            if isinstance(i, discord.ui.Button) and i.label == "Set colour"
+        ]
+        assert len(buttons) == 1
+        assert buttons[0].disabled is True
+
+    def test_next_is_disabled_on_the_last_page(self, enforced):
+        view = self.build(True, False)
+        nxt = next(
+            i
+            for i in view.children
+            if isinstance(i, discord.ui.Button) and i.label == "Next"
+        )
+        assert nxt.disabled is True
+
+    def test_earlier_pages_can_still_page_forward(self, enforced):
+        """Adding a page must not leave Next dead on the old last page."""
+        view = self.build(True, False, page=2)
+        nxt = next(
+            i
+            for i in view.children
+            if isinstance(i, discord.ui.Button) and i.label == "Next"
+        )
+        assert nxt.disabled is False
+
+    def test_it_reports_the_current_values(self, enforced):
+        content = self.build(True, False, embed_color=BRAND, show_icon=True).render_content()
+        assert "#5865F2" in content
+        assert "Show server icon: Yes" in content
+
+    def test_it_reports_the_default_when_no_colour_is_set(self, enforced):
+        content = self.build(True, False).render_content()
+        assert "Default blue" in content
+
+    def test_paging_carries_the_branding_values(self, enforced):
+        view = self.build(True, False, embed_color=BRAND, show_icon=True)
+        moved = view._rebuilt(0)
+        assert moved.embed_color == BRAND
+        assert moved.show_icon is True
+
+    def test_the_clear_button_only_appears_when_a_colour_is_set(self, enforced):
+        def labels(view):
+            return [
+                i.label for i in view.children if isinstance(i, discord.ui.Button)
+            ]
+
+        assert "Use default colour" not in labels(self.build(True, False))
+        assert "Use default colour" in labels(
+            self.build(True, False, embed_color=BRAND)
+        )
+
+    def test_the_page_is_registered_as_premium_gated(self):
+        assert bot.SETTINGS_PAGE_FEATURE[self.PAGE] == bot.FEATURE_BRANDED_PANEL
+
+
+# ---------------------------------------------------------------
+# Entitlement events keep the live panel honest
+# ---------------------------------------------------------------
+class TestEntitlementEvents:
+    def test_a_branded_guild_gets_its_panel_restyled(self, monkeypatch):
+        make_server(row_id=NEW_ID)
+        set_branding()
+        called = []
+        monkeypatch.setattr(
+            bot, "restyle_instruction_panel", lambda gid: called.append(gid)
+        )
+        monkeypatch.setattr(
+            bot.asyncio, "create_task", lambda coro: coro
+        )
+
+        bot._note_entitlement_change(
+            SimpleNamespace(guild_id=int(GUILD_ID)), "updated"
+        )
+        assert called == [int(GUILD_ID)]
+
+    def test_an_unbranded_guild_is_left_alone(self, monkeypatch):
+        """Nothing to change, so there is no reason to spend an edit."""
+        make_server(row_id=NEW_ID)
+        called = []
+        monkeypatch.setattr(
+            bot, "restyle_instruction_panel", lambda gid: called.append(gid)
+        )
+        monkeypatch.setattr(bot.asyncio, "create_task", lambda coro: coro)
+
+        bot._note_entitlement_change(
+            SimpleNamespace(guild_id=int(GUILD_ID)), "updated"
+        )
+        assert called == []
+
+    def test_a_user_scoped_entitlement_is_ignored(self, monkeypatch):
+        make_server(row_id=NEW_ID)
+        set_branding()
+        called = []
+        monkeypatch.setattr(
+            bot, "restyle_instruction_panel", lambda gid: called.append(gid)
+        )
+        monkeypatch.setattr(bot.asyncio, "create_task", lambda coro: coro)
+
+        bot._note_entitlement_change(SimpleNamespace(guild_id=None), "created")
+        assert called == []

--- a/tests/test_branding.py
+++ b/tests/test_branding.py
@@ -612,10 +612,7 @@ class TestEntitlementEvents:
         set_branding()
         called = []
         monkeypatch.setattr(
-            bot, "restyle_instruction_panel", lambda gid: called.append(gid)
-        )
-        monkeypatch.setattr(
-            bot.asyncio, "create_task", lambda coro: coro
+            bot, "schedule_panel_restyle", lambda gid: called.append(gid)
         )
 
         bot._note_entitlement_change(
@@ -628,9 +625,8 @@ class TestEntitlementEvents:
         make_server(row_id=NEW_ID)
         called = []
         monkeypatch.setattr(
-            bot, "restyle_instruction_panel", lambda gid: called.append(gid)
+            bot, "schedule_panel_restyle", lambda gid: called.append(gid)
         )
-        monkeypatch.setattr(bot.asyncio, "create_task", lambda coro: coro)
 
         bot._note_entitlement_change(
             SimpleNamespace(guild_id=int(GUILD_ID)), "updated"
@@ -645,9 +641,8 @@ class TestEntitlementEvents:
             bot, "load_panel_branding", lambda gid: bot.BRANDING_UNREADABLE
         )
         monkeypatch.setattr(
-            bot, "restyle_instruction_panel", lambda gid: called.append(gid)
+            bot, "schedule_panel_restyle", lambda gid: called.append(gid)
         )
-        monkeypatch.setattr(bot.asyncio, "create_task", lambda coro: coro)
 
         bot._note_entitlement_change(
             SimpleNamespace(guild_id=int(GUILD_ID)), "updated"
@@ -659,9 +654,39 @@ class TestEntitlementEvents:
         set_branding()
         called = []
         monkeypatch.setattr(
-            bot, "restyle_instruction_panel", lambda gid: called.append(gid)
+            bot, "schedule_panel_restyle", lambda gid: called.append(gid)
         )
-        monkeypatch.setattr(bot.asyncio, "create_task", lambda coro: coro)
 
         bot._note_entitlement_change(SimpleNamespace(guild_id=None), "created")
         assert called == []
+
+
+class TestScheduledRestyleSurvives:
+    """asyncio only weakly references a running task.
+
+    A bare create_task() can be collected mid-flight, so the panel edit would
+    silently never happen. The task has to be held until it finishes.
+    """
+
+    def test_the_task_is_held_until_it_completes(self, monkeypatch, premium):
+        make_server(row_id=NEW_ID)
+        set_branding()
+        PanelRecorder().install(monkeypatch)
+
+        async def scenario():
+            bot._restyle_tasks.clear()
+            bot.schedule_panel_restyle(GUILD_ID)
+            # Referenced while in flight, which is what stops the collection.
+            assert len(bot._restyle_tasks) == 1
+            task = next(iter(bot._restyle_tasks))
+            await task
+            # And released once done, so the set cannot grow without bound.
+            assert bot._restyle_tasks == set()
+
+        asyncio.run(scenario())
+
+    def test_no_event_loop_is_not_an_error(self, monkeypatch):
+        """Called from sync code, there is nothing to schedule onto."""
+        bot._restyle_tasks.clear()
+        bot.schedule_panel_restyle(GUILD_ID)  # must not raise
+        assert bot._restyle_tasks == set()

--- a/tests/test_branding.py
+++ b/tests/test_branding.py
@@ -217,12 +217,15 @@ class TestStorage:
         with bot.session_scope() as session:
             assert session.query(bot.InstructionPanelBranding).count() == 1
 
-    def test_a_read_failure_falls_back_to_defaults(self, monkeypatch):
+    def test_a_read_failure_is_not_reported_as_no_branding(self, monkeypatch):
+        """"Couldn't tell" has to stay distinct from "definitely nothing"."""
+
         def boom():
             raise RuntimeError("db down")
 
         monkeypatch.setattr(bot, "session_scope", boom)
-        assert bot.load_panel_branding(GUILD_ID) is None
+        assert bot.load_panel_branding(GUILD_ID) is bot.BRANDING_UNREADABLE
+        assert bot.load_panel_branding(GUILD_ID) is not None
 
 
 # ---------------------------------------------------------------
@@ -297,6 +300,12 @@ class TestResolvePanelStyle:
 
     def test_it_is_not_a_grandfathered_feature(self):
         assert bot.FEATURE_BRANDED_PANEL not in bot.GRANDFATHERED_FEATURES
+
+    def test_unreadable_branding_declines_to_answer(self, enforced, monkeypatch):
+        monkeypatch.setattr(
+            bot, "load_panel_branding", lambda gid: bot.BRANDING_UNREADABLE
+        )
+        assert run(bot.resolve_panel_style(GUILD_ID, FakeGuild())) is None
 
     def test_no_branding_row_skips_the_entitlement_read(self, enforced, monkeypatch):
         """The fleet refresh would otherwise be one lookup per panel."""
@@ -381,6 +390,27 @@ class TestRestylePanel:
         run(bot.restyle_instruction_panel(GUILD_ID))
 
         assert bot.load_panel_branding(GUILD_ID) == (BRAND, True)
+
+    def test_an_unreadable_table_leaves_the_panel_untouched(
+        self, monkeypatch, premium
+    ):
+        """A database blip must not restyle a paying server back to default.
+
+        The view is still refreshed — that is what the pass is for — but no
+        embed goes in the payload, so the panel keeps the look it has.
+        """
+        make_server(row_id=NEW_ID)
+        set_branding()
+        rec = PanelRecorder().install(monkeypatch)
+        monkeypatch.setattr(
+            bot, "load_panel_branding", lambda gid: bot.BRANDING_UNREADABLE
+        )
+
+        run(bot.restyle_instruction_panel(GUILD_ID))
+
+        assert len(rec.edits) == 1
+        assert "embed" not in rec.edits[0]
+        assert isinstance(rec.edits[0]["view"], bot.VRCVerifyInstructionView)
 
     def test_a_guild_with_no_panel_is_a_no_op(self, monkeypatch, premium):
         make_server(row_id=NEW_ID, with_panel=False)
@@ -597,6 +627,23 @@ class TestEntitlementEvents:
         """Nothing to change, so there is no reason to spend an edit."""
         make_server(row_id=NEW_ID)
         called = []
+        monkeypatch.setattr(
+            bot, "restyle_instruction_panel", lambda gid: called.append(gid)
+        )
+        monkeypatch.setattr(bot.asyncio, "create_task", lambda coro: coro)
+
+        bot._note_entitlement_change(
+            SimpleNamespace(guild_id=int(GUILD_ID)), "updated"
+        )
+        assert called == []
+
+    def test_an_unreadable_table_buys_no_edit(self, monkeypatch):
+        make_server(row_id=NEW_ID)
+        set_branding()
+        called = []
+        monkeypatch.setattr(
+            bot, "load_panel_branding", lambda gid: bot.BRANDING_UNREADABLE
+        )
         monkeypatch.setattr(
             bot, "restyle_instruction_panel", lambda gid: called.append(gid)
         )

--- a/tests/test_branding.py
+++ b/tests/test_branding.py
@@ -79,6 +79,9 @@ def clean_db():
             session.query(bot.User).delete()
             session.query(bot.InstructionPanelBranding).delete()
             session.query(bot.PremiumGrandfatherLine).delete()
+            # Recorded panel versions leak between tests otherwise, and
+            # load_instruction_panel now reports the real one.
+            session.query(bot.InstructionPanelView).delete()
 
     wipe()
     bot.premium_status_cache.clear()
@@ -659,6 +662,36 @@ class TestEntitlementEvents:
 
         bot._note_entitlement_change(SimpleNamespace(guild_id=None), "created")
         assert called == []
+
+
+class TestSinglePanelLookup:
+    def test_it_reports_the_recorded_view_version(self):
+        """Otherwise every restyle re-records a version that already matched."""
+        make_server(row_id=NEW_ID)
+        bot.record_panel_view_version(GUILD_ID)
+        entry = bot.load_instruction_panel(GUILD_ID)
+        assert entry["view_version"] == bot.INSTRUCTIONS_VIEW_VERSION
+
+    def test_an_unrecorded_panel_reads_as_zero(self):
+        make_server(row_id=NEW_ID)
+        entry = bot.load_instruction_panel(GUILD_ID)
+        assert entry["view_version"] == 0
+
+    def test_a_restyle_does_not_rewrite_a_matching_version(self, monkeypatch, premium):
+        make_server(row_id=NEW_ID)
+        set_branding()
+        bot.record_panel_view_version(GUILD_ID)
+        PanelRecorder().install(monkeypatch)
+
+        def boom(*args, **kwargs):
+            raise AssertionError("re-recorded a version that already matched")
+
+        monkeypatch.setattr(bot, "record_panel_view_version", boom)
+        assert run(bot.restyle_instruction_panel(GUILD_ID)) == "ok"
+
+    def test_a_guild_with_no_panel_reads_as_none(self):
+        make_server(row_id=NEW_ID, with_panel=False)
+        assert bot.load_instruction_panel(GUILD_ID) is None
 
 
 class TestScheduledRestyleSurvives:

--- a/tests/test_branding.py
+++ b/tests/test_branding.py
@@ -519,6 +519,60 @@ class TestSettingsBrandingPage:
         assert bot.SETTINGS_PAGE_FEATURE[self.PAGE] == bot.FEATURE_BRANDED_PANEL
 
 
+class TestSaveOrdering:
+    """Discord gives three seconds to acknowledge an interaction.
+
+    Editing the panel is a real HTTP call and message edits are rate limited
+    per channel, so it has to happen after the reply or a 429 turns a
+    successful save into "This interaction failed" for the admin.
+    """
+
+    def build_and_save(self, monkeypatch, premium_flag=True):
+        order = []
+
+        async def fake_restyle(guild_id):
+            order.append("panel_edit")
+            return "ok"
+
+        monkeypatch.setattr(bot, "restyle_instruction_panel", fake_restyle)
+
+        async def fake_response(**kwargs):
+            order.append("reply")
+
+        interaction = SimpleNamespace(
+            guild=SimpleNamespace(id=int(GUILD_ID)),
+            user=SimpleNamespace(id=int(OWNER_ID)),
+            locale="en-US",
+            response=SimpleNamespace(edit_message=fake_response),
+        )
+
+        view = bot.PagedSettingsView(
+            True,
+            "en-US",
+            True,
+            auto_verify_available=True,
+            page_index=bot.SETTINGS_LAST_PAGE,
+            premium=bot.PremiumFlags(premium=premium_flag, grandfathered=False),
+            embed_color=BRAND,
+            show_icon=True,
+        )
+        save = next(
+            i
+            for i in view.children
+            if isinstance(i, discord.ui.Button) and i.label == "Save"
+        )
+        run(save.callback(interaction))
+        return order
+
+    def test_the_reply_comes_before_the_panel_edit(self, monkeypatch, enforced):
+        make_server(row_id=NEW_ID)
+        assert self.build_and_save(monkeypatch) == ["reply", "panel_edit"]
+
+    def test_a_free_server_edits_no_panel(self, monkeypatch, enforced):
+        make_server(row_id=NEW_ID)
+        assert self.build_and_save(monkeypatch, premium_flag=False) == ["reply"]
+
+
 # ---------------------------------------------------------------
 # Entitlement events keep the live panel honest
 # ---------------------------------------------------------------

--- a/tests/test_instruction_refresh.py
+++ b/tests/test_instruction_refresh.py
@@ -494,11 +494,11 @@ class TestFleetIsolation:
         real = bot.build_instructions_embed
         seen = []
 
-        def build(locale):
+        def build(locale, *args, **kwargs):
             seen.append(locale)
             if len(seen) == 1:
                 raise ValueError("bad embed")
-            return real(locale)
+            return real(locale, *args, **kwargs)
 
         monkeypatch.setattr(bot, "build_instructions_embed", build)
 


### PR DESCRIPTION
Closes #58. Part of #46. Last item in the premium bundle.

Six commits: the feature, then five fixes from an adversarial review of it, each separately reviewable.

## The feature

Page 4 of `/vrcverify_settings` lets a premium server set its own embed colour and show its server icon as the instructions panel thumbnail. Both default to off, so subscribing does not restyle a panel the admin never asked to restyle.

**The instruction copy is not customisable**, per the issue's hard boundary. It is the part that actually gets people through verification correctly, and letting servers rewrite it means support requests about instructions nobody here wrote.

`build_instructions_embed` stays a pure function of its arguments — no database, no entitlement reads. Styling is resolved by the caller and handed in, which is what keeps the posted panel and the refreshed panel provably identical rather than merely intended to match. A test asserts the two produce byte-identical embeds.

**Lapse reverts because styling is resolved at edit time**, never stored with the panel. But a panel is a persisted Discord message, so something has to re-edit it — the startup refresh runs with `rebuild_embed=False`, so otherwise a change would not surface until an operator triggered a full refresh, potentially months. The bot re-edits on save and on entitlement changes. Firing on renewals *and* cancellations is deliberate: the event only means "re-resolve", and the resolver decides, so a subscription cancelled but not yet expired correctly keeps its styling.

Guilds with no branding row skip the entitlement read entirely, so the fleet refresh does not become one REST lookup per panel.

### Interface notes

Colour is a hex modal because **Discord has no colour-picker component of any kind** — the full component set is buttons, selects, text inputs and layout containers. A select could only offer a fixed palette, which is no use to a server with a real brand colour. `#000000` is nudged to `#010101`, because Discord reads a colour of 0 as "no colour" and would render the default grey, making the request look ignored.

The thumbnail is the guild's own icon rather than an arbitrary URL: nothing to validate, and no way for a server to put unrelated imagery inside an age-verification panel.

## Review fixes

**1. Branding rows that ask for nothing are no longer stored.** The settings view saves every page at once, so any premium server that touched an unrelated setting got a "default colour, no icon" row. No visible effect, but enough to make `resolve_panel_style` do an entitlement lookup for that guild on every fleet refresh — eroding the short-circuit above for exactly the servers most worth keeping cheap.

**2. The save reply now precedes the panel edit.** Editing the panel is a real HTTP call and message edits are rate limited per channel; discord.py sleeps through a 429, which can push the reply past the three seconds Discord allows. The admin would be told the interaction failed even though the save and the restyle both worked.

**3. An unreadable branding table leaves the panel alone.** `load_panel_branding` returned `None` for both "no branding" and "the read failed", so a database blip during a fleet refresh actively re-edited a paying server's panel back to plain blue — taking something away because we could not tell, the opposite of how `is_grandfathered` and the entitlement cache behave. A read failure is now its own answer and the refresh omits the embed, keeping whatever the panel has.

This also fixed a latent crash: `/vrcverify_settings` used `or (None, False)` against what became a truthy sentinel, which would have raised on unpack.

**4. The background restyle task is held until it finishes.** asyncio keeps only a weak reference to a running task, so the bare `create_task` could be collected mid-flight and the edit would silently never happen. The coroutine is also closed when there is no loop to schedule it on.

**5. `load_instruction_panel` reports the real view version** instead of a hardcoded `0`, which made every restyle re-record a version that already matched. The value written was correct, just redundant.

## Verification

676 tests pass (+69). New `tests/test_branding.py`.

Mutation-tested in two passes — 16 guards for the feature, 14 for the fixes, all caught. Notably three of the original 16 went `SKIP (anchor x0)` after the fixes moved their code; a skip is not a pass, so they were re-anchored and re-confirmed rather than left silently retired.

Two things I distrusted enough to read discord.py's source rather than assume, both fine: class-level `TextInput` is deepcopied per modal instance (so one server's colour cannot leak as another's placeholder), and `edit_message` is explicitly valid from a modal-submit interaction.

## Deployment

No migration to run — `create_all()` adds `instruction_panel_branding` on next start, and no existing table is altered. No new environment variables. Behaviour is unchanged for every server until an admin opts in, and the page is premium-gated, so this is inert for free and grandfathered servers.

## Known limitations, both deliberate

- A server that changes its Discord icon keeps the old thumbnail until its panel is next refreshed; the URL is baked into the message.
- The settings page text is English-only, matching the rest of that view. Only the hex validation error is localised, across all 12 locales.
