### PR TITLE
Add the bot's internal API for the web dashboard, inert by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,6 +135,50 @@ LOG_LEVEL=INFO
 # REST_CACHE_MAX=10000
 # REST_CONCURRENCY=8
 
+# --- Internal API for the web dashboard (bot.py, issue #65) ---
+# THIS IS THE KILL SWITCH. Leave it unset and no socket is ever opened — the
+# bot behaves exactly as it did before the dashboard existed. That is why this
+# code can ship and deploy long before the VPS is ready.
+#
+# It is the first inbound surface this project has, so before setting it read
+# the deployment rules below; they are requirements, not suggestions.
+# BOT_API_ENABLED=1
+#
+# The address to listen on. REQUIRED when enabled, and it must be the tailnet
+# address — the API refuses to start on 0.0.0.0, ::, or a blank value rather
+# than quietly listening on every interface. Never publish this port in
+# docker-compose, and never open it in the host firewall.
+# BOT_API_BIND=100.64.0.2
+# BOT_API_PORT=5002
+#
+# mTLS. Generate all of these with scripts/gen_bot_api_certs.sh (or .ps1) and
+# read that file's header for the rotation procedure. The bot demands a client
+# certificate on every connection even though the traffic is already inside
+# Tailscale: the tunnel is a segmentation control, not an authentication one.
+# BOT_API_CERT=/certs/bot-api.pem
+# BOT_API_KEY=/certs/bot-api.key
+# BOT_API_CA=/certs/ca.pem
+# Pins WHICH certificate from that CA may call in. Set it — without it, any
+# leaf the CA ever signs is accepted.
+# BOT_API_CLIENT_CN=vrcverify-dashboard
+#
+# Shared secret signing the per-request tokens that name the acting Discord
+# user, the target guild and the operation. Must be IDENTICAL on the bot and
+# the dashboard, at least 32 characters, and generated randomly:
+#   python -c "import secrets; print(secrets.token_urlsafe(48))"
+# The bot refuses to start with a shorter one.
+# BOT_API_TOKEN_SIGNING_KEY=
+#
+# Token lifetime and permitted clock drift, in seconds. Both are deliberately
+# small: together they bound how long a captured request stays replayable.
+# BOT_API_TOKEN_TTL=30
+# BOT_API_CLOCK_SKEW=5
+#
+# Request budgets. Per signed-in Discord user, and across everyone at once.
+# BOT_API_RATE_LIMIT=60
+# BOT_API_RATE_WINDOW=60
+# BOT_API_GLOBAL_RATE_LIMIT=600
+
 # --- docker-compose.deploy.yml only (not read by bot.py directly) ---
 # Pinned image tag to deploy; docker-compose.deploy.yml refuses to run
 # without it (never "latest" — see that file's header comment).

--- a/.env.example
+++ b/.env.example
@@ -174,6 +174,13 @@ LOG_LEVEL=INFO
 # BOT_API_TOKEN_TTL=30
 # BOT_API_CLOCK_SKEW=5
 #
+# How long an Administrator verdict is trusted before the bot re-asks Discord
+# (default 15). This is how long someone keeps dashboard access after their
+# admin role is removed, so keep it short — it is deliberately NOT the same
+# cache as REST_TTL_SECONDS above, which is tuned for verification traffic at
+# 180s and would be far too long to leave an authority answer standing.
+# BOT_API_ADMIN_TTL=15
+#
 # Request budgets. Per signed-in Discord user, and across everyone at once.
 # BOT_API_RATE_LIMIT=60
 # BOT_API_RATE_WINDOW=60

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Shell scripts are written on Windows but run on the Linux deploy host, where
+# CRLF line endings produce "bad interpreter: /bin/bash^M" and the script never
+# runs. Pin them to LF so this does not depend on each clone's core.autocrlf.
+*.sh text eol=lf
+
+# PowerShell scripts are the Windows-side counterparts.
+*.ps1 text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,10 @@ cython_debug/
 # Local security audit notes (never commit)
 SECURITY_AUDIT.md
 
+# VPS provisioning runbook — names the real host, firewall layout and tailnet
+# addresses. Same reasoning as the audit above: the repo is public.
+VPS_RUNBOOK.md
+
 # Bot API mTLS material (scripts/gen_bot_api_certs.*). The private keys are
 # what the whole dashboard trust chain rests on, and ca.key can mint a client
 # the bot will trust. Broad on purpose — none of these may ever be committed.

--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,15 @@ cython_debug/
 # Local security audit notes (never commit)
 SECURITY_AUDIT.md
 
+# Bot API mTLS material (scripts/gen_bot_api_certs.*). The private keys are
+# what the whole dashboard trust chain rests on, and ca.key can mint a client
+# the bot will trust. Broad on purpose — none of these may ever be committed.
+certs/
+*.key
+*.pem
+*.csr
+*.srl
+
 # VRChat session cookie store (VRCHAT_SESSION_FILE) - an auth credential.
 # Broad on purpose: any of these are plausible local VRCHAT_SESSION_FILE
 # values and none of them may ever be committed.

--- a/README.md
+++ b/README.md
@@ -297,9 +297,16 @@ Three independent checks guard every request:
 2. **A scoped token**, valid for one Discord user, one guild, one operation and
    about thirty seconds, and single-use. A captured request cannot be replayed
    against a different guild or a different endpoint.
-3. **The bot's own Administrator check**, re-run on every request rather than
-   cached against a session. Losing Administrator revokes access within one
-   request. Manage Server is not enough, matching every slash command.
+3. **The bot's own Administrator check**, re-run per request against a
+   short-lived cache (`BOT_API_ADMIN_TTL`, 15s) rather than held against a
+   session — so pulling someone's admin role cuts off their dashboard access
+   within seconds, which is what you need when the role is being pulled
+   *because* an account is compromised. Manage Server is not enough, matching
+   every slash command.
+
+The server picker only answers for guilds the caller actually administers. It
+will not confirm whether the bot is in a guild you have no standing in, so a
+stolen session cannot be used to enumerate which servers run this bot.
 
 Deployment rules, all enforced or explained in `.env.example`:
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,42 @@ Two known limits, both deliberate:
 
 ---
 
+## Internal API (dashboard groundwork)
+
+Groundwork for the web dashboard in issue #65. **Off by default and off in
+production** — with `BOT_API_ENABLED` unset, `src/bot_api.py` never opens a
+socket and the bot behaves exactly as it did before this existed.
+
+When it *is* enabled, it runs inside the bot process (sharing the gateway
+cache, so it can answer questions about roles, channels and permissions without
+a second copy of anything) and serves read-only settings data to the dashboard.
+Three independent checks guard every request:
+
+1. **mTLS** against a private CA — see `scripts/gen_bot_api_certs.sh`. The
+   Tailscale tunnel it runs inside is a segmentation control, not an
+   authentication one, so the transport is authenticated in its own right.
+2. **A scoped token**, valid for one Discord user, one guild, one operation and
+   about thirty seconds, and single-use. A captured request cannot be replayed
+   against a different guild or a different endpoint.
+3. **The bot's own Administrator check**, re-run on every request rather than
+   cached against a session. Losing Administrator revokes access within one
+   request. Manage Server is not enough, matching every slash command.
+
+Deployment rules, all enforced or explained in `.env.example`:
+
+- `BOT_API_BIND` must be the tailnet address. The bot **refuses to start** on
+  `0.0.0.0`, `::` or a blank value rather than listening on every interface.
+- Never publish the port in Docker. Enabling the API means host networking —
+  the compose file explains why the alternative is worse.
+- A misconfiguration stops the API, never the bot. Verification keeps working
+  through an expired dashboard certificate; the log says so at `ERROR`.
+
+This phase is **read-only by construction**: the API is handed a set of reader
+callables and nothing else, so it cannot express a write at all.
+`tests/test_bot_api.py` pins both that and the absence of any non-GET route.
+
+---
+
 ## Tech Stack
 
 - **Language:** Python 3.12 in the current containerized deployment

--- a/config/other_configs/docker-compose.deploy.yml
+++ b/config/other_configs/docker-compose.deploy.yml
@@ -28,6 +28,35 @@ services:
       REST_TTL_SECONDS: ${REST_TTL_SECONDS:-180}
       REST_CACHE_MAX: ${REST_CACHE_MAX:-10000}
       REST_CONCURRENCY: ${REST_CONCURRENCY:-8}
+      # Internal API for the web dashboard (issue #65). Unset by default, so
+      # nothing binds. See .env.example before switching it on.
+      BOT_API_ENABLED: ${BOT_API_ENABLED:-}
+      BOT_API_BIND: ${BOT_API_BIND:-}
+      BOT_API_PORT: ${BOT_API_PORT:-5002}
+      BOT_API_CERT: ${BOT_API_CERT:-}
+      BOT_API_KEY: ${BOT_API_KEY:-}
+      BOT_API_CA: ${BOT_API_CA:-}
+      BOT_API_CLIENT_CN: ${BOT_API_CLIENT_CN:-}
+      BOT_API_TOKEN_SIGNING_KEY: ${BOT_API_TOKEN_SIGNING_KEY:-}
+    #
+    # TURNING THE API ON ALSO NEEDS THE TWO LINES BELOW UNCOMMENTED.
+    #
+    # There is deliberately no `ports:` mapping, and there should never be one.
+    # A bridged container cannot bind the host's tailnet address, so the usual
+    # workaround is to listen on 0.0.0.0 inside the container and publish it as
+    # `100.64.0.2:5002:5002`. The bot refuses to start on 0.0.0.0 precisely so
+    # that arrangement is not available: it puts one typo (a dropped IP prefix
+    # in the publish rule) between this port and the whole internet, and the
+    # container itself has no idea anything is wrong.
+    #
+    # Host networking instead means BOT_API_BIND is a real host interface and
+    # the refusal above means exactly what it says. Check DATABASE_URL and
+    # RABBITMQ_HOST before switching: on host networking, container names stop
+    # resolving and both must name a host address.
+    #
+    # network_mode: host
+    # volumes:
+    #   - ${BOT_API_CERT_DIR:-./certs}:/certs:ro
     restart: unless-stopped
 
   vrc-online-checker:

--- a/config/other_configs/requirements-bot.txt
+++ b/config/other_configs/requirements-bot.txt
@@ -3,3 +3,8 @@ python-dotenv==1.2.2
 SQLAlchemy==2.0.51
 psycopg2-binary==2.9.12
 pika==1.4.2
+# Pinned explicitly even though discord.py already pulls it in: since issue #65
+# this also serves the internal API's TLS listener, and a security-relevant
+# version should not be decided by whatever discord.py's range happens to
+# resolve to on the next image build.
+aiohttp==3.14.1

--- a/docker/Dockerfile-bot
+++ b/docker/Dockerfile-bot
@@ -17,6 +17,10 @@ RUN useradd --create-home --uid 10001 appuser
 COPY --chown=appuser:appuser src/ ./src/
 USER appuser
 
+# The internal API the web dashboard reads settings through (issue #65).
+# Documentation only: nothing binds this port unless BOT_API_ENABLED is set,
+# and when it is, BOT_API_BIND must name the tailnet address — the API refuses
+# to start on a wildcard. Do NOT publish this port to the host.
 EXPOSE 5002
 
 CMD ["python", "src/bot.py"]

