### PR TITLE
Pass BOT_API_ADMIN_TTL through, and bound the container logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -181,6 +181,14 @@ LOG_LEVEL=INFO
 # 180s and would be far too long to leave an authority answer standing.
 # BOT_API_ADMIN_TTL=15
 #
+#
+# How long an Administrator verdict is cached before the bot re-asks Discord
+# (default 15). This is how long someone keeps dashboard access after their
+# admin role is removed, so keep it short. Deliberately NOT the same cache as
+# REST_TTL_SECONDS, which is tuned for verification traffic at 180s and would
+# be far too long to leave an authority answer standing.
+# BOT_API_ADMIN_TTL=15
+#
 # Request budgets. Per signed-in Discord user, and across everyone at once.
 # BOT_API_RATE_LIMIT=60
 # BOT_API_RATE_WINDOW=60

--- a/config/other_configs/docker-compose.deploy.yml
+++ b/config/other_configs/docker-compose.deploy.yml
@@ -38,6 +38,17 @@ services:
       BOT_API_CA: ${BOT_API_CA:-}
       BOT_API_CLIENT_CN: ${BOT_API_CLIENT_CN:-}
       BOT_API_TOKEN_SIGNING_KEY: ${BOT_API_TOKEN_SIGNING_KEY:-}
+      BOT_API_ADMIN_TTL: ${BOT_API_ADMIN_TTL:-15}
+    restart: unless-stopped
+    # Docker's json-file driver does not rotate by default, so container logs
+    # grow without bound until the disk does. Especially worth having here:
+    # the checker logs full VRChat bios at DEBUG (third-party PII), so an
+    # accidental LOG_LEVEL=DEBUG must not also mean "forever".
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     #
     # TURNING THE API ON ALSO NEEDS THE TWO LINES BELOW UNCOMMENTED.
     #
@@ -57,7 +68,6 @@ services:
     # network_mode: host
     # volumes:
     #   - ${BOT_API_CERT_DIR:-./certs}:/certs:ro
-    restart: unless-stopped
 
   vrc-online-checker:
     image: italiandogs/vrcverify-vrc-online-checker:${VRCVERIFY_VERSION:?Set VRCVERIFY_VERSION to a pushed version tag (never latest)}
@@ -84,6 +94,12 @@ services:
     volumes:
       - vrchat-session:/data
     restart: unless-stopped
+    # This is the service that logs bios at DEBUG. Rotation matters most here.
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 volumes:
   # Persists the VRChat auth cookie so restarts skip re-authentication.


### PR DESCRIPTION
Two small things found while doing the step-2 deployment of #65 against the real production host, after #68 had already merged.

**`BOT_API_ADMIN_TTL` was never wired through.** It arrived with the fix that gave the dashboard's Administrator check its own short-lived cache, but it was missing from both the deploy compose and `.env.example` — so on a real deploy it could only ever take its compiled default, and there'd be no way to tune the revocation window without a code change. That's the one knob controlling how long a demoted admin keeps dashboard access, so it should be adjustable without a release.

**Log rotation on both services.** Docker's `json-file` driver does not rotate by default, and `vrc_online_checker.py` logs full VRChat bios at DEBUG. Production was running `LOG_LEVEL=DEBUG`, so every verified user's bio was being written to disk with no bound — third-party PII from people who never agreed to it, accumulating indefinitely. The log level is fixed on the deploy side; this caps the damage if it ever gets set back.

Also removes a duplicate `restart:` key on `discord-bot` that #68 introduced (compose took the last one, so behaviour was unchanged, but it fails a YAML lint).

Production already runs this compose — it was applied directly to the host during the deploy. This brings the repo back in line with what's actually deployed.