--- a/scripts/gen_bot_api_certs.ps1
+++ b/scripts/gen_bot_api_certs.ps1
@@ -1,0 +1,112 @@
+# Issues the certificates the bot API and the dashboard authenticate each other
+# with (issue #65). A direct port of gen_bot_api_certs.sh — read that one for
+# why a private CA exists at all, and for the rotation procedure. Keep the two
+# in step if you change either.
+#
+# Needs openssl on PATH. Git for Windows ships one; if `openssl` is not found,
+# add C:\Program Files\Git\usr\bin to PATH for this session.
+#
+# USAGE
+#   .\scripts\gen_bot_api_certs.ps1 -Host 100.64.0.2
+#   .\scripts\gen_bot_api_certs.ps1 -Host vrcverify-bot.tailnet-name.ts.net -OutDir .\certs
+
+[CmdletBinding()]
+param(
+    # The name or tailnet IP the dashboard will connect to. Must match
+    # BOT_API_BIND and the host in BOT_API_URL, or the handshake fails on
+    # hostname verification.
+    [Parameter(Mandatory = $true)]
+    [string]$ApiHost,
+
+    [string]$OutDir = ".\certs"
+)
+
+$ErrorActionPreference = "Stop"
+
+# Git for Windows' openssl.exe is an MSYS program, so it rewrites any argument
+# starting with "/" into a Windows path — "/CN=VRCVerify Internal CA" would
+# arrive as "C:/Program Files/Git/CN=..." and be rejected as a malformed
+# subject. This disables that rewriting for the child processes below.
+$env:MSYS_NO_PATHCONV = "1"
+
+if (-not (Get-Command openssl -ErrorAction SilentlyContinue)) {
+    Write-Host "openssl was not found on PATH."
+    Write-Host "Try: `$env:PATH += ';C:\Program Files\Git\usr\bin'"
+    exit 1
+}
+
+# An IP needs an IP SAN, a name needs a DNS SAN. Getting this wrong is the
+# single most common reason an otherwise correct mTLS setup refuses to connect.
+if ($ApiHost -match '^\d+\.\d+\.\d+\.\d+$') {
+    $san = "IP:$ApiHost"
+} else {
+    $san = "DNS:$ApiHost"
+}
+
+if (-not (Test-Path $OutDir)) { New-Item -ItemType Directory -Path $OutDir | Out-Null }
+Push-Location $OutDir
+
+try {
+    Write-Host "==> Certificate authority"
+    if (Test-Path ca.key) {
+        Write-Host "    ca.key exists; reusing it (rotating leaves only)."
+    } else {
+        openssl genrsa -out ca.key 4096
+        openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 `
+            -subj "/CN=VRCVerify Internal CA" -out ca.pem
+    }
+
+    Write-Host "==> Server certificate for the bot API ($san)"
+    $serverExt = New-TemporaryFile
+    @(
+        "subjectAltName=$san",
+        "extendedKeyUsage=serverAuth",
+        "basicConstraints=CA:FALSE"
+    ) | Set-Content -Path $serverExt -Encoding ascii
+
+    openssl genrsa -out bot-api.key 4096
+    openssl req -new -key bot-api.key -subj "/CN=$ApiHost" -out bot-api.csr
+    openssl x509 -req -in bot-api.csr -CA ca.pem -CAkey ca.key -CAcreateserial `
+        -out bot-api.pem -days 825 -sha256 -extfile $serverExt
+
+    Write-Host "==> Client certificate for the dashboard"
+    # The CN here is what BOT_API_CLIENT_CN pins on the bot side. Keep them equal.
+    $clientExt = New-TemporaryFile
+    @(
+        "extendedKeyUsage=clientAuth",
+        "basicConstraints=CA:FALSE"
+    ) | Set-Content -Path $clientExt -Encoding ascii
+
+    openssl genrsa -out dashboard.key 4096
+    openssl req -new -key dashboard.key -subj "/CN=vrcverify-dashboard" -out dashboard.csr
+    openssl x509 -req -in dashboard.csr -CA ca.pem -CAkey ca.key -CAcreateserial `
+        -out dashboard.pem -days 825 -sha256 -extfile $clientExt
+
+    Remove-Item bot-api.csr, dashboard.csr, $serverExt, $clientExt -Force
+
+    Write-Host ""
+    Write-Host "Done. Files are in $(Get-Location)"
+    Write-Host ""
+    Write-Host "Homelab (.env):"
+    Write-Host "  BOT_API_CA=/certs/ca.pem"
+    Write-Host "  BOT_API_CERT=/certs/bot-api.pem"
+    Write-Host "  BOT_API_KEY=/certs/bot-api.key"
+    Write-Host "  BOT_API_CLIENT_CN=vrcverify-dashboard"
+    Write-Host ""
+    Write-Host "VPS (.env):"
+    Write-Host "  BOT_API_CA=/certs/ca.pem"
+    Write-Host "  BOT_API_CLIENT_CERT=/certs/dashboard.pem"
+    Write-Host "  BOT_API_CLIENT_KEY=/certs/dashboard.key"
+    Write-Host ""
+    Write-Host "Keep ca.key here. It is the only thing that can mint a client the"
+    Write-Host "bot will trust, and neither host ever needs it."
+    Write-Host ""
+    Write-Host "The .key files carry no ACL restriction on Windows — this machine is"
+    Write-Host "the CA host, not a deploy target. Move them over SSH, don't sync them."
+    Write-Host ""
+    Write-Host "Verify the pair before deploying:"
+    Write-Host "  openssl verify -CAfile ca.pem bot-api.pem dashboard.pem"
+}
+finally {
+    Pop-Location
+}

--- a/scripts/gen_bot_api_certs.sh
+++ b/scripts/gen_bot_api_certs.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Issues the certificates the bot API and the dashboard authenticate each other
+# with (issue #65).
+#
+# WHY A PRIVATE CA AT ALL, GIVEN TAILSCALE
+# ----------------------------------------
+# Because the tunnel is a segmentation control, not an authentication one. If
+# transport authentication came from Tailscale, then anything that ends up on
+# the tailnet — a second node, a compromised device, a misapplied ACL — can
+# talk to the bot API. With mTLS the API answers exactly one certificate, and
+# reaching the port without it gets nothing. Two independent things have to go
+# wrong instead of one.
+#
+# WHAT THIS PRODUCES
+#   ca.key / ca.pem          the CA. THE KEY NEVER LEAVES THIS MACHINE.
+#   bot-api.key / .pem       server cert, goes on the homelab host
+#   dashboard.key / .pem     client cert, goes on the IONOS VPS
+#
+# USAGE
+#   ./scripts/gen_bot_api_certs.sh <bot-api-host> [output-dir]
+#
+#   <bot-api-host> is the name or tailnet IP the dashboard will connect to, and
+#   it must match BOT_API_BIND. Pass it exactly as the dashboard will write it
+#   in BOT_API_URL, or the handshake fails on hostname verification.
+#
+# WHERE EACH FILE GOES
+#   homelab:  ca.pem, bot-api.pem, bot-api.key   -> BOT_API_CA / _CERT / _KEY
+#   VPS:      ca.pem, dashboard.pem, dashboard.key
+#                                    -> BOT_API_CA / _CLIENT_CERT / _CLIENT_KEY
+#   nowhere:  ca.key
+#
+# ROTATION
+#   Certificates below are valid for 825 days; the CA for 10 years.
+#
+#   To rotate a leaf (the normal case — a lost VPS, a suspected key leak, or
+#   just the expiry coming up), re-run this script and redeploy the affected
+#   side. The CA is unchanged, so the two ends can be updated independently and
+#   there is no window where they disagree.
+#
+#   To rotate the CA itself (only if ca.key is believed compromised): generate
+#   the new CA and both leaves, put the new ca.pem on BOTH hosts first, then
+#   swap the leaf certs, then restart. Doing it in that order means neither
+#   side is ever presented a certificate it cannot verify.
+#
+#   Revocation is deliberately not modelled. With exactly one client there is
+#   nothing a CRL would tell the bot that "reissue the CA and both leaves"
+#   doesn't say faster, and BOT_API_CLIENT_CN already pins which certificate is
+#   acceptable even if a second one exists.
+#
+set -euo pipefail
+
+# Under Git Bash / MSYS on Windows, an argument starting with "/" is rewritten
+# into a Windows path — so "/CN=VRCVerify Internal CA" reaches openssl as
+# "C:/Program Files/Git/CN=..." and it rejects the subject. Harmless anywhere
+# else, so it is set unconditionally rather than behind a platform test.
+export MSYS_NO_PATHCONV=1
+
+HOST="${1:-}"
+OUT="${2:-./certs}"
+
+if [ -z "$HOST" ]; then
+    echo "usage: $0 <bot-api-host> [output-dir]" >&2
+    echo "  e.g. $0 100.64.0.2" >&2
+    echo "       $0 vrcverify-bot.tailnet-name.ts.net" >&2
+    exit 64
+fi
+
+# An IP needs an IP SAN; a name needs a DNS SAN. Getting this wrong is the
+# single most common reason an otherwise correct mTLS setup refuses to connect.
+if [[ "$HOST" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    SAN="IP:$HOST"
+else
+    SAN="DNS:$HOST"
+fi
+
+mkdir -p "$OUT"
+cd "$OUT"
+
+umask 077  # keys are created unreadable to anyone else, from the start
+
+echo "==> Certificate authority"
+if [ -f ca.key ]; then
+    echo "    ca.key exists; reusing it (rotating leaves only)."
+else
+    openssl genrsa -out ca.key 4096
+    openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 \
+        -subj "/CN=VRCVerify Internal CA" -out ca.pem
+fi
+
+# Real files rather than <(...) process substitution: under Git Bash the latter
+# hands openssl.exe a /dev/fd/63 path a Windows binary cannot open.
+trap 'rm -f server.ext client.ext bot-api.csr dashboard.csr' EXIT
+
+printf 'subjectAltName=%s\nextendedKeyUsage=serverAuth\nbasicConstraints=CA:FALSE\n' "$SAN" > server.ext
+printf 'extendedKeyUsage=clientAuth\nbasicConstraints=CA:FALSE\n' > client.ext
+
+echo "==> Server certificate for the bot API ($SAN)"
+openssl genrsa -out bot-api.key 4096
+openssl req -new -key bot-api.key -subj "/CN=$HOST" -out bot-api.csr
+openssl x509 -req -in bot-api.csr -CA ca.pem -CAkey ca.key -CAcreateserial \
+    -out bot-api.pem -days 825 -sha256 -extfile server.ext
+
+echo "==> Client certificate for the dashboard"
+# The CN here is what BOT_API_CLIENT_CN pins on the bot side. Keep them equal.
+openssl genrsa -out dashboard.key 4096
+openssl req -new -key dashboard.key -subj "/CN=vrcverify-dashboard" -out dashboard.csr
+openssl x509 -req -in dashboard.csr -CA ca.pem -CAkey ca.key -CAcreateserial \
+    -out dashboard.pem -days 825 -sha256 -extfile client.ext
+chmod 600 ./*.key
+
+echo
+echo "Done. Files are in $(pwd)"
+echo
+echo "Homelab (.env):"
+echo "  BOT_API_CA=/certs/ca.pem"
+echo "  BOT_API_CERT=/certs/bot-api.pem"
+echo "  BOT_API_KEY=/certs/bot-api.key"
+echo "  BOT_API_CLIENT_CN=vrcverify-dashboard"
+echo
+echo "VPS (.env):"
+echo "  BOT_API_CA=/certs/ca.pem"
+echo "  BOT_API_CLIENT_CERT=/certs/dashboard.pem"
+echo "  BOT_API_CLIENT_KEY=/certs/dashboard.key"
+echo
+echo "Keep ca.key here. It is the only thing that can mint a client the bot"
+echo "will trust, and neither host ever needs it."
+echo
+echo "Verify the pair before deploying:"
+echo "  openssl verify -CAfile ca.pem bot-api.pem dashboard.pem"

--- a/src/bot.py
+++ b/src/bot.py
@@ -501,6 +501,18 @@ class _TTLCache:
 _member_fetch_cache = _TTLCache(REST_CACHE_MAX, REST_TTL_SECONDS)
 _rest_semaphore = asyncio.Semaphore(REST_CONCURRENCY)
 
+# Dashboard Administrator verdicts, cached separately from the member fetches
+# above and for far less time. 180 seconds is the right answer for the
+# verification path, where a slightly stale member costs nothing; it is the
+# wrong answer for an authority check, because it is also how long a demoted
+# admin would keep configuring the server after their role was pulled.
+#
+# 15s keeps a settings page (four API calls) to one lookup while making
+# revocation effectively immediate. Set 0 to expire entries as fast as the
+# clock allows, paying a REST call per check.
+BOT_API_ADMIN_TTL = _int_env("BOT_API_ADMIN_TTL", 15, minimum=0)
+_admin_check_cache = _TTLCache(REST_CACHE_MAX, BOT_API_ADMIN_TTL)
+
 async def fetch_member_cached(guild: discord.Guild, user_id: int) -> discord.Member | None:
     if not guild:
         return None
@@ -4379,10 +4391,19 @@ async def dashboard_is_admin(guild_id, user_id) -> bool:
     Deliberately not derived from the `permissions` field Discord handed the
     dashboard at login: that describes the user's guilds as of their last OAuth
     round trip, and an admin demoted since then would keep working until their
-    session expired. This asks the gateway, on every request.
+    session expired.
+
+    It also deliberately does NOT use fetch_member_cached. That cache serves
+    the verification hot path at REST_TTL_SECONDS (180s by default), and
+    reusing it here would mean a demoted admin — or a compromised account
+    someone is busy locking out — kept dashboard access for up to three
+    minutes. Revoking an admin role is the *first* thing anyone does during an
+    incident, so that is exactly the window that must not be three minutes.
+    BOT_API_ADMIN_TTL (15s) bounds it instead, and it is a separate cache so
+    tuning one workload can never silently widen the other.
 
     Owner first because it needs no member at all — `guild.owner_id` is always
-    cached, an owner always has Administrator, and it saves a REST fetch on the
+    cached, an owner always has Administrator, and it saves a REST call on the
     single most common case.
     """
     try:
@@ -4392,14 +4413,28 @@ async def dashboard_is_admin(guild_id, user_id) -> bool:
         member_id = int(user_id)
         if member_id == guild.owner_id:
             return True
-        # MemberCacheFlags is none() here, so get_member usually misses and the
-        # TTL-cached fetch is what actually answers.
-        member = guild.get_member(member_id) or await fetch_member_cached(
-            guild, member_id
-        )
+
+        key = (guild.id, member_id)
+        cached = _admin_check_cache.get(key)
+        if cached is not None:
+            return bool(cached.allowed)
+
+        # The gateway cache first: it is free, and GUILD_MEMBER_UPDATE keeps it
+        # current. MemberCacheFlags is none() here so it usually misses, which
+        # is why the fetch below is the path that normally answers.
+        member = guild.get_member(member_id)
         if member is None:
-            return False
-        return bool(member.guild_permissions.administrator)
+            async with _rest_semaphore:
+                try:
+                    member = await guild.fetch_member(member_id)
+                except discord.NotFound:
+                    member = None
+
+        allowed = bool(member is not None and member.guild_permissions.administrator)
+        # Only the verdict is cached, not the member. A stale Member object is
+        # a permission answer waiting to be recomputed wrongly somewhere else.
+        _admin_check_cache.set(key, SimpleNamespace(allowed=allowed))
+        return allowed
     except Exception:
         # Fail closed. An unanswerable authority question is a "no".
         logger.warning(
@@ -4409,6 +4444,51 @@ async def dashboard_is_admin(guild_id, user_id) -> bool:
             exc_info=True,
         )
         return False
+
+
+async def dashboard_admin_guilds(user_id, guild_ids) -> Optional[list]:
+    """Narrow a caller's own guild list to the ones they administer.
+
+    The picker's data source. Presence is checked first because it is free and
+    because it throws away most of the work: an id the bot has never joined
+    costs nothing and, importantly, is reported identically to a guild the
+    caller simply does not administer. The caller cannot tell those two apart,
+    which is the whole point — see handle_list_guilds in bot_api.py for what
+    went wrong when this endpoint answered on presence alone.
+    """
+    try:
+        member_id = int(user_id)
+        candidates = []
+        for guild_id in guild_ids:
+            try:
+                candidate = int(guild_id)
+            except (TypeError, ValueError):
+                continue
+            if bot.get_guild(candidate) is not None:
+                candidates.append(candidate)
+
+        if not candidates:
+            return []
+
+        # Concurrently, but every fetch inside dashboard_is_admin still passes
+        # through _rest_semaphore, so this cannot outrun the REST budget the
+        # rest of the bot shares.
+        verdicts = await asyncio.gather(
+            *(dashboard_is_admin(candidate, member_id) for candidate in candidates),
+            return_exceptions=True,
+        )
+        return [
+            candidate
+            for candidate, allowed in zip(candidates, verdicts)
+            if allowed is True
+        ]
+    except Exception:
+        logger.warning(
+            "Could not resolve the dashboard guild list for user %s.",
+            user_id,
+            exc_info=True,
+        )
+        return None
 
 
 async def read_dashboard_settings(guild_id) -> Optional[dict]:
@@ -4621,6 +4701,7 @@ def build_bot_api_deps() -> bot_api.BotAPIDeps:
         is_ready=bot.is_ready,
         guild_present=dashboard_guild_present,
         is_admin=dashboard_is_admin,
+        read_admin_guilds=dashboard_admin_guilds,
         read_settings=read_dashboard_settings,
         read_roles=read_dashboard_roles,
         read_channels=read_dashboard_channels,

--- a/src/bot.py
+++ b/src/bot.py
@@ -35,6 +35,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone, timedelta
 from dotenv import load_dotenv
 from locales import localizations, LANGUAGE_CODES
+import bot_api
 
 
 # --- Localization Helpers ---
@@ -535,6 +536,12 @@ class VRCVerifyBot(discord.Client):
         # Sync slash commands to the server
         await self.tree.sync()
 
+    async def close(self):
+        # Stop listening before the gateway goes away, so the dashboard gets a
+        # refused connection rather than requests the bot can no longer answer.
+        await stop_bot_api()
+        await super().close()
+
 
 bot = VRCVerifyBot()
 
@@ -633,6 +640,65 @@ FEATURE_BRANDED_PANEL = "branded_panel"
 # The reduced cooldown and the activity log are new, so nobody is losing them.
 GRANDFATHERED_FEATURES = frozenset(
     {FEATURE_UNVERIFIED_ROLE_REMOVAL, FEATURE_NICKNAME_SYNC, FEATURE_CUSTOM_DM}
+)
+
+
+class SettingsField:
+    """One configurable setting, and exactly how its plan gate behaves.
+
+    Gating in this bot bites in two different places, and the difference is not
+    an accident:
+
+    * `auto_nickname_change` and the panel branding are refused at *save* time —
+      PagedSettingsView disables the control and deliberately leaves the stored
+      value untouched, so an admin who subscribes later gets their original
+      choice back.
+    * `unverified_role_id` and the custom DM are saved by anyone. /vrcverify_setup
+      stores an unverified role for a free server quite happily; the gate is in
+      assign_role, which simply doesn't act on it.
+
+    A dashboard that guessed would end up stricter than the bot on two settings
+    and admins would find the website refusing to show them something they can
+    plainly set with a slash command. So the difference is written down here,
+    once, and both the API and (later) the write path read it from here.
+
+    `write_locked` says whether an unavailable feature blocks the save.
+    `active` — feature allowed right now — is what the "not active on your plan"
+    badge keys off, and it is reported for locked and unlocked fields alike.
+    """
+
+    def __init__(self, name: str, feature: Optional[str], write_locked: bool):
+        self.name = name
+        self.feature = feature
+        self.write_locked = write_locked
+
+    def state(self, flags: "PremiumFlags") -> dict:
+        active = self.feature is None or flags.allows(self.feature)
+        return {
+            "feature": self.feature,
+            "active": active,
+            "locked": bool(self.write_locked and not active),
+        }
+
+
+# The complete set of settings the dashboard may ever see or set. An explicit
+# allowlist rather than "whatever columns exist": the API cannot express
+# "update an arbitrary row" if it only knows about these.
+SETTINGS_FIELDS = (
+    SettingsField("role_id", None, write_locked=False),
+    SettingsField(
+        "unverified_role_id", FEATURE_UNVERIFIED_ROLE_REMOVAL, write_locked=False
+    ),
+    # Never gated, for anyone, ever. See the note above the FEATURE_ constants.
+    SettingsField("auto_verify_new_members", None, write_locked=False),
+    SettingsField("auto_nickname_change", FEATURE_NICKNAME_SYNC, write_locked=True),
+    SettingsField(
+        "custom_verification_requested_message", FEATURE_CUSTOM_DM, write_locked=False
+    ),
+    SettingsField("instructions_locale", None, write_locked=False),
+    SettingsField("panel_embed_color", FEATURE_BRANDED_PANEL, write_locked=True),
+    SettingsField("panel_show_icon", FEATURE_BRANDED_PANEL, write_locked=True),
+    SettingsField("verification_log_channel_id", FEATURE_ACTIVITY_LOG, write_locked=True),
 )
 
 # The grandfather line is drawn on the servers table's autoincrementing primary
@@ -4292,6 +4358,323 @@ async def watch_update_trigger_file(path: str = None, poll_interval: int = 5):
 background_tasks = {}
 
 
+# -------------------------------------------------------------------
+# Dashboard API (issue #65)
+# -------------------------------------------------------------------
+# The readers the web dashboard is allowed to reach, and nothing else. They
+# take and return plain data so src/bot_api.py never has to touch a discord.py
+# object, a session, or a model — see the module docstring there for why that
+# separation is a security control rather than a style preference.
+def dashboard_guild_present(guild_id) -> bool:
+    """Is the bot in this guild? A cache lookup; never a REST call."""
+    try:
+        return bot.get_guild(int(guild_id)) is not None
+    except (TypeError, ValueError):
+        return False
+
+
+async def dashboard_is_admin(guild_id, user_id) -> bool:
+    """The authority check, answered by the bot and nobody else.
+
+    Deliberately not derived from the `permissions` field Discord handed the
+    dashboard at login: that describes the user's guilds as of their last OAuth
+    round trip, and an admin demoted since then would keep working until their
+    session expired. This asks the gateway, on every request.
+
+    Owner first because it needs no member at all — `guild.owner_id` is always
+    cached, an owner always has Administrator, and it saves a REST fetch on the
+    single most common case.
+    """
+    try:
+        guild = bot.get_guild(int(guild_id))
+        if guild is None:
+            return False
+        member_id = int(user_id)
+        if member_id == guild.owner_id:
+            return True
+        # MemberCacheFlags is none() here, so get_member usually misses and the
+        # TTL-cached fetch is what actually answers.
+        member = guild.get_member(member_id) or await fetch_member_cached(
+            guild, member_id
+        )
+        if member is None:
+            return False
+        return bool(member.guild_permissions.administrator)
+    except Exception:
+        # Fail closed. An unanswerable authority question is a "no".
+        logger.warning(
+            "Could not resolve dashboard admin rights for user %s in guild %s.",
+            user_id,
+            guild_id,
+            exc_info=True,
+        )
+        return False
+
+
+async def read_dashboard_settings(guild_id) -> Optional[dict]:
+    """Every setting in SETTINGS_FIELDS, with its plan state resolved.
+
+    Returns None when the answer can't be trusted, which the API turns into a
+    503 rather than into a page showing defaults an admin never chose.
+    """
+    try:
+        flags = await resolve_premium_flags(guild_id)
+
+        # Same guard /vrcverify_settings uses: the column post-dates some
+        # deployments and a missing one must not break the whole read.
+        has_auto_verify = server_has_column("auto_verify_new_members")
+
+        with session_scope() as session:
+            srv = (
+                session.query(Server)
+                .filter_by(server_id=panel_view_key(guild_id))
+                .first()
+            )
+            if srv is None:
+                values = {
+                    "role_id": None,
+                    "unverified_role_id": None,
+                    "auto_verify_new_members": True,
+                    "auto_nickname_change": False,
+                    "custom_verification_requested_message": None,
+                    "instructions_locale": "en-US",
+                }
+            else:
+                raw_auto_verify = getattr(srv, "auto_verify_new_members", None)
+                values = {
+                    "role_id": srv.role_id,
+                    "unverified_role_id": getattr(srv, "unverified_role_id", None),
+                    "auto_verify_new_members": (
+                        True if raw_auto_verify is None else bool(raw_auto_verify)
+                    ),
+                    "auto_nickname_change": bool(srv.auto_nickname_change),
+                    "custom_verification_requested_message": (
+                        srv.custom_verification_requested_message
+                    ),
+                    "instructions_locale": srv.instructions_locale or "en-US",
+                }
+
+        branding = load_panel_branding(guild_id)
+        if branding is BRANDING_UNREADABLE:
+            # Showing "default blue, no icon" for a server that chose otherwise
+            # would be a lie, and the step-6 write path would then save the lie
+            # back. Refuse the read instead, exactly as restyle does.
+            return None
+        embed_color, show_icon = branding if isinstance(branding, tuple) else (None, False)
+        values["panel_embed_color"] = embed_color
+        values["panel_show_icon"] = bool(show_icon)
+        values["verification_log_channel_id"] = load_log_channel_id(guild_id)
+
+        return {
+            "guild_id": str(guild_id),
+            "premium": {
+                "enforced": PREMIUM_ENFORCED,
+                "premium": flags.premium,
+                "grandfathered": flags.grandfathered,
+            },
+            # A column the deployed database is missing is reported as such
+            # rather than silently rendered as a working toggle.
+            "auto_verify_column_present": has_auto_verify,
+            "fields": {
+                field.name: {"value": values.get(field.name), **field.state(flags)}
+                for field in SETTINGS_FIELDS
+            },
+        }
+    except Exception:
+        logger.warning(
+            "Could not read dashboard settings for guild %s.", guild_id, exc_info=True
+        )
+        return None
+
+
+async def read_dashboard_roles(guild_id) -> Optional[list]:
+    """This guild's roles, with whether the bot could actually grant each one.
+
+    `assignable` is new information. Today an unassignable verified role is
+    only discovered when assign_role catches a Forbidden mid-verification, by
+    which point a member is already waiting — the point of putting it in the
+    picker is that the admin finds out while choosing.
+
+    It is None, not False, when `guild.me` is unavailable: "we cannot tell" and
+    "we checked and no" are different answers, and greying out every role
+    because the bot's own member object was missing would be the worse guess.
+    """
+    try:
+        guild = bot.get_guild(int(guild_id))
+        if guild is None:
+            return None
+        me = guild.me
+        top_role = me.top_role if me is not None else None
+
+        roles = []
+        for role in guild.roles:
+            if role.is_default():
+                continue  # @everyone: not a choice, never assignable
+            if top_role is None:
+                assignable = None
+            else:
+                # Managed roles belong to an integration and cannot be granted
+                # by anyone, whatever the hierarchy says.
+                assignable = bool(not role.managed and top_role > role)
+            roles.append(
+                {
+                    "id": str(role.id),
+                    "name": role.name,
+                    "position": role.position,
+                    "color": role.color.value,
+                    "managed": bool(role.managed),
+                    "assignable": assignable,
+                }
+            )
+        roles.sort(key=lambda entry: entry["position"], reverse=True)
+        return roles
+    except Exception:
+        logger.warning("Could not read roles for guild %s.", guild_id, exc_info=True)
+        return None
+
+
+async def read_dashboard_channels(guild_id) -> Optional[list]:
+    """Text channels, flagged the way /vrcverify_logchannel judges them.
+
+    `is_news` is surfaced because an announcement channel is refused outright
+    for the verification log: other servers can *follow* it, which would
+    republish an age disclosure about a named member into servers they have no
+    relationship with.
+    """
+    try:
+        guild = bot.get_guild(int(guild_id))
+        if guild is None:
+            return None
+        me = guild.me
+
+        channels = []
+        for channel in guild.text_channels:
+            if me is None:
+                can_send = None
+            else:
+                perms = channel.permissions_for(me)
+                can_send = bool(perms.view_channel and perms.send_messages)
+            channels.append(
+                {
+                    "id": str(channel.id),
+                    "name": channel.name,
+                    "category": channel.category.name if channel.category else None,
+                    "position": channel.position,
+                    "is_news": bool(channel.is_news()),
+                    "can_send": can_send,
+                }
+            )
+        channels.sort(key=lambda entry: entry["position"])
+        return channels
+    except Exception:
+        logger.warning("Could not read channels for guild %s.", guild_id, exc_info=True)
+        return None
+
+
+async def read_dashboard_panel(guild_id) -> Optional[dict]:
+    """Where this guild's instructions panel is, and whether it looks reachable.
+
+    A read only. probe_instruction_panel() would answer more precisely but it
+    *edits* the message to do it, and a page load must not rewrite a panel.
+
+    Only the channel is checked, not the message: confirming the message still
+    exists costs a REST call per page load. Note also that load_instruction_panel
+    returns None both for "never posted" and for "the database could not be
+    read", so `posted: false` is not proof no panel exists — whatever offers to
+    repost a panel in step 6 has to confirm before it posts a duplicate.
+    """
+    try:
+        entry = load_instruction_panel(guild_id)
+        if entry is None or not entry.get("channel_id"):
+            return {"posted": False}
+
+        guild = bot.get_guild(int(guild_id))
+        channel = None
+        if guild is not None:
+            try:
+                channel = guild.get_channel_or_thread(int(entry["channel_id"]))
+            except (TypeError, ValueError):
+                channel = None
+
+        reachable = None
+        if guild is not None and guild.me is not None and channel is not None:
+            perms = channel.permissions_for(guild.me)
+            reachable = bool(perms.view_channel and perms.send_messages)
+
+        return {
+            "posted": True,
+            "channel_id": str(entry["channel_id"]),
+            "message_id": str(entry["message_id"]),
+            "channel_name": getattr(channel, "name", None),
+            "channel_exists": channel is not None,
+            "channel_reachable": reachable,
+            "locale": entry.get("locale", "en-US"),
+        }
+    except Exception:
+        logger.warning("Could not read the panel for guild %s.", guild_id, exc_info=True)
+        return None
+
+
+def build_bot_api_deps() -> bot_api.BotAPIDeps:
+    """Hand the API its complete set of capabilities. All of them reads."""
+    return bot_api.BotAPIDeps(
+        is_ready=bot.is_ready,
+        guild_present=dashboard_guild_present,
+        is_admin=dashboard_is_admin,
+        read_settings=read_dashboard_settings,
+        read_roles=read_dashboard_roles,
+        read_channels=read_dashboard_channels,
+        read_panel=read_dashboard_panel,
+    )
+
+
+_bot_api_server: Optional[bot_api.BotAPIServer] = None
+
+
+async def start_bot_api() -> None:
+    """Bring the API up, if it is switched on and correctly configured.
+
+    A bad configuration stops the API, not the bot. Verification is the product
+    and it must keep working through an expired dashboard certificate — but the
+    listener never comes up in a weaker shape than intended, and the log says so
+    at ERROR rather than leaving an operator to wonder.
+    """
+    global _bot_api_server
+    if _bot_api_server is not None:
+        return  # on_ready fires again on every reconnect.
+
+    try:
+        config = bot_api.BotAPIConfig.from_env()
+    except bot_api.BotAPIConfigError as error:
+        logger.error("⚠️ Bot API is enabled but misconfigured; not starting it: %s", error)
+        return
+
+    if config is None:
+        logger.info(
+            "Bot API is disabled (BOT_API_ENABLED unset); nothing is listening."
+        )
+        return
+
+    try:
+        server = bot_api.BotAPIServer(config, build_bot_api_deps())
+        await server.start()
+        _bot_api_server = server
+    except Exception:
+        logger.error("⚠️ Bot API failed to start; continuing without it.", exc_info=True)
+
+
+async def stop_bot_api() -> None:
+    global _bot_api_server
+    if _bot_api_server is None:
+        return
+    try:
+        await _bot_api_server.stop()
+    except Exception:
+        logger.warning("Bot API did not shut down cleanly.", exc_info=True)
+    finally:
+        _bot_api_server = None
+
+
 def start_background_task(name: str, coro, run_once: bool = False):
     """Schedule `coro` under `name`, unless that task is already accounted for.
 
@@ -4374,6 +4757,11 @@ async def on_ready():
     start_background_task(
         "instructions_trigger_watcher", watch_update_trigger_file(trigger_path, poll)
     )
+
+    # The dashboard's door. Does nothing at all unless BOT_API_ENABLED is set,
+    # and awaited rather than backgrounded so a refusal to bind is reported
+    # here, in startup order, instead of surfacing later as a dead task.
+    await start_bot_api()
 
     # Panel refresh logs its own completion summary once it finishes.
     logger.info("Bot startup tasks launched and ready to go!")

--- a/src/bot_api.py
+++ b/src/bot_api.py
@@ -23,7 +23,9 @@ Three things guard every request, in this order:
 3. **The bot's own answer.** Authority never comes from the dashboard, from the
    token, or from the `permissions` field Discord handed the dashboard at login.
    It comes from asking the bot whether this user is an Administrator of this
-   guild, on every single request.
+   guild, re-checked per request against a cache with a deliberately short life
+   (`BOT_API_ADMIN_TTL`, 15s) — so revoking someone's admin role revokes their
+   dashboard access within seconds rather than whenever a session expires.
 
 The whole thing is inert unless `BOT_API_ENABLED` is set. With it unset nothing
 binds and nothing listens.
@@ -133,9 +135,15 @@ class BotAPIDeps:
     # Has the gateway connected? Answers are meaningless before it has.
     is_ready: Callable[[], bool]
     # Is the bot in this guild at all? A pure cache lookup, no REST.
+    # Used only to tell "no such guild" (404) from "not yours" (403) on the
+    # guild-scoped routes; it is never an answer on its own.
     guild_present: Callable[[int], bool]
     # The authority check. Async because an uncached member costs a fetch.
     is_admin: Callable[[int, int], Awaitable[bool]]
+    # The same check, for the picker: narrows a caller's own guild list to the
+    # ones they administer. Kept as its own reader rather than a loop over
+    # is_admin so the bot can bound the work it does in one pass.
+    read_admin_guilds: Callable[[int, list], Awaitable[Optional[list]]]
     read_settings: Callable[[int], Awaitable[Optional[dict]]]
     read_roles: Callable[[int], Awaitable[Optional[list]]]
     read_channels: Callable[[int], Awaitable[Optional[list]]]
@@ -635,19 +643,27 @@ async def handle_health(request: web.Request) -> web.Response:
 
 
 async def handle_list_guilds(request: web.Request) -> web.Response:
-    """Which of the caller's own guilds this bot is in.
+    """Which of the caller's guilds this bot is in AND the caller administers.
 
     Names and icons are NOT returned, because the dashboard already has them:
     they came from the user's OAuth guild list, which is where the picker gets
-    its tiles. All this adds is the one bit the dashboard cannot know — whether
-    the bot is present — which is what decides greyscale-with-an-invite versus a
-    link into the settings pages.
+    its tiles. All this adds is the bit the dashboard cannot know — whether the
+    bot is present — which decides greyscale-with-an-invite versus a link into
+    the settings pages.
 
-    Keeping it to that bit also keeps the endpoint cheap. Resolving names,
-    entitlements or Administrator for a user in a hundred guilds would mean a
-    hundred lookups behind one page load; the real Administrator check happens
-    on the per-guild endpoints, where it is one guild at a time and where it
-    actually gates something.
+    The Administrator filter is not decoration. An earlier version answered
+    "is the bot in this guild?" for any id the caller sent, which made this the
+    one endpoint not bounded by the bot's own authority check. Under the design
+    assumption that the public host is eventually compromised — and a
+    compromised host holds the signing key, so it can mint tokens for any
+    actor — that turned into an unbounded oracle: walk arbitrary ids and
+    enumerate every server running this bot, i.e. a census of communities
+    operating 18+ gating. Every other endpoint yields only what a real
+    administrator could already see, and this one now matches.
+
+    So the answer is never about a guild the caller has no standing in, and a
+    guild the caller does not administer is indistinguishable from one the bot
+    has never joined.
     """
     try:
         claims = await _authorize(request, guild_scoped=False)
@@ -663,15 +679,17 @@ async def handle_list_guilds(request: web.Request) -> web.Response:
     if len(candidates) > MAX_GUILD_IDS:
         return _deny(request, 400, "too_many_ids", actor=claims.actor_id)
 
-    present = []
+    guild_ids = []
     for candidate in candidates:
         try:
-            guild_id = int(candidate)
+            guild_ids.append(int(candidate))
         except ValueError:
             return _deny(request, 400, "bad_guild_id", actor=claims.actor_id)
-        if deps.guild_present(guild_id):
-            present.append(str(guild_id))
-    return _json({"present": present})
+
+    present = await deps.read_admin_guilds(claims.actor_id, guild_ids)
+    if present is None:
+        return _deny(request, 503, "unavailable", actor=claims.actor_id)
+    return _json({"present": [str(guild_id) for guild_id in present]})
 
 
 def _guild_reader(read: str):

--- a/src/bot_api.py
+++ b/src/bot_api.py
@@ -1,0 +1,770 @@
+"""The bot's internal API — the only door the web dashboard may knock on.
+
+This module is deliberately *pure*: it imports neither `bot` nor `discord` nor
+SQLAlchemy. Everything it is allowed to touch arrives as a callable on
+`BotAPIDeps`, which the bot builds and hands over at startup.
+
+That is not tidiness, it is the "least privilege on the API surface" control
+issue #65 asks for. There is no generic "write these columns" entry point here
+because there is no writer in `BotAPIDeps` at all — in this phase the API is
+structurally incapable of changing a row. Adding a write path later means
+adding a named writer to that dataclass, which is a visible, reviewable diff
+rather than a new query string someone slipped past.
+
+Three things guard every request, in this order:
+
+1. **mTLS.** The client must present a certificate signed by our own CA. The
+   Tailscale tunnel this runs inside is a segmentation control, not an
+   authentication one, so the transport is authenticated in its own right.
+2. **A scoped, short-lived token.** It names the acting Discord user, the target
+   guild and the exact operation, and it is checked against the real method and
+   path. A captured request cannot be replayed against another guild, against
+   another endpoint, or after its window.
+3. **The bot's own answer.** Authority never comes from the dashboard, from the
+   token, or from the `permissions` field Discord handed the dashboard at login.
+   It comes from asking the bot whether this user is an Administrator of this
+   guild, on every single request.
+
+The whole thing is inert unless `BOT_API_ENABLED` is set. With it unset nothing
+binds and nothing listens.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hmac
+import ipaddress
+import json
+import logging
+import os
+import secrets
+import ssl
+import time
+from dataclasses import dataclass, fields
+from hashlib import sha256
+from typing import Any, Awaitable, Callable, Optional
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+# Reusing the port the Dockerfile has always (uselessly) EXPOSEd.
+DEFAULT_PORT = 5002
+
+# Tokens are minted per request and used immediately. Thirty seconds is
+# generous for a call across a tunnel and short enough that a captured token is
+# worthless by the time anyone notices they have it.
+DEFAULT_TOKEN_TTL = 30
+# Allowance for clock drift between the VPS and the homelab. Small on purpose:
+# every second here widens the replay window at both ends.
+DEFAULT_CLOCK_SKEW = 5
+
+# An HMAC key shorter than its own digest is weaker than the primitive it feeds.
+MIN_SIGNING_KEY_BYTES = 32
+
+# Per-actor request budget. The dashboard renders a handful of calls per page,
+# so this is roughly two orders of magnitude above honest use.
+DEFAULT_RATE_LIMIT = 60
+DEFAULT_RATE_WINDOW = 60
+# A second, global bucket so one compromised session cannot saturate the bot's
+# event loop even while staying inside its own per-actor budget.
+DEFAULT_GLOBAL_RATE_LIMIT = 600
+
+# Nothing here accepts a body yet; this only has to be big enough for headers.
+MAX_REQUEST_BYTES = 16 * 1024
+
+# The picker asks about the guilds the signed-in user is already a member of.
+# Capped so a malformed or hostile query cannot turn one request into an
+# unbounded loop.
+MAX_GUILD_IDS = 200
+
+TOKEN_VERSION = "v1"
+# Scope used by the one endpoint that is about the actor rather than a guild.
+OP_LIST_GUILDS = "GET /api/v1/guilds"
+
+
+class BotAPIConfigError(RuntimeError):
+    """The API was switched on but cannot be started safely."""
+
+
+# Typed keys rather than bare strings, so a handler reaching for something the
+# app was never given fails at the lookup instead of at whatever it does with
+# the None it got back.
+CONFIG_KEY: "web.AppKey" = web.AppKey("config")
+DEPS_KEY: "web.AppKey" = web.AppKey("deps")
+REPLAY_KEY: "web.AppKey" = web.AppKey("replay")
+RATE_KEY: "web.AppKey" = web.AppKey("rate_limiter")
+GLOBAL_RATE_KEY: "web.AppKey" = web.AppKey("global_rate_limiter")
+
+
+class TokenError(Exception):
+    """A token was absent, malformed, expired, or not for this request.
+
+    `actor` is set for every failure raised *after* the signature verified, so
+    the denial log can name who minted the token. That is the difference
+    between "someone sent us garbage" and "this specific signed-in user tried
+    to reach a guild they were not scoped for" — and the second is the one
+    worth alerting on.
+    """
+
+    def __init__(self, reason: str, actor: Optional[int] = None):
+        super().__init__(reason)
+        self.reason = reason
+        self.actor = actor
+
+
+# -------------------------------------------------------------------
+# What the bot lets this module reach
+# -------------------------------------------------------------------
+@dataclass(frozen=True)
+class BotAPIDeps:
+    """The complete list of things the API can do to the bot.
+
+    Every entry is a reader. Keep it that way: `tests/test_bot_api.py` pins the
+    exact field set, so a writer cannot be added by accident.
+
+    Readers take and return plain data — ids, dicts, lists — never discord.py
+    objects. Shaping a Guild into JSON is the bot's job, not this module's,
+    which is what keeps `discord` out of the import list above and makes every
+    handler testable against a dict.
+    """
+
+    # Has the gateway connected? Answers are meaningless before it has.
+    is_ready: Callable[[], bool]
+    # Is the bot in this guild at all? A pure cache lookup, no REST.
+    guild_present: Callable[[int], bool]
+    # The authority check. Async because an uncached member costs a fetch.
+    is_admin: Callable[[int, int], Awaitable[bool]]
+    read_settings: Callable[[int], Awaitable[Optional[dict]]]
+    read_roles: Callable[[int], Awaitable[Optional[list]]]
+    read_channels: Callable[[int], Awaitable[Optional[list]]]
+    read_panel: Callable[[int], Awaitable[Optional[dict]]]
+
+
+# -------------------------------------------------------------------
+# Configuration
+# -------------------------------------------------------------------
+def _truthy(raw: Optional[str]) -> bool:
+    return (raw or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _int_env(name: str, default: int, minimum: int = 1) -> int:
+    try:
+        return max(minimum, int(os.getenv(name, str(default))))
+    except ValueError:
+        return default
+
+
+@dataclass(frozen=True)
+class BotAPIConfig:
+    bind: str
+    port: int
+    cert_path: str
+    key_path: str
+    ca_path: str
+    signing_key: bytes
+    # Optional pin on *which* client certificate is acceptable, so a second
+    # cert issued by the same CA still cannot call the API.
+    client_cn: Optional[str] = None
+    token_ttl: int = DEFAULT_TOKEN_TTL
+    clock_skew: int = DEFAULT_CLOCK_SKEW
+    rate_limit: int = DEFAULT_RATE_LIMIT
+    rate_window: int = DEFAULT_RATE_WINDOW
+    global_rate_limit: int = DEFAULT_GLOBAL_RATE_LIMIT
+
+    @staticmethod
+    def enabled() -> bool:
+        """The kill switch, read fresh so tests can flip it."""
+        return _truthy(os.getenv("BOT_API_ENABLED"))
+
+    @classmethod
+    def from_env(cls) -> Optional["BotAPIConfig"]:
+        """Build the config, or None when the API is switched off.
+
+        Raises BotAPIConfigError when it is switched *on* but misconfigured.
+        Failing loudly is the point: the alternative to "refuse to start" is a
+        listener that came up in a weaker shape than the operator intended, and
+        the whole design here assumes the tunnel is not load-bearing.
+        """
+        if not cls.enabled():
+            return None
+
+        bind = (os.getenv("BOT_API_BIND") or "").strip()
+        _validate_bind(bind)
+
+        cert_path = _require_file("BOT_API_CERT")
+        key_path = _require_file("BOT_API_KEY")
+        ca_path = _require_file("BOT_API_CA")
+
+        raw_key = (os.getenv("BOT_API_TOKEN_SIGNING_KEY") or "").strip()
+        signing_key = raw_key.encode("utf-8")
+        if len(signing_key) < MIN_SIGNING_KEY_BYTES:
+            raise BotAPIConfigError(
+                "BOT_API_TOKEN_SIGNING_KEY must be at least "
+                f"{MIN_SIGNING_KEY_BYTES} characters; refusing to start."
+            )
+
+        client_cn = (os.getenv("BOT_API_CLIENT_CN") or "").strip() or None
+
+        return cls(
+            bind=bind,
+            port=_int_env("BOT_API_PORT", DEFAULT_PORT),
+            cert_path=cert_path,
+            key_path=key_path,
+            ca_path=ca_path,
+            signing_key=signing_key,
+            client_cn=client_cn,
+            token_ttl=_int_env("BOT_API_TOKEN_TTL", DEFAULT_TOKEN_TTL),
+            clock_skew=_int_env("BOT_API_CLOCK_SKEW", DEFAULT_CLOCK_SKEW, minimum=0),
+            rate_limit=_int_env("BOT_API_RATE_LIMIT", DEFAULT_RATE_LIMIT),
+            rate_window=_int_env("BOT_API_RATE_WINDOW", DEFAULT_RATE_WINDOW),
+            global_rate_limit=_int_env(
+                "BOT_API_GLOBAL_RATE_LIMIT", DEFAULT_GLOBAL_RATE_LIMIT
+            ),
+        )
+
+
+def _validate_bind(bind: str) -> None:
+    """Refuse anything that would listen on more than one interface.
+
+    A blank or wildcard bind is the single misconfiguration that would undo the
+    entire network design — the API would answer on the VPS-facing side of
+    whatever host it lands on, and only the firewall would be left standing
+    between it and the internet. It is cheaper to not start.
+    """
+    if not bind:
+        raise BotAPIConfigError(
+            "BOT_API_BIND is required when BOT_API_ENABLED is set; it must name "
+            "the tailnet interface, never a wildcard."
+        )
+    if bind in {"*", "[::]"}:
+        raise BotAPIConfigError(f"BOT_API_BIND={bind!r} is a wildcard; refusing to start.")
+    try:
+        address = ipaddress.ip_address(bind)
+    except ValueError:
+        # A hostname (a tailnet DNS name, say). Resolution happens at bind time.
+        return
+    if address.is_unspecified:
+        raise BotAPIConfigError(
+            f"BOT_API_BIND={bind!r} listens on every interface; refusing to start. "
+            "Bind the tailnet address explicitly."
+        )
+
+
+def _require_file(name: str) -> str:
+    path = (os.getenv(name) or "").strip()
+    if not path:
+        raise BotAPIConfigError(f"{name} is required when BOT_API_ENABLED is set.")
+    if not os.path.isfile(path):
+        raise BotAPIConfigError(f"{name} points at {path!r}, which is not a file.")
+    return path
+
+
+def build_ssl_context(config: BotAPIConfig) -> ssl.SSLContext:
+    """A TLS 1.3 server context that *demands* a client certificate."""
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.minimum_version = ssl.TLSVersion.TLSv1_3
+    context.verify_mode = ssl.CERT_REQUIRED
+    context.load_verify_locations(cafile=config.ca_path)
+    context.load_cert_chain(certfile=config.cert_path, keyfile=config.key_path)
+    return context
+
+
+# -------------------------------------------------------------------
+# Scoped request tokens
+# -------------------------------------------------------------------
+def _b64encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64decode(raw: str) -> bytes:
+    padding = "=" * (-len(raw) % 4)
+    return base64.urlsafe_b64decode(raw + padding)
+
+
+def _canonical(payload: dict) -> bytes:
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def mint_token(
+    signing_key: bytes,
+    *,
+    actor_id: int,
+    operation: str,
+    guild_id: Optional[int] = None,
+    ttl: int = DEFAULT_TOKEN_TTL,
+    now: Optional[float] = None,
+) -> str:
+    """Sign one token for one call.
+
+    Lives here rather than in the dashboard so both ends share exactly one
+    implementation of the format — a signer and a verifier that drift apart is
+    the classic way an auth scheme quietly stops meaning anything.
+    """
+    issued = int(now if now is not None else time.time())
+    payload = {
+        "act": int(actor_id),
+        "gid": None if guild_id is None else int(guild_id),
+        "op": operation,
+        "iat": issued,
+        "exp": issued + int(ttl),
+        "jti": _b64encode(secrets.token_bytes(12)),
+    }
+    encoded = _b64encode(_canonical(payload))
+    signature = hmac.new(signing_key, encoded.encode("ascii"), sha256).digest()
+    return f"{TOKEN_VERSION}.{encoded}.{_b64encode(signature)}"
+
+
+@dataclass(frozen=True)
+class TokenClaims:
+    actor_id: int
+    guild_id: Optional[int]
+    operation: str
+    expires_at: int
+    jti: str
+
+
+def verify_token(
+    token: str,
+    signing_key: bytes,
+    *,
+    expected_operation: str,
+    expected_guild_id: Optional[int],
+    max_ttl: int = DEFAULT_TOKEN_TTL,
+    clock_skew: int = DEFAULT_CLOCK_SKEW,
+    now: Optional[float] = None,
+) -> TokenClaims:
+    """Authenticate a token and confirm it was minted for *this* request.
+
+    The signature is checked before the payload is parsed, so no attacker-
+    supplied JSON is ever deserialised on an unauthenticated path.
+    """
+    current = now if now is not None else time.time()
+
+    parts = token.split(".")
+    if len(parts) != 3 or parts[0] != TOKEN_VERSION:
+        raise TokenError("malformed")
+    _, encoded, signature = parts
+
+    expected_sig = hmac.new(signing_key, encoded.encode("ascii"), sha256).digest()
+    try:
+        provided_sig = _b64decode(signature)
+    except (binascii.Error, ValueError):
+        raise TokenError("malformed")
+    if not hmac.compare_digest(expected_sig, provided_sig):
+        raise TokenError("bad_signature")
+
+    try:
+        payload = json.loads(_b64decode(encoded))
+    except (binascii.Error, ValueError, UnicodeDecodeError):
+        raise TokenError("malformed")
+    if not isinstance(payload, dict):
+        raise TokenError("malformed")
+
+    try:
+        actor_id = int(payload["act"])
+        operation = payload["op"]
+        issued_at = int(payload["iat"])
+        expires_at = int(payload["exp"])
+        jti = payload["jti"]
+        raw_guild = payload["gid"]
+        guild_id = None if raw_guild is None else int(raw_guild)
+    except (KeyError, TypeError, ValueError):
+        raise TokenError("malformed")
+    if not isinstance(operation, str) or not isinstance(jti, str) or not jti:
+        raise TokenError("malformed")
+
+    # Past this point the signature has verified, so every refusal below can
+    # name the actor it was minted for.
+    if expires_at <= current - clock_skew:
+        raise TokenError("expired", actor=actor_id)
+    if issued_at > current + clock_skew:
+        raise TokenError("not_yet_valid", actor=actor_id)
+    # A token whose own window is longer than we ever issue is either a bug in
+    # the dashboard or someone minting their own with a leaked key. Neither is
+    # a request worth serving.
+    if expires_at - issued_at > max_ttl:
+        raise TokenError("ttl_too_long", actor=actor_id)
+
+    # The two checks that make interception useless: a token is good for one
+    # operation against one guild, and nothing else.
+    if operation != expected_operation:
+        raise TokenError("wrong_operation", actor=actor_id)
+    if guild_id != expected_guild_id:
+        raise TokenError("wrong_guild", actor=actor_id)
+
+    return TokenClaims(
+        actor_id=actor_id,
+        guild_id=guild_id,
+        operation=operation,
+        expires_at=expires_at,
+        jti=jti,
+    )
+
+
+class ReplayGuard:
+    """Remembers spent token ids for as long as they could still be replayed.
+
+    Expiry checking alone leaves a window the length of the token's TTL in which
+    a captured request can be sent again. This closes it.
+    """
+
+    def __init__(self, maxsize: int = 20000):
+        self.maxsize = maxsize
+        self._seen: dict[str, int] = {}
+
+    def spend(
+        self,
+        jti: str,
+        expires_at: int,
+        now: Optional[float] = None,
+        actor: Optional[int] = None,
+    ) -> None:
+        """Record a token id, or raise if it has already been used."""
+        current = now if now is not None else time.time()
+        if self._seen.get(jti, 0) > current:
+            raise TokenError("replayed", actor=actor)
+
+        # Anything already expired can never be replayed, so it is free to drop.
+        if len(self._seen) >= self.maxsize:
+            self._seen = {
+                key: exp for key, exp in self._seen.items() if exp > current
+            }
+        if len(self._seen) >= self.maxsize:
+            # Only reachable if the rate limiters have already failed. Refusing
+            # is the safe direction — evicting live entries would hand back the
+            # replay window this class exists to close.
+            raise TokenError("replay_guard_full", actor=actor)
+
+        self._seen[jti] = int(expires_at)
+
+
+class RateLimiter:
+    """A fixed-window request budget, keyed by actor and by 'everyone'."""
+
+    def __init__(self, limit: int, window: int, maxsize: int = 10000):
+        self.limit = limit
+        self.window = window
+        self.maxsize = maxsize
+        self._hits: dict[str, list[float]] = {}
+
+    def allow(self, key: str, now: Optional[float] = None) -> bool:
+        current = now if now is not None else time.time()
+        cutoff = current - self.window
+
+        hits = [stamp for stamp in self._hits.get(key, ()) if stamp > cutoff]
+        if len(hits) >= self.limit:
+            self._hits[key] = hits
+            return False
+
+        hits.append(current)
+        self._hits[key] = hits
+
+        if len(self._hits) > self.maxsize:
+            self._hits = {
+                other: stamps
+                for other, stamps in self._hits.items()
+                if any(stamp > cutoff for stamp in stamps)
+            }
+        return True
+
+
+# -------------------------------------------------------------------
+# Request authorisation
+# -------------------------------------------------------------------
+def _peer_identities(request: web.Request) -> set[str]:
+    """Every name the presented client certificate claims.
+
+    TLS has already proven the certificate is signed by our CA by the time this
+    runs; this only answers *which* of our certificates it is.
+    """
+    transport = request.transport
+    peercert = transport.get_extra_info("peercert") if transport is not None else None
+    if not peercert:
+        return set()
+
+    names = set()
+    for rdn in peercert.get("subject", ()):  # ((('commonName', 'x'),), ...)
+        for attribute, value in rdn:
+            if attribute == "commonName":
+                names.add(value)
+    for kind, value in peercert.get("subjectAltName", ()):
+        if kind in {"DNS", "IP Address"}:
+            names.add(value)
+    return names
+
+
+def _deny(request: web.Request, status: int, reason: str, actor: Any = "unknown"):
+    """Refuse a request and leave the reason in the log.
+
+    Every denial is logged. Under an assume-breach model these lines are the
+    forensic record, and a run of them is the thing worth alerting on.
+    """
+    logger.warning(
+        "bot-api DENY actor=%s guild=%s op=%s reason=%s",
+        actor,
+        request.match_info.get("guild_id", "-"),
+        _operation_for(request),
+        reason,
+    )
+    return web.json_response(
+        {"error": reason}, status=status, headers={"Cache-Control": "no-store"}
+    )
+
+
+def _operation_for(request: web.Request) -> str:
+    """The canonical `METHOD /template/path` this request resolved to.
+
+    Taken from the matched route rather than the raw URL, so the token is bound
+    to the endpoint the router actually chose — not to a string the caller
+    could dress up to look like a different one.
+    """
+    route = request.match_info.route
+    resource = route.resource
+    canonical = resource.canonical if resource is not None else request.path
+    return f"{request.method} {canonical}"
+
+
+class _Denied(Exception):
+    """Carries a ready-made refusal back out of the authorisation helper."""
+
+    def __init__(self, response: web.Response):
+        self.response = response
+
+
+async def _authorize(request: web.Request, *, guild_scoped: bool) -> TokenClaims:
+    """Run all three gates. Returns the claims, or raises _Denied."""
+    config: BotAPIConfig = request.app[CONFIG_KEY]
+    deps: BotAPIDeps = request.app[DEPS_KEY]
+    operation = _operation_for(request)
+
+    # --- The client certificate, if we are pinning one ---
+    if config.client_cn is not None:
+        if config.client_cn not in _peer_identities(request):
+            raise _Denied(_deny(request, 403, "client_certificate_not_permitted"))
+
+    # --- The token ---
+    header = request.headers.get("Authorization", "")
+    scheme, _, raw_token = header.partition(" ")
+    if scheme.lower() != "bearer" or not raw_token.strip():
+        raise _Denied(_deny(request, 401, "missing_token"))
+
+    guild_id: Optional[int] = None
+    if guild_scoped:
+        try:
+            guild_id = int(request.match_info["guild_id"])
+        except (KeyError, ValueError):
+            raise _Denied(_deny(request, 400, "bad_guild_id"))
+
+    try:
+        claims = verify_token(
+            raw_token.strip(),
+            config.signing_key,
+            expected_operation=operation,
+            expected_guild_id=guild_id,
+            max_ttl=config.token_ttl,
+            clock_skew=config.clock_skew,
+        )
+        request.app[REPLAY_KEY].spend(claims.jti, claims.expires_at, actor=claims.actor_id)
+    except TokenError as error:
+        # 401 for "this token is not valid", 403 for "this token is valid but
+        # not for this" — the second is the interesting one in the log, and it
+        # is the one that can always name an actor.
+        status = 403 if error.reason in {"wrong_operation", "wrong_guild"} else 401
+        raise _Denied(
+            _deny(
+                request,
+                status,
+                error.reason,
+                actor="unknown" if error.actor is None else error.actor,
+            )
+        )
+
+    # --- Budgets, charged to the authenticated actor ---
+    limiter: RateLimiter = request.app[RATE_KEY]
+    global_limiter: RateLimiter = request.app[GLOBAL_RATE_KEY]
+    if not limiter.allow(str(claims.actor_id)) or not global_limiter.allow("*"):
+        raise _Denied(_deny(request, 429, "rate_limited", actor=claims.actor_id))
+
+    # --- The bot's own answer ---
+    if not deps.is_ready():
+        raise _Denied(_deny(request, 503, "not_ready", actor=claims.actor_id))
+
+    if guild_scoped:
+        if not deps.guild_present(guild_id):
+            raise _Denied(_deny(request, 404, "guild_not_found", actor=claims.actor_id))
+        # Re-checked here on every request, never cached against the session:
+        # losing Administrator revokes access within one request rather than
+        # whenever the session happens to expire.
+        if not await deps.is_admin(guild_id, claims.actor_id):
+            raise _Denied(_deny(request, 403, "not_administrator", actor=claims.actor_id))
+
+    logger.info(
+        "bot-api ALLOW actor=%s guild=%s op=%s",
+        claims.actor_id,
+        guild_id if guild_id is not None else "-",
+        operation,
+    )
+    return claims
+
+
+def _json(payload: Any) -> web.Response:
+    return web.json_response(payload, headers={"Cache-Control": "no-store"})
+
+
+# -------------------------------------------------------------------
+# Handlers — every one of them a read
+# -------------------------------------------------------------------
+async def handle_health(request: web.Request) -> web.Response:
+    """Liveness, behind mTLS but not behind a token.
+
+    Deliberately says nothing about guilds, servers or members: it exists so the
+    dashboard can tell "the tunnel and the certificates are working" apart from
+    "my token is wrong", which is otherwise a miserable thing to debug.
+    """
+    deps: BotAPIDeps = request.app[DEPS_KEY]
+    config: BotAPIConfig = request.app[CONFIG_KEY]
+    if config.client_cn is not None and config.client_cn not in _peer_identities(request):
+        return _deny(request, 403, "client_certificate_not_permitted")
+    # The one endpoint with no token, so the per-actor budget cannot apply. It
+    # still gets the global one rather than being a free unmetered handler.
+    if not request.app[GLOBAL_RATE_KEY].allow("*"):
+        return _deny(request, 429, "rate_limited")
+    return _json({"ok": True, "ready": bool(deps.is_ready())})
+
+
+async def handle_list_guilds(request: web.Request) -> web.Response:
+    """Which of the caller's own guilds this bot is in.
+
+    Names and icons are NOT returned, because the dashboard already has them:
+    they came from the user's OAuth guild list, which is where the picker gets
+    its tiles. All this adds is the one bit the dashboard cannot know — whether
+    the bot is present — which is what decides greyscale-with-an-invite versus a
+    link into the settings pages.
+
+    Keeping it to that bit also keeps the endpoint cheap. Resolving names,
+    entitlements or Administrator for a user in a hundred guilds would mean a
+    hundred lookups behind one page load; the real Administrator check happens
+    on the per-guild endpoints, where it is one guild at a time and where it
+    actually gates something.
+    """
+    try:
+        claims = await _authorize(request, guild_scoped=False)
+    except _Denied as denied:
+        return denied.response
+
+    deps: BotAPIDeps = request.app[DEPS_KEY]
+    raw_ids = (request.query.get("ids") or "").strip()
+    if not raw_ids:
+        return _json({"present": []})
+
+    candidates = [chunk for chunk in raw_ids.split(",") if chunk]
+    if len(candidates) > MAX_GUILD_IDS:
+        return _deny(request, 400, "too_many_ids", actor=claims.actor_id)
+
+    present = []
+    for candidate in candidates:
+        try:
+            guild_id = int(candidate)
+        except ValueError:
+            return _deny(request, 400, "bad_guild_id", actor=claims.actor_id)
+        if deps.guild_present(guild_id):
+            present.append(str(guild_id))
+    return _json({"present": present})
+
+
+def _guild_reader(read: str):
+    """Build a handler that authorises, then returns one guild-scoped read."""
+
+    async def handler(request: web.Request) -> web.Response:
+        try:
+            claims = await _authorize(request, guild_scoped=True)
+        except _Denied as denied:
+            return denied.response
+
+        deps: BotAPIDeps = request.app[DEPS_KEY]
+        guild_id = int(request.match_info["guild_id"])
+        payload = await getattr(deps, read)(guild_id)
+        if payload is None:
+            # The guild is present (checked above), so this is the bot failing
+            # to answer rather than the caller asking about something they
+            # should not see.
+            return _deny(request, 503, "unavailable", actor=claims.actor_id)
+        return _json(payload)
+
+    handler.__name__ = f"handle_{read}"
+    return handler
+
+
+def create_app(config: BotAPIConfig, deps: BotAPIDeps) -> web.Application:
+    """Wire the routes. Every route here is a GET, and that is load-bearing."""
+    app = web.Application(client_max_size=MAX_REQUEST_BYTES)
+    app[CONFIG_KEY] = config
+    app[DEPS_KEY] = deps
+    app[REPLAY_KEY] = ReplayGuard()
+    app[RATE_KEY] = RateLimiter(config.rate_limit, config.rate_window)
+    app[GLOBAL_RATE_KEY] = RateLimiter(config.global_rate_limit, config.rate_window)
+
+    app.router.add_get("/healthz", handle_health)
+    app.router.add_get("/api/v1/guilds", handle_list_guilds)
+    app.router.add_get(
+        "/api/v1/guilds/{guild_id}/settings", _guild_reader("read_settings")
+    )
+    app.router.add_get("/api/v1/guilds/{guild_id}/roles", _guild_reader("read_roles"))
+    app.router.add_get(
+        "/api/v1/guilds/{guild_id}/channels", _guild_reader("read_channels")
+    )
+    app.router.add_get("/api/v1/guilds/{guild_id}/panel", _guild_reader("read_panel"))
+
+    app.on_response_prepare.append(_harden_response)
+    return app
+
+
+async def _harden_response(request: web.Request, response: web.StreamResponse) -> None:
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    # aiohttp advertises its version by default; there is no reason to help.
+    response.headers["Server"] = "vrcverify"
+
+
+# -------------------------------------------------------------------
+# Lifecycle
+# -------------------------------------------------------------------
+class BotAPIServer:
+    """Owns the running listener so the bot can shut it down cleanly."""
+
+    def __init__(self, config: BotAPIConfig, deps: BotAPIDeps):
+        self.config = config
+        self.deps = deps
+        self._runner: Optional[web.AppRunner] = None
+
+    async def start(self) -> None:
+        app = create_app(self.config, self.deps)
+        self._runner = web.AppRunner(app, access_log=None)
+        await self._runner.setup()
+        site = web.TCPSite(
+            self._runner,
+            host=self.config.bind,
+            port=self.config.port,
+            ssl_context=build_ssl_context(self.config),
+        )
+        await site.start()
+        logger.info(
+            "Bot API listening on %s:%s (mTLS required%s).",
+            self.config.bind,
+            self.config.port,
+            f", client CN pinned to {self.config.client_cn}"
+            if self.config.client_cn
+            else "",
+        )
+
+    async def stop(self) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()
+            self._runner = None
+
+
+def deps_field_names() -> frozenset[str]:
+    """Every capability the API has been granted. Pinned by the tests."""
+    return frozenset(field.name for field in fields(BotAPIDeps))

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -1,0 +1,1012 @@
+"""Unit tests for the bot's internal API (issue #65, step 1).
+
+This is the first inbound surface the project has ever had, on a bot whose
+database links Discord identities to VRChat accounts and 18+ status, so these
+tests are almost entirely about the ways the door can be opened by someone who
+should not be able to open it:
+
+- a token is good for one actor, one guild and one operation, once
+- authority is the bot's answer about Administrator, never the caller's claim
+- a misconfigured listener refuses to start rather than binding wider than asked
+- the phase itself is pinned: no write route and no writer capability can land
+  here without deliberately editing this file
+
+TLS is configured at the socket, not in the application, so the mTLS chain is
+verified by hand against a real listener (see the issue's step-1 checklist).
+What is testable here is that a bad configuration never reaches that point.
+"""
+
+import asyncio
+import time
+from dataclasses import fields as dataclass_fields
+from types import SimpleNamespace
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+import bot
+import bot_api
+
+GUILD_ID = 987654321
+OTHER_GUILD_ID = 123456789
+ADMIN_ID = 4242
+MEMBER_ID = 9999
+OWNER_ID = 77
+SKU_ID = 555000111
+SIGNING_KEY = b"k" * bot_api.MIN_SIGNING_KEY_BYTES
+
+SETTINGS_PATH = f"/api/v1/guilds/{GUILD_ID}/settings"
+SETTINGS_OP = "GET /api/v1/guilds/{guild_id}/settings"
+ROLES_OP = "GET /api/v1/guilds/{guild_id}/roles"
+
+
+def run(coro):
+    """Run an async helper from a sync test (no pytest-asyncio needed)."""
+    return asyncio.run(coro)
+
+
+# -------------------------------------------------------------------
+# Fakes
+# -------------------------------------------------------------------
+def make_deps(**overrides) -> bot_api.BotAPIDeps:
+    """A permissive set of readers, so each test can break exactly one thing."""
+
+    async def is_admin(guild_id, user_id):
+        return int(user_id) == ADMIN_ID
+
+    async def read_settings(guild_id):
+        return {"guild_id": str(guild_id), "fields": {}}
+
+    async def read_roles(guild_id):
+        return [{"id": "1", "name": "Verified"}]
+
+    async def read_channels(guild_id):
+        return [{"id": "2", "name": "general"}]
+
+    async def read_panel(guild_id):
+        return {"posted": False}
+
+    defaults = dict(
+        is_ready=lambda: True,
+        guild_present=lambda guild_id: int(guild_id) == GUILD_ID,
+        is_admin=is_admin,
+        read_settings=read_settings,
+        read_roles=read_roles,
+        read_channels=read_channels,
+        read_panel=read_panel,
+    )
+    defaults.update(overrides)
+    return bot_api.BotAPIDeps(**defaults)
+
+
+def make_config(**overrides) -> bot_api.BotAPIConfig:
+    base = dict(
+        bind="127.0.0.1",
+        port=0,
+        cert_path="unused-in-app-tests",
+        key_path="unused-in-app-tests",
+        ca_path="unused-in-app-tests",
+        signing_key=SIGNING_KEY,
+    )
+    base.update(overrides)
+    return bot_api.BotAPIConfig(**base)
+
+
+def token_for(operation, guild_id=GUILD_ID, actor_id=ADMIN_ID, **kwargs):
+    return bot_api.mint_token(
+        SIGNING_KEY, actor_id=actor_id, operation=operation, guild_id=guild_id, **kwargs
+    )
+
+
+def serve(scenario, *, config=None, deps=None):
+    """Run `scenario(client)` against a live (plain HTTP) instance of the app."""
+    app = bot_api.create_app(config or make_config(), deps or make_deps())
+
+    async def runner():
+        async with TestClient(TestServer(app)) as client:
+            return await scenario(client)
+
+    return asyncio.run(runner())
+
+
+async def get(client, path, token=None):
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    response = await client.get(path, headers=headers)
+    return response.status, await response.json()
+
+
+# -------------------------------------------------------------------
+# Tokens
+# -------------------------------------------------------------------
+class TestTokens:
+    def verify(self, token, **overrides):
+        kwargs = dict(
+            expected_operation=SETTINGS_OP,
+            expected_guild_id=GUILD_ID,
+        )
+        kwargs.update(overrides)
+        return bot_api.verify_token(token, SIGNING_KEY, **kwargs)
+
+    def test_round_trip(self):
+        claims = self.verify(token_for(SETTINGS_OP))
+        assert claims.actor_id == ADMIN_ID
+        assert claims.guild_id == GUILD_ID
+        assert claims.operation == SETTINGS_OP
+
+    def test_expired_token_is_rejected(self):
+        old = token_for(SETTINGS_OP, ttl=1, now=time.time() - 3600)
+        with pytest.raises(bot_api.TokenError) as error:
+            self.verify(old)
+        assert error.value.reason == "expired"
+
+    def test_token_from_the_future_is_rejected(self):
+        ahead = token_for(SETTINGS_OP, now=time.time() + 3600)
+        with pytest.raises(bot_api.TokenError) as error:
+            self.verify(ahead)
+        assert error.value.reason == "not_yet_valid"
+
+    def test_self_minted_long_lived_token_is_rejected(self):
+        """A leaked signing key must not buy a token that lasts all week."""
+        forever = token_for(SETTINGS_OP, ttl=86400)
+        with pytest.raises(bot_api.TokenError) as error:
+            self.verify(forever)
+        assert error.value.reason == "ttl_too_long"
+
+    def test_token_cannot_be_replayed_against_another_guild(self):
+        with pytest.raises(bot_api.TokenError) as error:
+            self.verify(token_for(SETTINGS_OP), expected_guild_id=OTHER_GUILD_ID)
+        assert error.value.reason == "wrong_guild"
+
+    def test_token_cannot_be_replayed_against_another_endpoint(self):
+        with pytest.raises(bot_api.TokenError) as error:
+            self.verify(token_for(ROLES_OP), expected_operation=SETTINGS_OP)
+        assert error.value.reason == "wrong_operation"
+
+    def test_tampered_payload_is_rejected(self):
+        version, payload, signature = token_for(SETTINGS_OP).split(".")
+        forged = bot_api._b64encode(
+            bot_api._canonical(
+                {
+                    "act": ADMIN_ID,
+                    "gid": GUILD_ID,
+                    "op": SETTINGS_OP,
+                    "iat": int(time.time()),
+                    "exp": int(time.time()) + 30,
+                    "jti": "forged",
+                }
+            )
+        )
+        with pytest.raises(bot_api.TokenError) as error:
+            self.verify(f"{version}.{forged}.{signature}")
+        assert error.value.reason == "bad_signature"
+
+    def test_another_key_is_rejected(self):
+        other = bot_api.mint_token(
+            b"z" * bot_api.MIN_SIGNING_KEY_BYTES,
+            actor_id=ADMIN_ID,
+            operation=SETTINGS_OP,
+            guild_id=GUILD_ID,
+        )
+        with pytest.raises(bot_api.TokenError) as error:
+            self.verify(other)
+        assert error.value.reason == "bad_signature"
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["", "nonsense", "v1.only-two", "v2.a.b", "v1.!!!.???", "v1..", "a.b.c"],
+    )
+    def test_malformed_tokens_are_rejected(self, bad):
+        with pytest.raises(bot_api.TokenError):
+            self.verify(bad)
+
+    def test_payload_is_not_parsed_before_the_signature_is_checked(self):
+        """Unauthenticated JSON must never reach json.loads()."""
+        payload = bot_api._b64encode(b'{"act": "not-an-int"}')
+        with pytest.raises(bot_api.TokenError) as error:
+            self.verify(f"v1.{payload}.{bot_api._b64encode(b'wrong')}")
+        assert error.value.reason == "bad_signature"
+
+
+class TestReplayGuard:
+    def test_a_token_id_can_only_be_spent_once(self):
+        guard = bot_api.ReplayGuard()
+        expires = time.time() + 30
+        guard.spend("abc", expires)
+        with pytest.raises(bot_api.TokenError) as error:
+            guard.spend("abc", expires)
+        assert error.value.reason == "replayed"
+
+    def test_expired_ids_stop_being_remembered(self):
+        guard = bot_api.ReplayGuard(maxsize=2)
+        guard.spend("old", time.time() - 1)
+        guard.spend("new", time.time() + 30)
+        # 'old' can no longer be replayed, so forgetting it is free.
+        guard.spend("old", time.time() + 30)
+
+    def test_a_full_guard_refuses_rather_than_forgetting(self):
+        """Evicting a live entry would hand back the window this closes."""
+        guard = bot_api.ReplayGuard(maxsize=2)
+        guard.spend("a", time.time() + 30)
+        guard.spend("b", time.time() + 30)
+        with pytest.raises(bot_api.TokenError) as error:
+            guard.spend("c", time.time() + 30)
+        assert error.value.reason == "replay_guard_full"
+
+
+class TestRateLimiter:
+    def test_budget_runs_out(self):
+        limiter = bot_api.RateLimiter(limit=3, window=60)
+        assert all(limiter.allow("actor") for _ in range(3))
+        assert not limiter.allow("actor")
+
+    def test_budgets_are_per_key(self):
+        limiter = bot_api.RateLimiter(limit=1, window=60)
+        assert limiter.allow("one")
+        assert not limiter.allow("one")
+        assert limiter.allow("two")
+
+    def test_budget_refills_as_the_window_moves(self):
+        limiter = bot_api.RateLimiter(limit=1, window=60)
+        now = time.time()
+        assert limiter.allow("actor", now=now)
+        assert not limiter.allow("actor", now=now + 1)
+        assert limiter.allow("actor", now=now + 61)
+
+
+# -------------------------------------------------------------------
+# Configuration — the listener must refuse to come up wrong
+# -------------------------------------------------------------------
+class TestConfig:
+    @pytest.fixture(autouse=True)
+    def clear_env(self, monkeypatch):
+        for name in (
+            "BOT_API_ENABLED",
+            "BOT_API_BIND",
+            "BOT_API_PORT",
+            "BOT_API_CERT",
+            "BOT_API_KEY",
+            "BOT_API_CA",
+            "BOT_API_TOKEN_SIGNING_KEY",
+            "BOT_API_CLIENT_CN",
+        ):
+            monkeypatch.delenv(name, raising=False)
+
+    def enable(self, monkeypatch, tmp_path, **overrides):
+        for name in ("cert", "key", "ca"):
+            (tmp_path / f"{name}.pem").write_text("placeholder")
+        env = {
+            "BOT_API_ENABLED": "1",
+            "BOT_API_BIND": "100.64.0.2",
+            "BOT_API_CERT": str(tmp_path / "cert.pem"),
+            "BOT_API_KEY": str(tmp_path / "key.pem"),
+            "BOT_API_CA": str(tmp_path / "ca.pem"),
+            "BOT_API_TOKEN_SIGNING_KEY": "s" * 40,
+        }
+        env.update(overrides)
+        for name, value in env.items():
+            if value is None:
+                monkeypatch.delenv(name, raising=False)
+            else:
+                monkeypatch.setenv(name, value)
+
+    def test_unset_is_the_kill_switch(self):
+        assert bot_api.BotAPIConfig.from_env() is None
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "maybe"])
+    def test_only_an_explicit_yes_switches_it_on(self, monkeypatch, value):
+        monkeypatch.setenv("BOT_API_ENABLED", value)
+        assert bot_api.BotAPIConfig.from_env() is None
+
+    def test_happy_path(self, monkeypatch, tmp_path):
+        self.enable(monkeypatch, tmp_path)
+        config = bot_api.BotAPIConfig.from_env()
+        assert config.bind == "100.64.0.2"
+        assert config.port == bot_api.DEFAULT_PORT
+        assert len(config.signing_key) >= bot_api.MIN_SIGNING_KEY_BYTES
+
+    @pytest.mark.parametrize("bind", ["0.0.0.0", "::", "*", "[::]", ""])
+    def test_a_wildcard_bind_refuses_to_start(self, monkeypatch, tmp_path, bind):
+        """The one misconfiguration that would undo the whole network design."""
+        self.enable(monkeypatch, tmp_path, BOT_API_BIND=bind)
+        with pytest.raises(bot_api.BotAPIConfigError):
+            bot_api.BotAPIConfig.from_env()
+
+    def test_a_tailnet_hostname_is_accepted(self, monkeypatch, tmp_path):
+        self.enable(monkeypatch, tmp_path, BOT_API_BIND="vrcverify.tailnet.ts.net")
+        assert bot_api.BotAPIConfig.from_env().bind == "vrcverify.tailnet.ts.net"
+
+    @pytest.mark.parametrize("missing", ["BOT_API_CERT", "BOT_API_KEY", "BOT_API_CA"])
+    def test_missing_credentials_refuse_to_start(self, monkeypatch, tmp_path, missing):
+        self.enable(monkeypatch, tmp_path, **{missing: None})
+        with pytest.raises(bot_api.BotAPIConfigError):
+            bot_api.BotAPIConfig.from_env()
+
+    def test_a_certificate_path_that_is_not_a_file_refuses_to_start(
+        self, monkeypatch, tmp_path
+    ):
+        self.enable(monkeypatch, tmp_path, BOT_API_CERT=str(tmp_path / "absent.pem"))
+        with pytest.raises(bot_api.BotAPIConfigError):
+            bot_api.BotAPIConfig.from_env()
+
+    def test_a_weak_signing_key_refuses_to_start(self, monkeypatch, tmp_path):
+        self.enable(monkeypatch, tmp_path, BOT_API_TOKEN_SIGNING_KEY="short")
+        with pytest.raises(bot_api.BotAPIConfigError):
+            bot_api.BotAPIConfig.from_env()
+
+    def test_the_ssl_context_really_loads_the_files(self, monkeypatch, tmp_path):
+        """Placeholder files must blow up, proving the chain isn't ignored."""
+        self.enable(monkeypatch, tmp_path)
+        config = bot_api.BotAPIConfig.from_env()
+        with pytest.raises(Exception):
+            bot_api.build_ssl_context(config)
+
+
+class TestStartupWiring:
+    """bot.start_bot_api never takes the bot down and never binds by accident."""
+
+    @pytest.fixture(autouse=True)
+    def no_server(self, monkeypatch):
+        monkeypatch.setattr(bot, "_bot_api_server", None)
+        monkeypatch.delenv("BOT_API_ENABLED", raising=False)
+
+    def test_disabled_starts_nothing(self, caplog):
+        with caplog.at_level("INFO"):
+            run(bot.start_bot_api())
+        assert bot._bot_api_server is None
+        assert "disabled" in caplog.text
+
+    def test_a_bad_configuration_is_loud_but_not_fatal(self, monkeypatch, caplog):
+        monkeypatch.setenv("BOT_API_ENABLED", "1")  # enabled, nothing else set
+        with caplog.at_level("ERROR"):
+            run(bot.start_bot_api())
+        assert bot._bot_api_server is None
+        assert "misconfigured" in caplog.text
+
+    def test_deps_are_wired_to_the_real_readers(self):
+        deps = bot.build_bot_api_deps()
+        assert deps.read_settings is bot.read_dashboard_settings
+        assert deps.read_roles is bot.read_dashboard_roles
+        assert deps.read_channels is bot.read_dashboard_channels
+        assert deps.read_panel is bot.read_dashboard_panel
+        assert deps.is_admin is bot.dashboard_is_admin
+
+
+# -------------------------------------------------------------------
+# The request path, end to end
+# -------------------------------------------------------------------
+class TestRequests:
+    def test_health_needs_no_token(self):
+        async def scenario(client):
+            return await get(client, "/healthz")
+
+        status, body = serve(scenario)
+        assert status == 200
+        assert body == {"ok": True, "ready": True}
+
+    def test_a_read_needs_a_token(self):
+        async def scenario(client):
+            return await get(client, SETTINGS_PATH)
+
+        status, body = serve(scenario)
+        assert status == 401
+        assert body["error"] == "missing_token"
+
+    def test_a_valid_token_gets_the_payload(self):
+        async def scenario(client):
+            return await get(client, SETTINGS_PATH, token_for(SETTINGS_OP))
+
+        status, body = serve(scenario)
+        assert status == 200
+        assert body["guild_id"] == str(GUILD_ID)
+
+    def test_a_token_for_one_guild_does_not_work_on_another(self):
+        async def scenario(client):
+            return await get(
+                client,
+                f"/api/v1/guilds/{OTHER_GUILD_ID}/settings",
+                token_for(SETTINGS_OP, guild_id=GUILD_ID),
+            )
+
+        status, body = serve(scenario)
+        assert status == 403
+        assert body["error"] == "wrong_guild"
+
+    def test_a_token_for_one_endpoint_does_not_work_on_another(self):
+        async def scenario(client):
+            return await get(client, SETTINGS_PATH, token_for(ROLES_OP))
+
+        status, body = serve(scenario)
+        assert status == 403
+        assert body["error"] == "wrong_operation"
+
+    def test_a_token_cannot_be_used_twice(self):
+        async def scenario(client):
+            token = token_for(SETTINGS_OP)
+            first = await get(client, SETTINGS_PATH, token)
+            second = await get(client, SETTINGS_PATH, token)
+            return first, second
+
+        (first_status, _), (second_status, second_body) = serve(scenario)
+        assert first_status == 200
+        assert second_status == 401
+        assert second_body["error"] == "replayed"
+
+    def test_an_expired_token_is_refused(self):
+        async def scenario(client):
+            stale = token_for(SETTINGS_OP, ttl=1, now=time.time() - 3600)
+            return await get(client, SETTINGS_PATH, stale)
+
+        status, body = serve(scenario)
+        assert status == 401
+        assert body["error"] == "expired"
+
+    def test_a_non_administrator_is_refused(self):
+        """A valid token proves who you are, never what you may do."""
+
+        async def scenario(client):
+            return await get(
+                client, SETTINGS_PATH, token_for(SETTINGS_OP, actor_id=MEMBER_ID)
+            )
+
+        status, body = serve(scenario)
+        assert status == 403
+        assert body["error"] == "not_administrator"
+
+    def test_a_guild_the_bot_is_not_in_is_a_404(self):
+        async def scenario(client):
+            return await get(
+                client,
+                f"/api/v1/guilds/{OTHER_GUILD_ID}/settings",
+                token_for(SETTINGS_OP, guild_id=OTHER_GUILD_ID),
+            )
+
+        status, body = serve(scenario)
+        assert status == 404
+        assert body["error"] == "guild_not_found"
+
+    def test_nothing_is_answered_before_the_gateway_connects(self):
+        async def scenario(client):
+            return await get(client, SETTINGS_PATH, token_for(SETTINGS_OP))
+
+        status, body = serve(scenario, deps=make_deps(is_ready=lambda: False))
+        assert status == 503
+        assert body["error"] == "not_ready"
+
+    def test_an_unreadable_setting_is_a_503_not_a_guess(self):
+        async def unreadable(guild_id):
+            return None
+
+        async def scenario(client):
+            return await get(client, SETTINGS_PATH, token_for(SETTINGS_OP))
+
+        status, body = serve(scenario, deps=make_deps(read_settings=unreadable))
+        assert status == 503
+        assert body["error"] == "unavailable"
+
+    def test_the_budget_runs_out(self):
+        async def scenario(client):
+            results = []
+            for _ in range(3):
+                results.append(await get(client, SETTINGS_PATH, token_for(SETTINGS_OP)))
+            return results
+
+        results = serve(scenario, config=make_config(rate_limit=2))
+        assert [status for status, _ in results] == [200, 200, 429]
+
+    def test_health_is_metered_too(self):
+        """The one tokenless endpoint still can't be an unmetered handler."""
+
+        async def scenario(client):
+            return [await get(client, "/healthz") for _ in range(3)]
+
+        results = serve(scenario, config=make_config(global_rate_limit=2))
+        assert [status for status, _ in results] == [200, 200, 429]
+
+    def test_responses_are_not_cacheable(self):
+        async def scenario(client):
+            response = await client.get("/healthz")
+            return dict(response.headers)
+
+        headers = serve(scenario)
+        assert headers["Cache-Control"] == "no-store"
+        assert headers["X-Content-Type-Options"] == "nosniff"
+        assert "aiohttp" not in headers.get("Server", "")
+
+    def test_a_pinned_client_certificate_is_required_when_configured(self):
+        """Plain HTTP presents no certificate, so the pin must refuse it."""
+
+        async def scenario(client):
+            return await get(client, SETTINGS_PATH, token_for(SETTINGS_OP))
+
+        status, body = serve(scenario, config=make_config(client_cn="dashboard"))
+        assert status == 403
+        assert body["error"] == "client_certificate_not_permitted"
+
+    def test_peer_identities_reads_both_subject_and_san(self):
+        request = SimpleNamespace(
+            transport=SimpleNamespace(
+                get_extra_info=lambda _: {
+                    "subject": ((("commonName", "dashboard"),),),
+                    "subjectAltName": (("DNS", "dashboard.tailnet.ts.net"),),
+                }
+            )
+        )
+        assert bot_api._peer_identities(request) == {
+            "dashboard",
+            "dashboard.tailnet.ts.net",
+        }
+
+    def test_every_denial_is_logged_with_actor_guild_and_operation(self, caplog):
+        async def scenario(client):
+            return await get(
+                client, SETTINGS_PATH, token_for(SETTINGS_OP, actor_id=MEMBER_ID)
+            )
+
+        with caplog.at_level("WARNING"):
+            serve(scenario)
+        assert f"actor={MEMBER_ID}" in caplog.text
+        assert f"guild={GUILD_ID}" in caplog.text
+        assert "reason=not_administrator" in caplog.text
+
+    def test_a_signed_token_names_its_actor_even_when_refused(self, caplog):
+        """The forensically interesting case: a real session, out of scope.
+
+        The signature verified, so we know exactly whose token this was — that
+        is the field worth alerting on, and logging 'unknown' would lose it.
+        """
+
+        async def scenario(client):
+            return await get(
+                client,
+                f"/api/v1/guilds/{OTHER_GUILD_ID}/settings",
+                token_for(SETTINGS_OP, guild_id=GUILD_ID, actor_id=MEMBER_ID),
+            )
+
+        with caplog.at_level("WARNING"):
+            serve(scenario)
+        assert f"actor={MEMBER_ID}" in caplog.text
+        assert "reason=wrong_guild" in caplog.text
+
+    def test_a_replayed_token_names_its_actor(self, caplog):
+        async def scenario(client):
+            token = token_for(SETTINGS_OP)
+            await get(client, SETTINGS_PATH, token)
+            return await get(client, SETTINGS_PATH, token)
+
+        with caplog.at_level("WARNING"):
+            serve(scenario)
+        assert f"actor={ADMIN_ID}" in caplog.text
+        assert "reason=replayed" in caplog.text
+
+    def test_an_unsigned_token_cannot_name_an_actor(self, caplog):
+        """A claim we never authenticated must not be written into the log."""
+
+        async def scenario(client):
+            return await get(client, SETTINGS_PATH, "v1.garbage.garbage")
+
+        with caplog.at_level("WARNING"):
+            serve(scenario)
+        assert "actor=unknown" in caplog.text
+
+
+class TestGuildList:
+    OP = bot_api.OP_LIST_GUILDS
+
+    def test_returns_only_the_guilds_the_bot_is_in(self):
+        async def scenario(client):
+            return await get(
+                client,
+                f"/api/v1/guilds?ids={GUILD_ID},{OTHER_GUILD_ID}",
+                bot_api.mint_token(
+                    SIGNING_KEY, actor_id=ADMIN_ID, operation=self.OP, guild_id=None
+                ),
+            )
+
+        status, body = serve(scenario)
+        assert status == 200
+        assert body == {"present": [str(GUILD_ID)]}
+
+    def test_a_guild_scoped_token_cannot_reach_it(self):
+        async def scenario(client):
+            return await get(client, "/api/v1/guilds", token_for(self.OP))
+
+        status, body = serve(scenario)
+        assert status == 403
+        assert body["error"] == "wrong_guild"
+
+    def test_an_oversized_query_is_refused(self):
+        async def scenario(client):
+            ids = ",".join(str(n) for n in range(bot_api.MAX_GUILD_IDS + 1))
+            return await get(
+                client,
+                f"/api/v1/guilds?ids={ids}",
+                bot_api.mint_token(
+                    SIGNING_KEY, actor_id=ADMIN_ID, operation=self.OP, guild_id=None
+                ),
+            )
+
+        status, body = serve(scenario)
+        assert status == 400
+        assert body["error"] == "too_many_ids"
+
+
+# -------------------------------------------------------------------
+# Pinning the phase
+# -------------------------------------------------------------------
+class TestReadOnlyPhase:
+    """Step 1 is read-only. Both guards below have to be edited on purpose."""
+
+    def test_no_route_can_change_anything(self):
+        app = bot_api.create_app(make_config(), make_deps())
+        methods = {route.method for route in app.router.routes()}
+        assert methods <= {"GET", "HEAD"}, f"a write route appeared: {methods}"
+
+    def test_the_api_holds_no_writer(self):
+        assert bot_api.deps_field_names() == frozenset(
+            {
+                "is_ready",
+                "guild_present",
+                "is_admin",
+                "read_settings",
+                "read_roles",
+                "read_channels",
+                "read_panel",
+            }
+        )
+
+    def test_every_capability_is_named_as_a_read(self):
+        for field in dataclass_fields(bot_api.BotAPIDeps):
+            assert field.name.startswith(("read_", "is_", "guild_"))
+
+
+# -------------------------------------------------------------------
+# The bot-side readers
+# -------------------------------------------------------------------
+def make_server(server_id=str(GUILD_ID), row_id=10, **overrides):
+    fields = dict(
+        id=row_id,
+        server_id=server_id,
+        owner_id=str(OWNER_ID),
+        role_id="1",
+        instructions_locale="en-US",
+    )
+    fields.update(overrides)
+    with bot.session_scope() as session:
+        session.add(bot.Server(**fields))
+
+
+class FakeRole:
+    def __init__(self, role_id, name, position, managed=False, default=False):
+        self.id = role_id
+        self.name = name
+        self.position = position
+        self.managed = managed
+        self.color = SimpleNamespace(value=0x5865F2)
+        self._default = default
+
+    def is_default(self):
+        return self._default
+
+    def __gt__(self, other):
+        return self.position > other.position
+
+
+class FakeChannel:
+    def __init__(self, channel_id, name, position=0, news=False, sendable=True):
+        self.id = channel_id
+        self.name = name
+        self.position = position
+        self.category = None
+        self._news = news
+        self._sendable = sendable
+
+    def is_news(self):
+        return self._news
+
+    def permissions_for(self, _member):
+        return SimpleNamespace(view_channel=True, send_messages=self._sendable)
+
+
+class FakeGuild:
+    def __init__(self, roles=(), channels=(), me=True, owner_id=OWNER_ID):
+        self.id = GUILD_ID
+        self.owner_id = owner_id
+        self.roles = list(roles)
+        self.text_channels = list(channels)
+        self.me = SimpleNamespace(top_role=FakeRole(90, "Bot", 90)) if me else None
+        self._members = {}
+
+    def get_member(self, user_id):
+        return self._members.get(user_id)
+
+    def get_channel_or_thread(self, channel_id):
+        for channel in self.text_channels:
+            if channel.id == channel_id:
+                return channel
+        return None
+
+
+@pytest.fixture(autouse=True)
+def clean_db():
+    def wipe():
+        with bot.session_scope() as session:
+            session.query(bot.Server).delete()
+            session.query(bot.InstructionPanelBranding).delete()
+            session.query(bot.VerificationLogChannel).delete()
+            session.query(bot.PremiumGrandfatherLine).delete()
+            session.query(bot.InstructionPanelView).delete()
+
+    wipe()
+    bot.premium_status_cache.clear()
+    yield
+    wipe()
+    bot.premium_status_cache.clear()
+
+
+@pytest.fixture
+def enforced(monkeypatch):
+    monkeypatch.setattr(bot, "PREMIUM_SKU_ID", SKU_ID)
+    monkeypatch.setattr(bot, "PREMIUM_ENFORCED", True)
+    bot.premium_status_cache.clear()
+
+
+@pytest.fixture
+def free(monkeypatch, enforced):
+    """Not subscribed and not grandfathered."""
+
+    async def no(guild_id):
+        return False
+
+    monkeypatch.setattr(bot, "guild_has_premium", no)
+    with bot.session_scope() as session:
+        session.add(bot.PremiumGrandfatherLine(id=1, max_server_id=1))
+    bot.premium_status_cache.clear()
+
+
+@pytest.fixture
+def subscribed(monkeypatch, enforced):
+    async def yes(guild_id):
+        return True
+
+    monkeypatch.setattr(bot, "guild_has_premium", yes)
+    bot.premium_status_cache.clear()
+
+
+class TestSettingsReader:
+    def test_an_unconfigured_guild_reads_as_defaults(self):
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+        assert payload["fields"]["role_id"]["value"] is None
+        assert payload["fields"]["auto_verify_new_members"]["value"] is True
+
+    def test_stored_values_come_back(self):
+        make_server(role_id="555", auto_nickname_change=True, instructions_locale="fr")
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+        fields = payload["fields"]
+        assert fields["role_id"]["value"] == "555"
+        assert fields["auto_nickname_change"]["value"] is True
+        assert fields["instructions_locale"]["value"] == "fr"
+
+    def test_nothing_is_locked_while_the_tier_is_off(self):
+        make_server()
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+        assert not any(field["locked"] for field in payload["fields"].values())
+        assert all(field["active"] for field in payload["fields"].values())
+
+    def test_a_subscribed_guild_has_everything_active(self, subscribed):
+        make_server()
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+        assert payload["premium"]["premium"] is True
+        assert not any(field["locked"] for field in payload["fields"].values())
+
+    def test_a_free_guild_locks_only_what_the_bot_locks(self, free):
+        make_server(row_id=9000)
+        fields = run(bot.read_dashboard_settings(GUILD_ID))["fields"]
+
+        # Refused at save time by PagedSettingsView, so refused here too.
+        assert fields["auto_nickname_change"]["locked"] is True
+        assert fields["panel_embed_color"]["locked"] is True
+        assert fields["panel_show_icon"]["locked"] is True
+        assert fields["verification_log_channel_id"]["locked"] is True
+
+        # Saveable by anyone today via /vrcverify_setup and
+        # /vrcverify_setrequestmessage. The website must not be stricter than
+        # the slash command an admin can already run.
+        assert fields["unverified_role_id"]["locked"] is False
+        assert fields["unverified_role_id"]["active"] is False
+        assert fields["custom_verification_requested_message"]["locked"] is False
+        assert fields["custom_verification_requested_message"]["active"] is False
+
+    def test_auto_verify_on_join_is_never_gated(self, free):
+        """Free for everyone, forever — the same guard test_premium.py pins."""
+        make_server(row_id=9000)
+        field = run(bot.read_dashboard_settings(GUILD_ID))["fields"][
+            "auto_verify_new_members"
+        ]
+        assert field["feature"] is None
+        assert field["locked"] is False
+        assert field["active"] is True
+
+    def test_a_grandfathered_guild_keeps_its_three_features(self, free):
+        make_server(row_id=1)  # at or below the line drawn in the fixture
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+        fields = payload["fields"]
+        assert payload["premium"]["grandfathered"] is True
+        assert fields["auto_nickname_change"]["active"] is True
+        assert fields["unverified_role_id"]["active"] is True
+        # New features are not grandfathered — nobody is losing these.
+        assert fields["verification_log_channel_id"]["active"] is False
+        assert fields["verification_log_channel_id"]["locked"] is True
+
+    def test_branding_is_reported_when_stored(self):
+        make_server()
+        bot.save_panel_branding(GUILD_ID, 0xFF0000, True)
+        fields = run(bot.read_dashboard_settings(GUILD_ID))["fields"]
+        assert fields["panel_embed_color"]["value"] == 0xFF0000
+        assert fields["panel_show_icon"]["value"] is True
+
+    def test_unreadable_branding_refuses_rather_than_showing_defaults(
+        self, monkeypatch
+    ):
+        """Rendering 'default blue' for a server that chose otherwise is a lie."""
+        make_server()
+        monkeypatch.setattr(
+            bot, "load_panel_branding", lambda guild_id: bot.BRANDING_UNREADABLE
+        )
+        assert run(bot.read_dashboard_settings(GUILD_ID)) is None
+
+    def test_the_log_channel_is_reported(self):
+        make_server()
+        bot.set_log_channel(GUILD_ID, "424242")
+        fields = run(bot.read_dashboard_settings(GUILD_ID))["fields"]
+        assert fields["verification_log_channel_id"]["value"] == "424242"
+
+    def test_a_database_failure_reads_as_unavailable(self, monkeypatch):
+        def boom():
+            raise RuntimeError("database is down")
+
+        monkeypatch.setattr(bot, "session_scope", boom)
+        assert run(bot.read_dashboard_settings(GUILD_ID)) is None
+
+
+class TestRoleReader:
+    def guild(self, monkeypatch, **kwargs):
+        guild = FakeGuild(**kwargs)
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
+        return guild
+
+    def test_roles_are_ranked_and_everyone_is_dropped(self, monkeypatch):
+        self.guild(
+            monkeypatch,
+            roles=[
+                FakeRole(1, "@everyone", 0, default=True),
+                FakeRole(2, "Verified", 10),
+                FakeRole(3, "Mods", 50),
+            ],
+        )
+        roles = run(bot.read_dashboard_roles(GUILD_ID))
+        assert [role["name"] for role in roles] == ["Mods", "Verified"]
+
+    def test_a_role_above_the_bot_is_not_assignable(self, monkeypatch):
+        self.guild(
+            monkeypatch,
+            roles=[FakeRole(2, "Below", 10), FakeRole(3, "Above", 99)],
+        )
+        roles = {role["name"]: role["assignable"] for role in run(
+            bot.read_dashboard_roles(GUILD_ID)
+        )}
+        assert roles["Below"] is True
+        assert roles["Above"] is False
+
+    def test_an_integration_role_is_never_assignable(self, monkeypatch):
+        self.guild(monkeypatch, roles=[FakeRole(2, "Booster", 5, managed=True)])
+        assert run(bot.read_dashboard_roles(GUILD_ID))[0]["assignable"] is False
+
+    def test_assignability_is_unknown_rather_than_no_without_a_bot_member(
+        self, monkeypatch
+    ):
+        self.guild(monkeypatch, roles=[FakeRole(2, "Verified", 10)], me=False)
+        assert run(bot.read_dashboard_roles(GUILD_ID))[0]["assignable"] is None
+
+    def test_an_absent_guild_reads_as_unavailable(self, monkeypatch):
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: None)
+        assert run(bot.read_dashboard_roles(GUILD_ID)) is None
+
+
+class TestChannelReader:
+    def test_announcement_channels_are_flagged(self, monkeypatch):
+        guild = FakeGuild(
+            channels=[
+                FakeChannel(1, "general", position=0),
+                FakeChannel(2, "announcements", position=1, news=True),
+            ]
+        )
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
+        channels = run(bot.read_dashboard_channels(GUILD_ID))
+        assert [channel["is_news"] for channel in channels] == [False, True]
+
+    def test_unpostable_channels_are_flagged(self, monkeypatch):
+        guild = FakeGuild(channels=[FakeChannel(1, "locked", sendable=False)])
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
+        assert run(bot.read_dashboard_channels(GUILD_ID))[0]["can_send"] is False
+
+
+class TestPanelReader:
+    def test_no_panel_reads_as_not_posted(self, monkeypatch):
+        make_server()
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: FakeGuild())
+        assert run(bot.read_dashboard_panel(GUILD_ID)) == {"posted": False}
+
+    def test_a_posted_panel_reports_where_it_is(self, monkeypatch):
+        make_server(instructions_channel_id="1", instructions_message_id="55")
+        guild = FakeGuild(channels=[FakeChannel(1, "verify")])
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
+        panel = run(bot.read_dashboard_panel(GUILD_ID))
+        assert panel["posted"] is True
+        assert panel["channel_name"] == "verify"
+        assert panel["channel_reachable"] is True
+
+    def test_a_deleted_channel_is_reported(self, monkeypatch):
+        make_server(instructions_channel_id="999", instructions_message_id="55")
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: FakeGuild())
+        panel = run(bot.read_dashboard_panel(GUILD_ID))
+        assert panel["channel_exists"] is False
+        assert panel["channel_reachable"] is None
+
+
+class TestAdminCheck:
+    def test_the_owner_needs_no_lookup(self, monkeypatch):
+        guild = FakeGuild()
+
+        async def never(*args):
+            raise AssertionError("the owner shortcut should avoid a fetch")
+
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
+        monkeypatch.setattr(bot, "fetch_member_cached", never)
+        assert run(bot.dashboard_is_admin(GUILD_ID, OWNER_ID)) is True
+
+    def test_an_administrator_is_allowed(self, monkeypatch):
+        guild = FakeGuild()
+        member = SimpleNamespace(
+            guild_permissions=SimpleNamespace(administrator=True)
+        )
+
+        async def fetch(_guild, _user_id):
+            return member
+
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
+        monkeypatch.setattr(bot, "fetch_member_cached", fetch)
+        assert run(bot.dashboard_is_admin(GUILD_ID, ADMIN_ID)) is True
+
+    def test_manage_server_is_not_enough(self, monkeypatch):
+        """Administrator only, matching every slash command's own check."""
+        guild = FakeGuild()
+        member = SimpleNamespace(
+            guild_permissions=SimpleNamespace(administrator=False)
+        )
+
+        async def fetch(_guild, _user_id):
+            return member
+
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
+        monkeypatch.setattr(bot, "fetch_member_cached", fetch)
+        assert run(bot.dashboard_is_admin(GUILD_ID, ADMIN_ID)) is False
+
+    def test_a_non_member_is_refused(self, monkeypatch):
+        async def fetch(_guild, _user_id):
+            return None
+
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: FakeGuild())
+        monkeypatch.setattr(bot, "fetch_member_cached", fetch)
+        assert run(bot.dashboard_is_admin(GUILD_ID, ADMIN_ID)) is False
+
+    def test_an_unanswerable_question_fails_closed(self, monkeypatch):
+        async def boom(_guild, _user_id):
+            raise RuntimeError("gateway is unhappy")
+
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: FakeGuild())
+        monkeypatch.setattr(bot, "fetch_member_cached", boom)
+        assert run(bot.dashboard_is_admin(GUILD_ID, ADMIN_ID)) is False
+
+    def test_an_absent_guild_is_refused(self, monkeypatch):
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: None)
+        assert run(bot.dashboard_is_admin(GUILD_ID, ADMIN_ID)) is False

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -54,6 +54,11 @@ def make_deps(**overrides) -> bot_api.BotAPIDeps:
     async def is_admin(guild_id, user_id):
         return int(user_id) == ADMIN_ID
 
+    async def read_admin_guilds(user_id, guild_ids):
+        if int(user_id) != ADMIN_ID:
+            return []
+        return [gid for gid in guild_ids if int(gid) == GUILD_ID]
+
     async def read_settings(guild_id):
         return {"guild_id": str(guild_id), "fields": {}}
 
@@ -70,6 +75,7 @@ def make_deps(**overrides) -> bot_api.BotAPIDeps:
         is_ready=lambda: True,
         guild_present=lambda guild_id: int(guild_id) == GUILD_ID,
         is_admin=is_admin,
+        read_admin_guilds=read_admin_guilds,
         read_settings=read_settings,
         read_roles=read_roles,
         read_channels=read_channels,
@@ -592,19 +598,61 @@ class TestRequests:
 class TestGuildList:
     OP = bot_api.OP_LIST_GUILDS
 
+    def token(self, actor_id=ADMIN_ID):
+        return bot_api.mint_token(
+            SIGNING_KEY, actor_id=actor_id, operation=self.OP, guild_id=None
+        )
+
     def test_returns_only_the_guilds_the_bot_is_in(self):
         async def scenario(client):
             return await get(
                 client,
                 f"/api/v1/guilds?ids={GUILD_ID},{OTHER_GUILD_ID}",
-                bot_api.mint_token(
-                    SIGNING_KEY, actor_id=ADMIN_ID, operation=self.OP, guild_id=None
-                ),
+                self.token(),
             )
 
         status, body = serve(scenario)
         assert status == 200
         assert body == {"present": [str(GUILD_ID)]}
+
+    def test_it_is_not_a_bot_presence_oracle(self):
+        """The bug this endpoint shipped with, pinned shut.
+
+        It used to answer "is the bot in this guild?" for any id the caller
+        sent, making it the one endpoint not bounded by the bot's own authority
+        check. Since a compromised dashboard holds the signing key and can mint
+        a token for any actor, that let an attacker walk arbitrary ids and
+        enumerate every server running this bot.
+        """
+
+        async def scenario(client):
+            return await get(
+                client,
+                # GUILD_ID is a real guild the bot is in — but this caller has
+                # no standing in it, so it must come back indistinguishable
+                # from one the bot has never joined.
+                f"/api/v1/guilds?ids={GUILD_ID},{OTHER_GUILD_ID}",
+                self.token(actor_id=MEMBER_ID),
+            )
+
+        status, body = serve(scenario)
+        assert status == 200
+        assert body == {"present": []}
+
+    def test_an_unreadable_answer_is_a_503_not_an_empty_list(self):
+        """An empty list means "none of these"; it must not mean "we failed"."""
+
+        async def unavailable(user_id, guild_ids):
+            return None
+
+        async def scenario(client):
+            return await get(
+                client, f"/api/v1/guilds?ids={GUILD_ID}", self.token()
+            )
+
+        status, body = serve(scenario, deps=make_deps(read_admin_guilds=unavailable))
+        assert status == 503
+        assert body["error"] == "unavailable"
 
     def test_a_guild_scoped_token_cannot_reach_it(self):
         async def scenario(client):
@@ -617,17 +665,29 @@ class TestGuildList:
     def test_an_oversized_query_is_refused(self):
         async def scenario(client):
             ids = ",".join(str(n) for n in range(bot_api.MAX_GUILD_IDS + 1))
-            return await get(
-                client,
-                f"/api/v1/guilds?ids={ids}",
-                bot_api.mint_token(
-                    SIGNING_KEY, actor_id=ADMIN_ID, operation=self.OP, guild_id=None
-                ),
-            )
+            return await get(client, f"/api/v1/guilds?ids={ids}", self.token())
 
         status, body = serve(scenario)
         assert status == 400
         assert body["error"] == "too_many_ids"
+
+    def test_the_actor_is_taken_from_the_token_not_the_query(self):
+        """There is no way to ask on someone else's behalf."""
+        seen = {}
+
+        async def record(user_id, guild_ids):
+            seen["actor"] = int(user_id)
+            return []
+
+        async def scenario(client):
+            return await get(
+                client,
+                f"/api/v1/guilds?ids={GUILD_ID}&user_id={ADMIN_ID}",
+                self.token(actor_id=MEMBER_ID),
+            )
+
+        serve(scenario, deps=make_deps(read_admin_guilds=record))
+        assert seen["actor"] == MEMBER_ID
 
 
 # -------------------------------------------------------------------
@@ -647,6 +707,7 @@ class TestReadOnlyPhase:
                 "is_ready",
                 "guild_present",
                 "is_admin",
+                "read_admin_guilds",
                 "read_settings",
                 "read_roles",
                 "read_channels",
@@ -953,60 +1014,164 @@ class TestPanelReader:
         assert panel["channel_reachable"] is None
 
 
+def member(administrator=True):
+    return SimpleNamespace(
+        guild_permissions=SimpleNamespace(administrator=administrator)
+    )
+
+
+@pytest.fixture(autouse=True)
+def clear_admin_cache():
+    """Verdicts are cached, so they would otherwise leak between tests."""
+    bot._admin_check_cache._store.clear()
+    yield
+    bot._admin_check_cache._store.clear()
+
+
 class TestAdminCheck:
-    def test_the_owner_needs_no_lookup(self, monkeypatch):
-        guild = FakeGuild()
+    def guild_with(self, monkeypatch, fetch_result=None, fetches=None, **kwargs):
+        guild = FakeGuild(**kwargs)
 
-        async def never(*args):
-            raise AssertionError("the owner shortcut should avoid a fetch")
+        async def fetch_member(user_id):
+            if fetches is not None:
+                fetches.append(user_id)
+            if isinstance(fetch_result, Exception):
+                raise fetch_result
+            if fetch_result is None:
+                raise discord.NotFound(SimpleNamespace(status=404), "nope")
+            return fetch_result
 
+        guild.fetch_member = fetch_member
         monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
-        monkeypatch.setattr(bot, "fetch_member_cached", never)
+        return guild
+
+    def test_the_owner_needs_no_lookup(self, monkeypatch):
+        fetches = []
+        self.guild_with(monkeypatch, fetch_result=member(), fetches=fetches)
         assert run(bot.dashboard_is_admin(GUILD_ID, OWNER_ID)) is True
+        assert fetches == []
 
     def test_an_administrator_is_allowed(self, monkeypatch):
-        guild = FakeGuild()
-        member = SimpleNamespace(
-            guild_permissions=SimpleNamespace(administrator=True)
-        )
-
-        async def fetch(_guild, _user_id):
-            return member
-
-        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
-        monkeypatch.setattr(bot, "fetch_member_cached", fetch)
+        self.guild_with(monkeypatch, fetch_result=member(administrator=True))
         assert run(bot.dashboard_is_admin(GUILD_ID, ADMIN_ID)) is True
 
     def test_manage_server_is_not_enough(self, monkeypatch):
         """Administrator only, matching every slash command's own check."""
-        guild = FakeGuild()
-        member = SimpleNamespace(
-            guild_permissions=SimpleNamespace(administrator=False)
-        )
-
-        async def fetch(_guild, _user_id):
-            return member
-
-        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
-        monkeypatch.setattr(bot, "fetch_member_cached", fetch)
+        self.guild_with(monkeypatch, fetch_result=member(administrator=False))
         assert run(bot.dashboard_is_admin(GUILD_ID, ADMIN_ID)) is False
 
     def test_a_non_member_is_refused(self, monkeypatch):
-        async def fetch(_guild, _user_id):
-            return None
-
-        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: FakeGuild())
-        monkeypatch.setattr(bot, "fetch_member_cached", fetch)
+        self.guild_with(monkeypatch, fetch_result=None)
         assert run(bot.dashboard_is_admin(GUILD_ID, ADMIN_ID)) is False
 
     def test_an_unanswerable_question_fails_closed(self, monkeypatch):
-        async def boom(_guild, _user_id):
-            raise RuntimeError("gateway is unhappy")
-
-        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: FakeGuild())
-        monkeypatch.setattr(bot, "fetch_member_cached", boom)
+        self.guild_with(monkeypatch, fetch_result=RuntimeError("gateway is unhappy"))
         assert run(bot.dashboard_is_admin(GUILD_ID, ADMIN_ID)) is False
 
     def test_an_absent_guild_is_refused(self, monkeypatch):
         monkeypatch.setattr(bot.bot, "get_guild", lambda _id: None)
         assert run(bot.dashboard_is_admin(GUILD_ID, ADMIN_ID)) is False
+
+    def test_the_verdict_is_cached_across_a_page_load(self, monkeypatch):
+        """Four endpoint calls behind one page must not be four REST calls."""
+        fetches = []
+        self.guild_with(monkeypatch, fetch_result=member(), fetches=fetches)
+
+        async def scenario():
+            return [await bot.dashboard_is_admin(GUILD_ID, ADMIN_ID) for _ in range(4)]
+
+        assert run(scenario()) == [True] * 4
+        assert len(fetches) == 1
+
+    def test_the_admin_cache_is_not_the_verification_cache(self):
+        """The whole point of fix #2: a 180s member cache must not decide authority.
+
+        Sharing REST_TTL_SECONDS would mean a demoted admin kept configuring
+        the server for up to three minutes — precisely the window that matters
+        when the role is being pulled because an account was compromised.
+        """
+        assert bot._admin_check_cache is not bot._member_fetch_cache
+        assert bot._admin_check_cache.ttl < bot._member_fetch_cache.ttl
+        assert bot.BOT_API_ADMIN_TTL <= 30
+
+    def test_a_demotion_takes_effect_once_the_entry_expires(self, monkeypatch):
+        current = member(administrator=True)
+        fetches = []
+        self.guild_with(monkeypatch, fetch_result=current, fetches=fetches)
+
+        async def scenario():
+            assert await bot.dashboard_is_admin(GUILD_ID, ADMIN_ID) is True
+
+            current.guild_permissions.administrator = False
+
+            # Age the cached verdict past its TTL rather than deleting it, so
+            # this exercises _TTLCache's expiry branch — the thing that
+            # actually bounds how long a demoted admin keeps access.
+            store = bot._admin_check_cache._store
+            stale = asyncio.get_event_loop().time() - 1
+            for key, (_expires_at, value) in list(store.items()):
+                store[key] = (stale, value)
+
+            return await bot.dashboard_is_admin(GUILD_ID, ADMIN_ID)
+
+        assert run(scenario()) is False
+        assert len(fetches) == 2
+
+
+class TestAdminGuildList:
+    def setup_guilds(self, monkeypatch, present, admin_of):
+        def get_guild(guild_id):
+            if int(guild_id) not in present:
+                return None
+            guild = FakeGuild()
+            guild.id = int(guild_id)
+            return guild
+
+        async def is_admin(guild_id, user_id):
+            return int(guild_id) in admin_of
+
+        monkeypatch.setattr(bot.bot, "get_guild", get_guild)
+        monkeypatch.setattr(bot, "dashboard_is_admin", is_admin)
+
+    def test_returns_the_intersection(self, monkeypatch):
+        self.setup_guilds(monkeypatch, present={1, 2, 3}, admin_of={2, 3, 9})
+        assert run(bot.dashboard_admin_guilds(ADMIN_ID, [1, 2, 3, 9])) == [2, 3]
+
+    def test_a_guild_the_caller_does_not_administer_looks_absent(self, monkeypatch):
+        """Indistinguishable from one the bot never joined — that's the fix."""
+        self.setup_guilds(monkeypatch, present={1}, admin_of=set())
+        assert run(bot.dashboard_admin_guilds(MEMBER_ID, [1, 2])) == []
+
+    def test_absent_guilds_cost_no_authority_check(self, monkeypatch):
+        checked = []
+
+        async def is_admin(guild_id, user_id):
+            checked.append(int(guild_id))
+            return True
+
+        monkeypatch.setattr(bot.bot, "get_guild", lambda gid: None)
+        monkeypatch.setattr(bot, "dashboard_is_admin", is_admin)
+        assert run(bot.dashboard_admin_guilds(ADMIN_ID, [1, 2, 3])) == []
+        assert checked == []
+
+    def test_unparseable_ids_are_skipped_not_fatal(self, monkeypatch):
+        self.setup_guilds(monkeypatch, present={7}, admin_of={7})
+        assert run(bot.dashboard_admin_guilds(ADMIN_ID, ["7", "nonsense", None])) == [7]
+
+    def test_one_failed_check_does_not_grant_the_others(self, monkeypatch):
+        async def is_admin(guild_id, user_id):
+            if int(guild_id) == 2:
+                raise RuntimeError("gateway is unhappy")
+            return True
+
+        monkeypatch.setattr(bot.bot, "get_guild", lambda gid: FakeGuild())
+        monkeypatch.setattr(bot, "dashboard_is_admin", is_admin)
+        # The raiser is dropped, never treated as an allow.
+        assert run(bot.dashboard_admin_guilds(ADMIN_ID, [1, 2, 3])) == [1, 3]
+
+    def test_an_unanswerable_list_is_none_not_empty(self, monkeypatch):
+        def boom(_guild_id):
+            raise RuntimeError("cache is gone")
+
+        monkeypatch.setattr(bot.bot, "get_guild", boom)
+        assert run(bot.dashboard_admin_guilds(ADMIN_ID, [1])) is None


### PR DESCRIPTION
Step 1 of #65. Groundwork for the web dashboard: the door it will eventually knock on, built and verified before anything can be written through it.

**This deploys inert.** With `BOT_API_ENABLED` unset no socket is opened and the bot is byte-for-byte the service it was before — the same kill-switch pattern as `PREMIUM_SKU_ID`. It should stay unset in production until VPS hardening (step 2) is done and verified from outside.

## Why this is structured the way it is

This is the first inbound network surface the project has ever had, on a bot whose database links Discord identities to VRChat accounts and 18+ status. So every endpoint here is a GET, and the read-only-ness is structural rather than a promise: `src/bot_api.py` imports neither `bot` nor `discord` nor SQLAlchemy, and its capabilities arrive as a `BotAPIDeps` dataclass holding only readers. There is no generic "write these columns" entry point because there is no writer to call. Adding a write path later means adding a named writer — a reviewable diff, not a query string someone slipped past.

Tests pin both that field set and the absence of any non-GET route, so the phase can't drift without someone editing the test on purpose.

## Three gates on every request

1. **mTLS** against a private CA (`scripts/gen_bot_api_certs.sh`), enforced inside the tailnet too — the tunnel is a segmentation control, not an authentication one.
2. **A scoped token** bound to one actor, one guild and one method-and-path, ~30s, single use.
3. **The bot's own Administrator check**, re-read per request behind a deliberately short cache. Manage Server is not enough, matching every slash command.

## Behaviour that had to match the bot exactly

`SETTINGS_FIELDS` records which settings a lapsed plan blocks at *save* time and which it merely stops acting on. That split already exists — `/vrcverify_setup` stores an unverified role for any server while `assign_role` ignores it, whereas `PagedSettingsView` refuses to save nickname sync at all. Writing it down once is what stops the website ending up stricter than the slash commands.

Auto-verify-on-join is reported as never gated, mirroring the guard in `tests/test_premium.py`.

## Two findings from an adversarial review, fixed in the second commit

- **`GET /api/v1/guilds` was a bot-presence oracle.** It answered for any id supplied, checking presence only — the one endpoint not bounded by the Administrator check, and so the one place the "assume the public host is compromised" premise stopped holding, since a compromised host holds the signing key and can mint a token for any actor. Now filtered through `dashboard_admin_guilds`; a guild you don't administer is reported identically to one the bot never joined.
- **The Administrator check read from the 180s verification member cache**, so a demoted admin kept dashboard access for up to three minutes — exactly the window that matters when the role is being pulled *because* an account was compromised. Now its own 15s cache, caching the verdict rather than the `Member`. The README claimed revocation was "within one request", which was never true; the claim was corrected to match the code rather than the reverse.

Cleared in the same review and left alone deliberately: base64 malleability can't forge a token (the HMAC covers the encoded string before any decode), and `int()` accepting `1_0`/Unicode digits for a path guild id isn't a bypass because the parsed value must still equal the token's `gid`.

## Deployment notes

- `BOT_API_BIND` must be the tailnet address. The listener **refuses to start** on `0.0.0.0`, `::` or blank rather than listening everywhere.
- That rules out the usual container pattern of listening wide behind a published port, which leaves one typo in a publish rule between this port and the internet. Enabling the API therefore means `network_mode: host`; the compose file explains it and flags that `DATABASE_URL`/`RABBITMQ_HOST` need checking first.
- A misconfiguration stops the API and never the bot — verification is the product.
- `aiohttp` is now pinned explicitly in `requirements-bot.txt`; it was only transitive via discord.py, and it now serves a TLS listener.
- `.gitattributes` pins `*.sh` to LF so the cert script doesn't reach the Linux host with CRLF.

## Verification

799 tests pass. Beyond the unit tests, the whole chain was exercised against a real TLS listener: no client certificate is dropped at handshake (not a 401), a valid token returns 200, a replayed one 401, a non-administrator 403, a token minted for another guild 403, and one aimed at another endpoint 403.

Next: step 2, VPS provisioning and hardening.