### PR TITLE
Add the dashboard: Discord login, sessions, and a read-only server picker

### DIFF
--- a/config/other_configs/docker-compose.dashboard.yml
+++ b/config/other_configs/docker-compose.dashboard.yml
@@ -1,0 +1,68 @@
+# The web dashboard, for the public VPS (issue #65). NOT the homelab pair —
+# that stays docker-compose.deploy.yml.
+#
+# Usage, on the VPS next to dashboard.env, cloudflared.env and certs/:
+#   VRCVERIFY_VERSION=2.3.0 docker compose -f docker-compose.dashboard.yml up -d
+#
+# Two properties this file exists to preserve, both easy to undo by accident:
+#
+# 1. NEITHER SERVICE PUBLISHES A PORT. cloudflared dials out to Cloudflare and
+#    reaches the dashboard over the Docker network by name. The host firewall
+#    is default-deny inbound and the IONOS panel allows only Tailscale — but
+#    neither of those would save you, because published Docker ports are DNAT'd
+#    in PREROUTING and never traverse the INPUT chain. The absence of `ports:`
+#    is the actual control.
+#
+# 2. THE DASHBOARD HOLDS NO DATABASE CREDENTIAL AND NO BOT TOKEN. It asks the
+#    bot for everything over mTLS. A full compromise of this box yields no
+#    route to the users table. Adding DATABASE_URL here would quietly discard
+#    the main reason the bot API exists.
+
+services:
+  dashboard:
+    image: italiandogs/vrcverify-dashboard:${VRCVERIFY_VERSION:?Set VRCVERIFY_VERSION to a pushed version tag (never latest)}
+    env_file:
+      - dashboard.env
+    volumes:
+      # The client certificate, its key, and the CA that signed the bot's.
+      - ./certs:/certs:ro
+      # Sessions. A named volume so `docker compose down` doesn't sign
+      # everyone out.
+      - dashboard-sessions:/data
+    restart: unless-stopped
+    # No new privileges, no capabilities, non-root user (from the Dockerfile).
+    # The filesystem stays writable only where it must: /data.
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    command: tunnel --no-autoupdate run
+    env_file:
+      - cloudflared.env
+    depends_on:
+      - dashboard
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+volumes:
+  dashboard-sessions:

--- a/config/other_configs/requirements-dashboard.txt
+++ b/config/other_configs/requirements-dashboard.txt
@@ -1,0 +1,12 @@
+# Web dashboard (issue #65). Runs on the public VPS.
+#
+# Deliberately short. This service is the internet-facing one, so every
+# dependency here is something an attacker gets to probe — the page is plain
+# server-rendered HTML precisely so the list can stay this size.
+#
+# Note what is ABSENT and must stay absent: no database driver and no
+# discord.py. The dashboard holds no database credential and no bot token; it
+# asks the bot for everything over mTLS. Adding either would undo that.
+Flask==3.1.3
+requests==2.34.2
+gunicorn==23.0.0

--- a/config/other_configs/requirements-dev.txt
+++ b/config/other_configs/requirements-dev.txt
@@ -2,3 +2,8 @@
 -r requirements.txt
 pytest==9.1.1
 pytest-cov==7.1.0
+# The dashboard's runtime deps, so tests/test_dashboard.py can run from a
+# fresh clone. That file skips itself if Flask is absent, which keeps the
+# suite green without them -- but a skipped security test is not a passed one,
+# so they belong here.
+-r requirements-dashboard.txt

--- a/docker/Dockerfile-dashboard
+++ b/docker/Dockerfile-dashboard
@@ -1,0 +1,52 @@
+# Dockerfile-dashboard — the public-facing web dashboard (issue #65).
+#
+# This is the only image in the project that runs on an internet-reachable
+# host, so it deliberately carries less than the others: no database driver,
+# no discord.py, no bot token. Everything it knows, it asks the bot for over
+# mTLS, and the bot decides what it is allowed to know.
+
+FROM python:3.14.6-slim AS runtime
+
+ENV PIP_NO_CACHE_DIR=1 \
+	PIP_DISABLE_PIP_VERSION_CHECK=1 \
+	PYTHONDONTWRITEBYTECODE=1 \
+	PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY config/other_configs/requirements-dashboard.txt ./requirements.txt
+RUN pip install --no-compile -r requirements.txt
+
+RUN useradd --create-home --uid 10001 appuser
+
+# api_tokens.py is shared with the bot on purpose: both ends must sign and
+# verify with byte-identical code, and copying it here rather than
+# reimplementing is what guarantees that. It is stdlib-only, so it brings
+# nothing with it.
+COPY --chown=appuser:appuser src/api_tokens.py ./src/api_tokens.py
+COPY --chown=appuser:appuser src/dashboard/ ./src/dashboard/
+
+# Sessions live here. Mount a volume over it; the image itself keeps nothing.
+RUN mkdir -p /data && chown appuser:appuser /data
+VOLUME ["/data"]
+
+USER appuser
+ENV PYTHONPATH=/app/src
+
+# Bound to loopback inside the container. cloudflared reaches it over the
+# Docker network, and there is no published port — see the compose file.
+EXPOSE 8000
+
+# --forwarded-allow-ips="*" lets gunicorn honour X-Forwarded-Proto. It defaults
+# to trusting only 127.0.0.1, and cloudflared reaches us from a Docker network
+# address, so without this the scheme is ignored and every OAuth callback URL
+# comes out as http:// — which Discord rejects outright.
+#
+# Trusting "*" is safe here specifically because this container publishes no
+# port: cloudflared is the only thing that can connect to it at all. If that
+# ever changes, this must be narrowed at the same time.
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", \
+	"--workers", "2", "--threads", "4", \
+	"--access-logfile", "-", "--error-logfile", "-", \
+	"--forwarded-allow-ips", "*", \
+	"dashboard.app:main()"]

--- a/src/api_tokens.py
+++ b/src/api_tokens.py
@@ -1,0 +1,197 @@
+"""The scoped request tokens the dashboard signs and the bot verifies.
+
+Split out of `bot_api.py` so both ends can import the *same* implementation
+without the dashboard also having to install aiohttp. That sharing is the whole
+point: a signer and a verifier that drift apart is the classic way an auth
+scheme quietly stops meaning anything, and this format's security rests
+entirely on both sides agreeing about what is covered by the signature.
+
+Deliberately stdlib-only. Nothing here should ever grow a dependency, because
+the moment it does, one of the two services has to take it on for no reason of
+its own.
+
+The token names one Discord user, one guild, and one operation, and is good for
+about thirty seconds and a single use. See `bot_api.py` for the replay guard
+and the enforcement side.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hmac
+import json
+import secrets
+import time
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Optional
+
+TOKEN_VERSION = "v1"
+
+# The operations both ends must agree on, verbatim. The bot derives what it
+# expects from the aiohttp route it actually matched, so these are the route
+# templates exactly as registered -- braces and all, never the interpolated
+# path. Getting one wrong is a 403 `wrong_operation`, which looks like a
+# permissions bug rather than a typo, so they live here with the signer.
+OP_LIST_GUILDS = "GET /api/v1/guilds"
+OP_GUILD_SETTINGS = "GET /api/v1/guilds/{guild_id}/settings"
+OP_GUILD_ROLES = "GET /api/v1/guilds/{guild_id}/roles"
+OP_GUILD_CHANNELS = "GET /api/v1/guilds/{guild_id}/channels"
+OP_GUILD_PANEL = "GET /api/v1/guilds/{guild_id}/panel"
+
+# Tokens are minted per request and used immediately. Thirty seconds is
+# generous for a call across a tunnel and short enough that a captured token is
+# worthless by the time anyone notices they have it.
+DEFAULT_TOKEN_TTL = 30
+# Allowance for clock drift between the VPS and the homelab. Small on purpose:
+# every second here widens the replay window at both ends.
+DEFAULT_CLOCK_SKEW = 5
+
+# An HMAC key shorter than its own digest is weaker than the primitive it feeds.
+MIN_SIGNING_KEY_BYTES = 32
+
+
+class TokenError(Exception):
+    """A token was absent, malformed, expired, or not for this request.
+
+    `actor` is set for every failure raised *after* the signature verified, so
+    the denial log can name who minted the token. That is the difference
+    between "someone sent us garbage" and "this specific signed-in user tried
+    to reach a guild they were not scoped for" -- and the second is the one
+    worth alerting on.
+    """
+
+    def __init__(self, reason: str, actor: Optional[int] = None):
+        super().__init__(reason)
+        self.reason = reason
+        self.actor = actor
+
+
+def _b64encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64decode(raw: str) -> bytes:
+    padding = "=" * (-len(raw) % 4)
+    return base64.urlsafe_b64decode(raw + padding)
+
+
+def _canonical(payload: dict) -> bytes:
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def mint_token(
+    signing_key: bytes,
+    *,
+    actor_id: int,
+    operation: str,
+    guild_id: Optional[int] = None,
+    ttl: int = DEFAULT_TOKEN_TTL,
+    now: Optional[float] = None,
+) -> str:
+    """Sign one token for one call.
+
+    Lives here rather than in the dashboard so both ends share exactly one
+    implementation of the format — a signer and a verifier that drift apart is
+    the classic way an auth scheme quietly stops meaning anything.
+    """
+    issued = int(now if now is not None else time.time())
+    payload = {
+        "act": int(actor_id),
+        "gid": None if guild_id is None else int(guild_id),
+        "op": operation,
+        "iat": issued,
+        "exp": issued + int(ttl),
+        "jti": _b64encode(secrets.token_bytes(12)),
+    }
+    encoded = _b64encode(_canonical(payload))
+    signature = hmac.new(signing_key, encoded.encode("ascii"), sha256).digest()
+    return f"{TOKEN_VERSION}.{encoded}.{_b64encode(signature)}"
+
+
+@dataclass(frozen=True)
+class TokenClaims:
+    actor_id: int
+    guild_id: Optional[int]
+    operation: str
+    expires_at: int
+    jti: str
+
+
+def verify_token(
+    token: str,
+    signing_key: bytes,
+    *,
+    expected_operation: str,
+    expected_guild_id: Optional[int],
+    max_ttl: int = DEFAULT_TOKEN_TTL,
+    clock_skew: int = DEFAULT_CLOCK_SKEW,
+    now: Optional[float] = None,
+) -> TokenClaims:
+    """Authenticate a token and confirm it was minted for *this* request.
+
+    The signature is checked before the payload is parsed, so no attacker-
+    supplied JSON is ever deserialised on an unauthenticated path.
+    """
+    current = now if now is not None else time.time()
+
+    parts = token.split(".")
+    if len(parts) != 3 or parts[0] != TOKEN_VERSION:
+        raise TokenError("malformed")
+    _, encoded, signature = parts
+
+    expected_sig = hmac.new(signing_key, encoded.encode("ascii"), sha256).digest()
+    try:
+        provided_sig = _b64decode(signature)
+    except (binascii.Error, ValueError):
+        raise TokenError("malformed")
+    if not hmac.compare_digest(expected_sig, provided_sig):
+        raise TokenError("bad_signature")
+
+    try:
+        payload = json.loads(_b64decode(encoded))
+    except (binascii.Error, ValueError, UnicodeDecodeError):
+        raise TokenError("malformed")
+    if not isinstance(payload, dict):
+        raise TokenError("malformed")
+
+    try:
+        actor_id = int(payload["act"])
+        operation = payload["op"]
+        issued_at = int(payload["iat"])
+        expires_at = int(payload["exp"])
+        jti = payload["jti"]
+        raw_guild = payload["gid"]
+        guild_id = None if raw_guild is None else int(raw_guild)
+    except (KeyError, TypeError, ValueError):
+        raise TokenError("malformed")
+    if not isinstance(operation, str) or not isinstance(jti, str) or not jti:
+        raise TokenError("malformed")
+
+    # Past this point the signature has verified, so every refusal below can
+    # name the actor it was minted for.
+    if expires_at <= current - clock_skew:
+        raise TokenError("expired", actor=actor_id)
+    if issued_at > current + clock_skew:
+        raise TokenError("not_yet_valid", actor=actor_id)
+    # A token whose own window is longer than we ever issue is either a bug in
+    # the dashboard or someone minting their own with a leaked key. Neither is
+    # a request worth serving.
+    if expires_at - issued_at > max_ttl:
+        raise TokenError("ttl_too_long", actor=actor_id)
+
+    # The two checks that make interception useless: a token is good for one
+    # operation against one guild, and nothing else.
+    if operation != expected_operation:
+        raise TokenError("wrong_operation", actor=actor_id)
+    if guild_id != expected_guild_id:
+        raise TokenError("wrong_guild", actor=actor_id)
+
+    return TokenClaims(
+        actor_id=actor_id,
+        guild_id=guild_id,
+        operation=operation,
+        expires_at=expires_at,
+        jti=jti,
+    )

--- a/src/bot_api.py
+++ b/src/bot_api.py
@@ -33,37 +33,39 @@ binds and nothing listens.
 
 from __future__ import annotations
 
-import base64
-import binascii
-import hmac
 import ipaddress
-import json
 import logging
 import os
-import secrets
 import ssl
 import time
 from dataclasses import dataclass, fields
-from hashlib import sha256
 from typing import Any, Awaitable, Callable, Optional
 
 from aiohttp import web
+
+# The token format lives in its own stdlib-only module so the dashboard can
+# sign with the identical implementation this verifies with, without also
+# taking on aiohttp. Re-exported below, because this module is where the
+# enforcement lives and callers should not need to know the split exists.
+from api_tokens import (  # noqa: F401  (re-exported)
+    DEFAULT_CLOCK_SKEW,
+    DEFAULT_TOKEN_TTL,
+    MIN_SIGNING_KEY_BYTES,
+    OP_LIST_GUILDS,
+    TOKEN_VERSION,
+    TokenClaims,
+    TokenError,
+    _b64decode,
+    _b64encode,
+    _canonical,
+    mint_token,
+    verify_token,
+)
 
 logger = logging.getLogger(__name__)
 
 # Reusing the port the Dockerfile has always (uselessly) EXPOSEd.
 DEFAULT_PORT = 5002
-
-# Tokens are minted per request and used immediately. Thirty seconds is
-# generous for a call across a tunnel and short enough that a captured token is
-# worthless by the time anyone notices they have it.
-DEFAULT_TOKEN_TTL = 30
-# Allowance for clock drift between the VPS and the homelab. Small on purpose:
-# every second here widens the replay window at both ends.
-DEFAULT_CLOCK_SKEW = 5
-
-# An HMAC key shorter than its own digest is weaker than the primitive it feeds.
-MIN_SIGNING_KEY_BYTES = 32
 
 # Per-actor request budget. The dashboard renders a handful of calls per page,
 # so this is roughly two orders of magnitude above honest use.
@@ -81,10 +83,6 @@ MAX_REQUEST_BYTES = 16 * 1024
 # unbounded loop.
 MAX_GUILD_IDS = 200
 
-TOKEN_VERSION = "v1"
-# Scope used by the one endpoint that is about the actor rather than a guild.
-OP_LIST_GUILDS = "GET /api/v1/guilds"
-
 
 class BotAPIConfigError(RuntimeError):
     """The API was switched on but cannot be started safely."""
@@ -98,22 +96,6 @@ DEPS_KEY: "web.AppKey" = web.AppKey("deps")
 REPLAY_KEY: "web.AppKey" = web.AppKey("replay")
 RATE_KEY: "web.AppKey" = web.AppKey("rate_limiter")
 GLOBAL_RATE_KEY: "web.AppKey" = web.AppKey("global_rate_limiter")
-
-
-class TokenError(Exception):
-    """A token was absent, malformed, expired, or not for this request.
-
-    `actor` is set for every failure raised *after* the signature verified, so
-    the denial log can name who minted the token. That is the difference
-    between "someone sent us garbage" and "this specific signed-in user tried
-    to reach a guild they were not scoped for" — and the second is the one
-    worth alerting on.
-    """
-
-    def __init__(self, reason: str, actor: Optional[int] = None):
-        super().__init__(reason)
-        self.reason = reason
-        self.actor = actor
 
 
 # -------------------------------------------------------------------
@@ -282,133 +264,10 @@ def build_ssl_context(config: BotAPIConfig) -> ssl.SSLContext:
 # -------------------------------------------------------------------
 # Scoped request tokens
 # -------------------------------------------------------------------
-def _b64encode(raw: bytes) -> str:
-    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
-
-
-def _b64decode(raw: str) -> bytes:
-    padding = "=" * (-len(raw) % 4)
-    return base64.urlsafe_b64decode(raw + padding)
-
-
-def _canonical(payload: dict) -> bytes:
-    return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
-def mint_token(
-    signing_key: bytes,
-    *,
-    actor_id: int,
-    operation: str,
-    guild_id: Optional[int] = None,
-    ttl: int = DEFAULT_TOKEN_TTL,
-    now: Optional[float] = None,
-) -> str:
-    """Sign one token for one call.
-
-    Lives here rather than in the dashboard so both ends share exactly one
-    implementation of the format — a signer and a verifier that drift apart is
-    the classic way an auth scheme quietly stops meaning anything.
-    """
-    issued = int(now if now is not None else time.time())
-    payload = {
-        "act": int(actor_id),
-        "gid": None if guild_id is None else int(guild_id),
-        "op": operation,
-        "iat": issued,
-        "exp": issued + int(ttl),
-        "jti": _b64encode(secrets.token_bytes(12)),
-    }
-    encoded = _b64encode(_canonical(payload))
-    signature = hmac.new(signing_key, encoded.encode("ascii"), sha256).digest()
-    return f"{TOKEN_VERSION}.{encoded}.{_b64encode(signature)}"
-
-
-@dataclass(frozen=True)
-class TokenClaims:
-    actor_id: int
-    guild_id: Optional[int]
-    operation: str
-    expires_at: int
-    jti: str
-
-
-def verify_token(
-    token: str,
-    signing_key: bytes,
-    *,
-    expected_operation: str,
-    expected_guild_id: Optional[int],
-    max_ttl: int = DEFAULT_TOKEN_TTL,
-    clock_skew: int = DEFAULT_CLOCK_SKEW,
-    now: Optional[float] = None,
-) -> TokenClaims:
-    """Authenticate a token and confirm it was minted for *this* request.
-
-    The signature is checked before the payload is parsed, so no attacker-
-    supplied JSON is ever deserialised on an unauthenticated path.
-    """
-    current = now if now is not None else time.time()
-
-    parts = token.split(".")
-    if len(parts) != 3 or parts[0] != TOKEN_VERSION:
-        raise TokenError("malformed")
-    _, encoded, signature = parts
-
-    expected_sig = hmac.new(signing_key, encoded.encode("ascii"), sha256).digest()
-    try:
-        provided_sig = _b64decode(signature)
-    except (binascii.Error, ValueError):
-        raise TokenError("malformed")
-    if not hmac.compare_digest(expected_sig, provided_sig):
-        raise TokenError("bad_signature")
-
-    try:
-        payload = json.loads(_b64decode(encoded))
-    except (binascii.Error, ValueError, UnicodeDecodeError):
-        raise TokenError("malformed")
-    if not isinstance(payload, dict):
-        raise TokenError("malformed")
-
-    try:
-        actor_id = int(payload["act"])
-        operation = payload["op"]
-        issued_at = int(payload["iat"])
-        expires_at = int(payload["exp"])
-        jti = payload["jti"]
-        raw_guild = payload["gid"]
-        guild_id = None if raw_guild is None else int(raw_guild)
-    except (KeyError, TypeError, ValueError):
-        raise TokenError("malformed")
-    if not isinstance(operation, str) or not isinstance(jti, str) or not jti:
-        raise TokenError("malformed")
-
-    # Past this point the signature has verified, so every refusal below can
-    # name the actor it was minted for.
-    if expires_at <= current - clock_skew:
-        raise TokenError("expired", actor=actor_id)
-    if issued_at > current + clock_skew:
-        raise TokenError("not_yet_valid", actor=actor_id)
-    # A token whose own window is longer than we ever issue is either a bug in
-    # the dashboard or someone minting their own with a leaked key. Neither is
-    # a request worth serving.
-    if expires_at - issued_at > max_ttl:
-        raise TokenError("ttl_too_long", actor=actor_id)
-
-    # The two checks that make interception useless: a token is good for one
-    # operation against one guild, and nothing else.
-    if operation != expected_operation:
-        raise TokenError("wrong_operation", actor=actor_id)
-    if guild_id != expected_guild_id:
-        raise TokenError("wrong_guild", actor=actor_id)
-
-    return TokenClaims(
-        actor_id=actor_id,
-        guild_id=guild_id,
-        operation=operation,
-        expires_at=expires_at,
-        jti=jti,
-    )
+# The format itself lives in api_tokens.py so the dashboard can sign with the
+# identical implementation this verifies with, without also having to install
+# aiohttp. Re-exported here because this module is where the enforcement side
+# lives, and callers should not need to know the split exists.
 
 
 class ReplayGuard:

--- a/src/dashboard/__init__.py
+++ b/src/dashboard/__init__.py
@@ -1,0 +1,6 @@
+"""VRCVerify web dashboard (issue #65).
+
+Runs on the public VPS. Deliberately holds no database credential and no
+Discord bot token: everything it knows about a server it asks the bot for, over
+mTLS, and every answer is authorised by the bot rather than here.
+"""

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,0 +1,340 @@
+"""The dashboard web app — step 3 of issue #65: login, session, picker.
+
+Read-only. There is no route here that changes anything about a server; the
+bot API it talks to has no write endpoint to call even if there were. Saving
+settings is step 5, and it arrives with the audit trail.
+
+Design notes worth keeping in view while reading:
+
+* **Cloudflare Access sits in front of this in development and comes off at
+  launch.** Nothing here may ever read `Cf-Access-*` headers, because code that
+  authorised on them would silently become a complete bypass the day the wall
+  is removed. Authority is the Discord session plus the bot's own answer.
+* **The reverse proxy is trusted for exactly one thing**: the scheme, via
+  `X-Forwarded-Proto`. Without it Flask builds `http://` callback URLs and
+  Discord rejects them.
+* **No client-side framework, no CDN, no inline script.** The CSP below is
+  strict enough to be worth having only because the pages are plain enough not
+  to need anything else.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from typing import Optional
+
+from flask import (
+    Flask,
+    abort,
+    g,
+    make_response,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from werkzeug.middleware.proxy_fix import ProxyFix
+
+from dashboard import oauth
+from dashboard.botapi import BotAPIClient, BotAPIError
+from dashboard.config import DashboardConfig
+from dashboard.sessions import SessionStore
+
+logger = logging.getLogger(__name__)
+
+SESSION_COOKIE = "vrcverify_session"
+
+# Everything is same-origin and self-hosted, so the policy can be close to
+# nothing. The one external origin is Discord's icon CDN: guild icons are
+# served from there and proxying them would mean the dashboard fetching
+# arbitrary URLs on a user's behalf, which is a worse trade than allowing one
+# well-known image host. Note it is img-src only -- no script or style may come
+# from anywhere but here.
+CSP = (
+    "default-src 'none'; "
+    "script-src 'self'; "
+    "style-src 'self'; "
+    "img-src 'self' https://cdn.discordapp.com; "
+    "form-action 'self'; "
+    "base-uri 'none'; "
+    "frame-ancestors 'none'"
+)
+
+
+def create_app(
+    config: Optional[DashboardConfig] = None,
+    *,
+    store: Optional[SessionStore] = None,
+    client: Optional[BotAPIClient] = None,
+) -> Flask:
+    config = config or DashboardConfig.from_env()
+    app = Flask(__name__)
+    app.config["DASHBOARD"] = config
+    app.secret_key = config.secret_key
+
+    # Trust exactly one hop, for exactly the scheme and host. cloudflared is
+    # the only thing that can reach this app -- it has no published port -- so
+    # one hop is the whole chain.
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1, x_for=1)
+
+    app.config["STORE"] = store or SessionStore(
+        config.session_db_path, config.session_max_age
+    )
+    app.config["BOT_API"] = client or BotAPIClient(
+        config.bot_api_url,
+        client_cert=config.bot_api_client_cert,
+        client_key=config.bot_api_client_key,
+        ca_bundle=config.bot_api_ca,
+        signing_key=config.bot_api_signing_key,
+        timeout=config.request_timeout,
+    )
+
+    _register_routes(app)
+    _register_hooks(app)
+    return app
+
+
+# -------------------------------------------------------------------
+# Request plumbing
+# -------------------------------------------------------------------
+def _store() -> SessionStore:
+    from flask import current_app
+
+    return current_app.config["STORE"]
+
+
+def _config() -> DashboardConfig:
+    from flask import current_app
+
+    return current_app.config["DASHBOARD"]
+
+
+def _bot_api() -> BotAPIClient:
+    from flask import current_app
+
+    return current_app.config["BOT_API"]
+
+
+def _register_hooks(app: Flask) -> None:
+    @app.before_request
+    def load_session():
+        g.session = _store().load(request.cookies.get(SESSION_COOKIE))
+
+    @app.after_request
+    def harden(response):
+        response.headers["Content-Security-Policy"] = CSP
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        # The dashboard URL identifies a server admin. Sending it to Discord's
+        # CDN with every icon request would leak which guild is being looked at.
+        response.headers["Referrer-Policy"] = "no-referrer"
+        response.headers["Cross-Origin-Opener-Policy"] = "same-origin"
+        # Authenticated pages must not sit in a shared cache, and there is
+        # nothing here worth caching anyway.
+        response.headers["Cache-Control"] = "no-store"
+        # Cloudflare terminates TLS, but HSTS is the origin's statement, and a
+        # future non-tunnel deployment should still carry it.
+        response.headers["Strict-Transport-Security"] = (
+            "max-age=31536000; includeSubDomains"
+        )
+        return response
+
+
+def _set_session_cookie(response, sid: str, max_age: int):
+    response.set_cookie(
+        SESSION_COOKIE,
+        sid,
+        max_age=max_age,
+        # Not readable from JavaScript, only sent over TLS, and not attached to
+        # cross-site requests -- which is also what makes the logout form's
+        # CSRF token a second line rather than the only one.
+        httponly=True,
+        secure=True,
+        samesite="Lax",
+        path="/",
+    )
+    return response
+
+
+def _require_login():
+    session = getattr(g, "session", None)
+    if session is None or not session.authenticated:
+        return None
+    return session
+
+
+# -------------------------------------------------------------------
+# Routes
+# -------------------------------------------------------------------
+def _register_routes(app: Flask) -> None:
+    @app.get("/healthz")
+    def healthz():
+        """Liveness only. Says nothing about sessions, guilds or the bot."""
+        return {"ok": True}
+
+    @app.get("/")
+    def index():
+        session = _require_login()
+        if session is None:
+            return render_template("login.html")
+
+        config = _config()
+        # Display filter only. `admin_hint` came from Discord at authorisation
+        # time and is already stale; it decides which tiles to draw, never what
+        # anyone may do.
+        candidates = [g_ for g_ in (session.guilds or []) if g_.get("admin_hint")]
+
+        try:
+            installed = _bot_api().admin_guild_ids(
+                int(session.discord_id), [g_["id"] for g_ in candidates]
+            )
+            reachable = True
+        except BotAPIError as error:
+            # The picker still renders, with everything shown as un-installed
+            # and a banner explaining why. Better than a blank page that looks
+            # like the user has no servers.
+            logger.warning("bot API unreachable while rendering the picker: %s", error)
+            installed = set()
+            reachable = False
+
+        servers = [
+            {
+                "id": g_["id"],
+                "name": g_["name"],
+                "icon_url": oauth.icon_url(g_),
+                "installed": g_["id"] in installed,
+                "invite_url": _invite_url(config.discord_client_id, g_["id"]),
+            }
+            for g_ in candidates
+        ]
+        # Installed first, then alphabetical -- the ones you can actually
+        # configure are the reason you came.
+        servers.sort(key=lambda s: (not s["installed"], s["name"].lower()))
+
+        return render_template(
+            "picker.html",
+            servers=servers,
+            reachable=reachable,
+            csrf_token=session.csrf_token,
+        )
+
+    @app.get("/login")
+    def login():
+        state = oauth.new_state()
+        session = _store().begin_login(state)
+        config = _config()
+        response = redirect(
+            oauth.authorize_url(
+                config.discord_client_id, config.oauth_redirect_uri, state
+            )
+        )
+        # 600s: the pre-auth row's own lifetime. An abandoned login should not
+        # leave a cookie behind for hours.
+        return _set_session_cookie(response, session.sid, 600)
+
+    @app.get("/callback")
+    def callback():
+        config = _config()
+        store = _store()
+        pending = store.load(request.cookies.get(SESSION_COOKIE))
+
+        error = request.args.get("error")
+        if error:
+            # User clicked Cancel, or Discord refused. Not an error condition
+            # worth a stack trace.
+            return render_template("error.html", message="Authorisation was declined."), 400
+
+        code = request.args.get("code")
+        state = request.args.get("state")
+        if pending is None or not pending.oauth_state or not code or not state:
+            return render_template("error.html", message="That login link has expired. Please try again."), 400
+
+        # The check that makes CSRF against the login flow impossible: the
+        # state came from us, in this browser, for this attempt.
+        if not secrets.compare_digest(pending.oauth_state, state):
+            logger.warning("OAuth state mismatch; refusing the callback.")
+            store.destroy(pending.sid)
+            return render_template("error.html", message="That login could not be verified. Please try again."), 400
+
+        try:
+            discord_id, guilds = oauth.login(
+                code,
+                client_id=config.discord_client_id,
+                client_secret=config.discord_client_secret,
+                redirect_uri=config.oauth_redirect_uri,
+                timeout=config.request_timeout,
+            )
+        except oauth.OAuthError as failure:
+            logger.warning("OAuth login failed: %s", failure)
+            store.destroy(pending.sid)
+            return render_template("error.html", message="Discord could not complete the login. Please try again."), 502
+
+        # New session id at the moment privilege is granted; the pre-auth row
+        # is deleted. See SessionStore.complete_login.
+        session = store.complete_login(pending.sid, discord_id, guilds)
+        logger.info("dashboard login actor=%s guilds=%d", discord_id, len(guilds))
+        return _set_session_cookie(
+            redirect(url_for("index")), session.sid, config.session_max_age
+        )
+
+    @app.post("/logout")
+    def logout():
+        session = _require_login()
+        if session is not None:
+            submitted = request.form.get("csrf_token", "")
+            if not secrets.compare_digest(session.csrf_token, submitted):
+                abort(400)
+            _store().destroy(session.sid)
+        response = redirect(url_for("index"))
+        response.delete_cookie(SESSION_COOKIE, path="/")
+        return response
+
+    @app.errorhandler(404)
+    def not_found(_error):
+        return render_template("error.html", message="Page not found."), 404
+
+    @app.errorhandler(500)
+    def server_error(_error):  # pragma: no cover - defensive
+        return render_template("error.html", message="Something went wrong."), 500
+
+
+def _invite_url(client_id: str, guild_id: str) -> str:
+    """Deep-link the bot's install flow at one specific server.
+
+    `disable_guild_select` plus `guild_id` means the admin lands on the right
+    server rather than a dropdown, which is the whole reason a greyed-out tile
+    is worth clicking.
+
+    The permissions integer is what the bot actually needs: Manage Roles (to
+    assign the verified role), and Send Messages / Embed Links / Read History
+    (to post and maintain the instructions panel). Asking for more would be a
+    worse pitch and a bigger blast radius.
+    """
+    permissions = (
+        0x10000000  # Manage Roles
+        | 0x800  # Send Messages
+        | 0x4000  # Embed Links
+        | 0x10000  # Read Message History
+        | 0x400  # View Channel
+    )
+    return (
+        "https://discord.com/oauth2/authorize"
+        f"?client_id={client_id}"
+        f"&scope=bot+applications.commands"
+        f"&permissions={permissions}"
+        f"&guild_id={guild_id}"
+        "&disable_guild_select=true"
+    )
+
+
+def main():  # pragma: no cover - container entrypoint
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    return create_app()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main().run(host="127.0.0.1", port=8000)

--- a/src/dashboard/botapi.py
+++ b/src/dashboard/botapi.py
@@ -1,0 +1,165 @@
+"""The client half of the bot's internal API.
+
+Every call carries two independent proofs:
+
+* the **client certificate**, presented at the TLS layer and checked against
+  the bot's CA (and, in production, pinned by CN). This authenticates the
+  *dashboard*.
+* a **scoped token**, minted here per request from the shared signing key,
+  naming the acting Discord user, the target guild, and the exact operation.
+  This authorises one specific thing on behalf of one specific person.
+
+Neither is sufficient alone, and that is deliberate: a leaked certificate
+cannot act as a user, and a leaked signing key cannot reach the port.
+
+Note the token names an actor but does not *prove* they are an administrator.
+The bot decides that itself, per request, from its own gateway cache. Nothing
+this module sends is trusted as an authority claim.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import requests
+
+from api_tokens import (
+    OP_GUILD_CHANNELS,
+    OP_GUILD_PANEL,
+    OP_GUILD_ROLES,
+    OP_GUILD_SETTINGS,
+    OP_LIST_GUILDS,
+    mint_token,
+)
+
+logger = logging.getLogger(__name__)
+
+# The bot answers about at most this many guilds in one call.
+MAX_GUILD_IDS = 200
+
+
+class BotAPIError(Exception):
+    """The bot API could not be reached, or refused the request."""
+
+    def __init__(self, message: str, status: Optional[int] = None):
+        super().__init__(message)
+        self.status = status
+
+
+class BotAPIClient:
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        client_cert: str,
+        client_key: str,
+        ca_bundle: str,
+        signing_key: bytes,
+        timeout: int = 10,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.signing_key = signing_key
+        self.timeout = timeout
+        self._session = requests.Session()
+        # Both halves of mTLS in one place: our certificate, and the CA we
+        # require the bot to have been signed by. `verify` must never become
+        # False -- without it this is an encrypted channel to whoever answers.
+        self._session.cert = (client_cert, client_key)
+        self._session.verify = ca_bundle
+
+    # ----- plumbing -----
+    def _get(self, path: str, operation: str, actor_id: int, guild_id=None) -> dict:
+        token = mint_token(
+            self.signing_key,
+            actor_id=int(actor_id),
+            operation=operation,
+            guild_id=None if guild_id is None else int(guild_id),
+        )
+        try:
+            response = self._session.get(
+                f"{self.base_url}{path}",
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=self.timeout,
+            )
+        except requests.exceptions.SSLError as error:
+            # Worth its own branch: this is the failure that means the trust
+            # chain is wrong, not that the request was refused. Confusing the
+            # two costs hours.
+            raise BotAPIError(f"TLS failure talking to the bot API: {error}") from error
+        except requests.RequestException as error:
+            raise BotAPIError(f"could not reach the bot API: {error}") from error
+
+        if response.status_code == 200:
+            return response.json()
+
+        reason = ""
+        try:
+            reason = response.json().get("error", "")
+        except ValueError:
+            pass
+        logger.warning(
+            "bot API refused %s for actor=%s guild=%s: %s %s",
+            operation,
+            actor_id,
+            guild_id,
+            response.status_code,
+            reason,
+        )
+        raise BotAPIError(reason or "bot API refused the request", response.status_code)
+
+    # ----- reads -----
+    def healthz(self) -> dict:
+        """No token: proves the certificate and tunnel work, independent of auth."""
+        try:
+            response = self._session.get(
+                f"{self.base_url}/healthz", timeout=self.timeout
+            )
+        except requests.RequestException as error:
+            raise BotAPIError(f"could not reach the bot API: {error}") from error
+        if response.status_code != 200:
+            raise BotAPIError("bot API is not healthy", response.status_code)
+        return response.json()
+
+    def admin_guild_ids(self, actor_id: int, guild_ids: list) -> set:
+        """Which of these guilds the bot is in AND this user administers.
+
+        The bot answers only about guilds the caller has standing in, so a
+        guild missing from the response means either "bot not there" or "not
+        yours" — indistinguishable on purpose.
+        """
+        wanted = [str(int(g)) for g in guild_ids][:MAX_GUILD_IDS]
+        if not wanted:
+            return set()
+        payload = self._get(
+            f"/api/v1/guilds?ids={','.join(wanted)}",
+            OP_LIST_GUILDS,
+            actor_id,
+        )
+        return {str(g) for g in payload.get("present", [])}
+
+    def settings(self, actor_id: int, guild_id) -> dict:
+        return self._get(
+            f"/api/v1/guilds/{int(guild_id)}/settings",
+            OP_GUILD_SETTINGS,
+            actor_id,
+            guild_id,
+        )
+
+    def roles(self, actor_id: int, guild_id) -> list:
+        return self._get(
+            f"/api/v1/guilds/{int(guild_id)}/roles", OP_GUILD_ROLES, actor_id, guild_id
+        )
+
+    def channels(self, actor_id: int, guild_id) -> list:
+        return self._get(
+            f"/api/v1/guilds/{int(guild_id)}/channels",
+            OP_GUILD_CHANNELS,
+            actor_id,
+            guild_id,
+        )
+
+    def panel(self, actor_id: int, guild_id) -> dict:
+        return self._get(
+            f"/api/v1/guilds/{int(guild_id)}/panel", OP_GUILD_PANEL, actor_id, guild_id
+        )

--- a/src/dashboard/config.py
+++ b/src/dashboard/config.py
@@ -1,0 +1,152 @@
+"""Dashboard configuration, validated at startup or not started at all.
+
+Same discipline as `bot_api.BotAPIConfig`: a misconfiguration must stop the
+service rather than degrade it. A web app that boots with a weak session key or
+a missing client certificate is worse than one that refuses to boot, because
+nobody finds out until it matters.
+
+Everything here is read from the environment. Nothing is defaulted that would
+be dangerous to guess.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import urlparse
+
+from api_tokens import MIN_SIGNING_KEY_BYTES
+
+# Flask signs the session cookie with this. The cookie carries only an opaque
+# session id, but forging one is still forging a session, so it gets the same
+# floor as the API signing key.
+MIN_SECRET_KEY_BYTES = 32
+
+# How long a login lasts, no matter how active. Deliberately not sliding: an
+# absolute cap means a stolen cookie has a bounded life even if the thief keeps
+# it warm.
+DEFAULT_SESSION_MAX_AGE = 8 * 3600
+# How long the OAuth guild list is reused before the user has to log in again
+# to refresh it. The Discord token is discarded at login (see oauth.py), so
+# there is no way to refresh this without a new authorisation -- which is the
+# intended trade.
+DEFAULT_GUILD_CACHE_TTL = 900
+
+
+class DashboardConfigError(RuntimeError):
+    """The dashboard cannot start safely with the environment it was given."""
+
+
+@dataclass(frozen=True)
+class DashboardConfig:
+    discord_client_id: str
+    discord_client_secret: str
+    oauth_redirect_uri: str
+    secret_key: str
+    session_db_path: str
+    bot_api_url: str
+    bot_api_client_cert: str
+    bot_api_client_key: str
+    bot_api_ca: str
+    bot_api_signing_key: bytes
+    session_max_age: int = DEFAULT_SESSION_MAX_AGE
+    guild_cache_ttl: int = DEFAULT_GUILD_CACHE_TTL
+    request_timeout: int = 10
+
+    @classmethod
+    def from_env(cls) -> "DashboardConfig":
+        client_id = _require("DISCORD_CLIENT_ID")
+        client_secret = _require("DISCORD_CLIENT_SECRET")
+        redirect_uri = _require("OAUTH_REDIRECT_URI")
+        _validate_redirect(redirect_uri)
+
+        secret_key = _require("DASHBOARD_SECRET_KEY")
+        if len(secret_key) < MIN_SECRET_KEY_BYTES:
+            raise DashboardConfigError(
+                f"DASHBOARD_SECRET_KEY must be at least {MIN_SECRET_KEY_BYTES} "
+                "characters; refusing to start."
+            )
+
+        signing_key = _require("BOT_API_TOKEN_SIGNING_KEY").encode("utf-8")
+        if len(signing_key) < MIN_SIGNING_KEY_BYTES:
+            raise DashboardConfigError(
+                f"BOT_API_TOKEN_SIGNING_KEY must be at least {MIN_SIGNING_KEY_BYTES} "
+                "characters, and identical to the bot's; refusing to start."
+            )
+        if signing_key == secret_key.encode("utf-8"):
+            # Two different trust domains: one signs cookies handed to browsers,
+            # the other authorises calls into the homelab. Sharing them means a
+            # cookie-signing bug becomes an API-forgery bug.
+            raise DashboardConfigError(
+                "BOT_API_TOKEN_SIGNING_KEY and DASHBOARD_SECRET_KEY must differ."
+            )
+
+        bot_api_url = _require("BOT_API_URL").rstrip("/")
+        if not bot_api_url.startswith("https://"):
+            raise DashboardConfigError(
+                f"BOT_API_URL must be https; got {bot_api_url!r}. The mTLS is the "
+                "authentication, and plain http would discard it."
+            )
+
+        return cls(
+            discord_client_id=client_id,
+            discord_client_secret=client_secret,
+            oauth_redirect_uri=redirect_uri,
+            secret_key=secret_key,
+            session_db_path=os.getenv("SESSION_DB_PATH", "/data/sessions.db"),
+            bot_api_url=bot_api_url,
+            bot_api_client_cert=_require_file("BOT_API_CLIENT_CERT"),
+            bot_api_client_key=_require_file("BOT_API_CLIENT_KEY"),
+            bot_api_ca=_require_file("BOT_API_CA"),
+            bot_api_signing_key=signing_key,
+            session_max_age=_int_env("DASHBOARD_SESSION_MAX_AGE", DEFAULT_SESSION_MAX_AGE),
+            guild_cache_ttl=_int_env("DASHBOARD_GUILD_CACHE_TTL", DEFAULT_GUILD_CACHE_TTL),
+            request_timeout=_int_env("DASHBOARD_REQUEST_TIMEOUT", 10),
+        )
+
+
+def _require(name: str) -> str:
+    value = (os.getenv(name) or "").strip()
+    if not value:
+        raise DashboardConfigError(f"{name} is required; refusing to start.")
+    return value
+
+
+def _require_file(name: str) -> str:
+    path = _require(name)
+    if not os.path.isfile(path):
+        raise DashboardConfigError(f"{name} points at {path!r}, which is not a file.")
+    return path
+
+
+def _int_env(name: str, default: int, minimum: int = 1) -> int:
+    try:
+        return max(minimum, int(os.getenv(name, str(default))))
+    except ValueError:
+        return default
+
+
+def _validate_redirect(uri: str) -> None:
+    """The redirect URI is where Discord sends an authorisation code.
+
+    Over plain http that code crosses the network in the clear and can be
+    stolen and exchanged before the real user's browser gets there. Discord
+    itself allows http for localhost, and so do we, for local development only.
+    """
+    parsed = urlparse(uri)
+    if parsed.scheme == "https":
+        return
+    if parsed.scheme == "http" and parsed.hostname in {"localhost", "127.0.0.1"}:
+        return
+    raise DashboardConfigError(
+        f"OAUTH_REDIRECT_URI must be https (or http on localhost); got {uri!r}."
+    )
+
+
+def optional_config() -> Optional[DashboardConfig]:
+    """Config, or None -- for tooling that must import without a full env."""
+    try:
+        return DashboardConfig.from_env()
+    except DashboardConfigError:
+        return None

--- a/src/dashboard/oauth.py
+++ b/src/dashboard/oauth.py
@@ -1,0 +1,173 @@
+"""Discord OAuth — used to establish *who* someone is, and nothing else.
+
+The single most important thing in this module is what it throws away.
+
+`login()` exchanges the code, reads the user's id and guild list, and then
+discards the access token and refresh token without storing them anywhere. The
+public host is assumed to be compromised eventually; a stored Discord token
+would let whoever compromised it act as every user who ever logged in, against
+Discord, indefinitely. An id and a stale guild list are worth far less.
+
+What the guild list is *for* also matters. It renders the picker — which server
+tiles to show, and which to grey out. It is **not** authority. The `permissions`
+field Discord returns here describes the user at the moment they authorised,
+and is used only as a display hint; every real decision is re-asked of the bot,
+which reads its own gateway cache. See `bot_api.dashboard_is_admin`.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Optional
+from urllib.parse import urlencode
+
+import requests
+
+DISCORD_API = "https://discord.com/api/v10"
+AUTHORIZE_URL = "https://discord.com/oauth2/authorize"
+TOKEN_URL = f"{DISCORD_API}/oauth2/token"
+
+# `identify` gives us the user id. `guilds` gives us the list to render.
+# Nothing else is requested, because nothing else is needed, and every extra
+# scope is something a compromised host could have used.
+SCOPES = "identify guilds"
+
+# Discord's ADMINISTRATOR permission bit.
+ADMINISTRATOR = 0x8
+
+
+class OAuthError(Exception):
+    """The authorisation could not be completed."""
+
+
+def new_state() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def authorize_url(client_id: str, redirect_uri: str, state: str) -> str:
+    """Where to send the browser to start a login."""
+    return f"{AUTHORIZE_URL}?" + urlencode(
+        {
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "scope": SCOPES,
+            "state": state,
+            # Always re-prompt. Without this Discord silently reuses an
+            # existing authorisation, which makes "log in as someone else" on a
+            # shared machine quietly impossible.
+            "prompt": "consent",
+        }
+    )
+
+
+def exchange_code(
+    code: str,
+    *,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+    timeout: int = 10,
+    session: Optional[requests.Session] = None,
+) -> str:
+    """Swap the authorisation code for an access token. Returns the token."""
+    http = session or requests
+    response = http.post(
+        TOKEN_URL,
+        data={
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=timeout,
+    )
+    if response.status_code != 200:
+        # Deliberately not echoing the body: it can contain the code we sent.
+        raise OAuthError(f"token exchange failed ({response.status_code})")
+    token = response.json().get("access_token")
+    if not token:
+        raise OAuthError("token exchange returned no access_token")
+    return token
+
+
+def fetch_identity(
+    access_token: str, *, timeout: int = 10, session: Optional[requests.Session] = None
+) -> tuple[str, list]:
+    """Read the user's id and guild list. Returns (discord_id, guilds)."""
+    http = session or requests
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    me = http.get(f"{DISCORD_API}/users/@me", headers=headers, timeout=timeout)
+    if me.status_code != 200:
+        raise OAuthError(f"could not read the user ({me.status_code})")
+    discord_id = str(me.json()["id"])
+
+    guilds = http.get(f"{DISCORD_API}/users/@me/guilds", headers=headers, timeout=timeout)
+    if guilds.status_code != 200:
+        raise OAuthError(f"could not read the guild list ({guilds.status_code})")
+
+    return discord_id, [_shape_guild(g) for g in guilds.json()]
+
+
+def _shape_guild(raw: dict) -> dict:
+    """Keep only what the picker draws, and label the hint as a hint.
+
+    `admin_hint` is exactly that. It comes from the permissions Discord handed
+    us at authorisation time, so it is already stale by the time it is
+    rendered, and a user demoted since then would still see the tile. That is
+    acceptable *because opening the server asks the bot*, which answers from
+    its own gateway cache. Never let this field gate anything.
+    """
+    try:
+        permissions = int(raw.get("permissions", 0))
+    except (TypeError, ValueError):
+        permissions = 0
+    return {
+        "id": str(raw.get("id", "")),
+        "name": raw.get("name") or "(unnamed server)",
+        "icon": raw.get("icon"),
+        "admin_hint": bool(raw.get("owner")) or bool(permissions & ADMINISTRATOR),
+    }
+
+
+def login(
+    code: str,
+    *,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+    timeout: int = 10,
+    session: Optional[requests.Session] = None,
+) -> tuple[str, list]:
+    """The whole flow, ending with the token out of scope and unreferenced.
+
+    Returning only (discord_id, guilds) is the point: there is no path by which
+    a caller could persist the token, because it never leaves this function.
+    `tests/test_dashboard.py` asserts that no stored session ever contains it.
+    """
+    access_token = exchange_code(
+        code,
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+        timeout=timeout,
+        session=session,
+    )
+    return fetch_identity(access_token, timeout=timeout, session=session)
+
+
+def icon_url(guild: dict, size: int = 64) -> Optional[str]:
+    """Discord's CDN URL for a guild icon, at an explicit small size.
+
+    Explicit size because the default is large, and the picker may draw dozens
+    of these; the width is the whole cost of the page.
+    """
+    if not guild.get("icon") or not guild.get("id"):
+        return None
+    return (
+        f"https://cdn.discordapp.com/icons/{guild['id']}/{guild['icon']}.png"
+        f"?size={size}"
+    )

--- a/src/dashboard/sessions.py
+++ b/src/dashboard/sessions.py
@@ -1,0 +1,201 @@
+"""Server-side sessions, in SQLite.
+
+Server-side rather than a signed cookie for two reasons that matter here:
+
+* **They can be destroyed.** A cookie session is valid until it expires, no
+  matter what you learn afterwards. A row can be deleted, which is what makes
+  logout mean something and what lets a compromised session be cut off.
+* **The cached guild list would not fit in a cookie**, and putting it there
+  would hand every user an editable copy of what the picker renders from.
+
+What is deliberately *not* stored: the Discord access token, and the refresh
+token. Both are discarded the moment login completes (see `oauth.py`). The
+public host therefore holds no credential that can act as the user against
+Discord — only their id and a short-lived copy of their guild list, which is
+data rather than authority. Refreshing that list means logging in again, and
+that is the intended trade rather than an omission.
+
+The schema is created on first use. There is no migration story because there
+is nothing here worth migrating: worst case the file is deleted and everyone
+logs in again.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import sqlite3
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+# 32 bytes of urandom, url-safe. The session id is the only thing standing
+# between a cookie and an account, so it is generated the same way the API
+# tokens are rather than from anything predictable.
+SESSION_ID_BYTES = 32
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS sessions (
+    sid            TEXT PRIMARY KEY,
+    discord_id     TEXT,
+    oauth_state    TEXT,
+    csrf_token     TEXT NOT NULL,
+    guilds_json    TEXT,
+    guilds_at      INTEGER,
+    created_at     INTEGER NOT NULL,
+    expires_at     INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS sessions_expires_at ON sessions (expires_at);
+"""
+
+
+@dataclass
+class Session:
+    sid: str
+    discord_id: Optional[str]
+    oauth_state: Optional[str]
+    csrf_token: str
+    guilds: Optional[list]
+    guilds_at: Optional[int]
+    created_at: int
+    expires_at: int
+
+    @property
+    def authenticated(self) -> bool:
+        """A session exists from the moment login *starts*, not when it ends.
+
+        The pre-auth row is what carries the OAuth state across the redirect.
+        It is a session with no identity, and must never be treated as one.
+        """
+        return self.discord_id is not None
+
+    def guilds_fresh(self, ttl: int, now: Optional[float] = None) -> bool:
+        if self.guilds is None or self.guilds_at is None:
+            return False
+        current = now if now is not None else time.time()
+        return (current - self.guilds_at) < ttl
+
+
+class SessionStore:
+    def __init__(self, path: str, max_age: int):
+        self.path = path
+        self.max_age = max_age
+        self._connect().close()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path, timeout=10)
+        conn.row_factory = sqlite3.Row
+        conn.executescript(_SCHEMA)
+        return conn
+
+    # ----- lifecycle -----
+    def begin_login(self, oauth_state: str, now: Optional[float] = None) -> Session:
+        """Create the pre-auth row that carries OAuth state across the redirect."""
+        current = int(now if now is not None else time.time())
+        session = Session(
+            sid=secrets.token_urlsafe(SESSION_ID_BYTES),
+            discord_id=None,
+            oauth_state=oauth_state,
+            csrf_token=secrets.token_urlsafe(32),
+            guilds=None,
+            guilds_at=None,
+            created_at=current,
+            # A login that is started and abandoned should not sit around for
+            # the full session lifetime.
+            expires_at=current + 600,
+        )
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO sessions (sid, discord_id, oauth_state, csrf_token,"
+                " guilds_json, guilds_at, created_at, expires_at)"
+                " VALUES (?, NULL, ?, ?, NULL, NULL, ?, ?)",
+                (
+                    session.sid,
+                    session.oauth_state,
+                    session.csrf_token,
+                    session.created_at,
+                    session.expires_at,
+                ),
+            )
+        return session
+
+    def complete_login(
+        self, sid: str, discord_id: str, guilds: list, now: Optional[float] = None
+    ) -> Session:
+        """Promote a pre-auth row to an authenticated one, under a NEW id.
+
+        The id change is not cosmetic. Without it, an attacker who can set a
+        victim's cookie before login (session fixation) still knows the id
+        afterwards, and the victim authenticates the attacker's session for
+        them. Issuing a fresh id at the moment privilege is granted breaks
+        that, and the old row is deleted rather than left usable.
+        """
+        current = int(now if now is not None else time.time())
+        session = Session(
+            sid=secrets.token_urlsafe(SESSION_ID_BYTES),
+            discord_id=str(discord_id),
+            oauth_state=None,
+            csrf_token=secrets.token_urlsafe(32),
+            guilds=guilds,
+            guilds_at=current,
+            created_at=current,
+            expires_at=current + self.max_age,
+        )
+        with self._connect() as conn:
+            conn.execute("DELETE FROM sessions WHERE sid = ?", (sid,))
+            conn.execute(
+                "INSERT INTO sessions (sid, discord_id, oauth_state, csrf_token,"
+                " guilds_json, guilds_at, created_at, expires_at)"
+                " VALUES (?, ?, NULL, ?, ?, ?, ?, ?)",
+                (
+                    session.sid,
+                    session.discord_id,
+                    session.csrf_token,
+                    json.dumps(guilds),
+                    session.guilds_at,
+                    session.created_at,
+                    session.expires_at,
+                ),
+            )
+        return session
+
+    def load(self, sid: Optional[str], now: Optional[float] = None) -> Optional[Session]:
+        if not sid:
+            return None
+        current = int(now if now is not None else time.time())
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM sessions WHERE sid = ?", (sid,)
+            ).fetchone()
+        if row is None:
+            return None
+        if row["expires_at"] <= current:
+            # Expired rows are removed on sight rather than waiting for a
+            # sweep, so an expired session can never be resurrected by a clock
+            # adjustment.
+            self.destroy(sid)
+            return None
+        return Session(
+            sid=row["sid"],
+            discord_id=row["discord_id"],
+            oauth_state=row["oauth_state"],
+            csrf_token=row["csrf_token"],
+            guilds=json.loads(row["guilds_json"]) if row["guilds_json"] else None,
+            guilds_at=row["guilds_at"],
+            created_at=row["created_at"],
+            expires_at=row["expires_at"],
+        )
+
+    def destroy(self, sid: Optional[str]) -> None:
+        if not sid:
+            return
+        with self._connect() as conn:
+            conn.execute("DELETE FROM sessions WHERE sid = ?", (sid,))
+
+    def purge_expired(self, now: Optional[float] = None) -> int:
+        current = int(now if now is not None else time.time())
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "DELETE FROM sessions WHERE expires_at <= ?", (current,)
+            )
+            return cursor.rowcount

--- a/src/dashboard/static/style.css
+++ b/src/dashboard/static/style.css
@@ -1,0 +1,162 @@
+/* Plain on purpose.
+ *
+ * No framework, no webfont, no CDN. Partly because the CSP forbids external
+ * origins and this is what makes that policy cheap to keep, and partly because
+ * the whole page is a list of servers and a form -- anything more would be
+ * weight an admin pays for on every visit for no benefit.
+ *
+ * No animations and no spinners, per the original request. */
+
+:root {
+  color-scheme: light dark;
+  --bg: #f5f6f8;
+  --panel: #ffffff;
+  --ink: #1c1e21;
+  --muted: #5c6570;
+  --line: #dfe3e8;
+  --accent: #5865f2;
+  --notice: #8a6d00;
+  --notice-bg: #fff6d6;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #15171a;
+    --panel: #1e2126;
+    --ink: #e8eaed;
+    --muted: #99a1ab;
+    --line: #2e333a;
+    --accent: #7d88f7;
+    --notice: #ffd66b;
+    --notice-bg: #33290a;
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font: 16px/1.55 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+.bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1.25rem;
+  background: var(--panel);
+  border-bottom: 1px solid var(--line);
+}
+
+.brand { font-weight: 650; color: var(--ink); text-decoration: none; }
+
+main { max-width: 60rem; margin: 0 auto; padding: 1.5rem 1.25rem 3rem; }
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 1.5rem;
+}
+
+.centered { max-width: 34rem; margin: 3rem auto; }
+
+h1 { margin: 0 0 0.75rem; font-size: 1.4rem; }
+
+.muted { color: var(--muted); font-size: 0.925rem; }
+
+.notice {
+  background: var(--notice-bg);
+  color: var(--notice);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  margin: 0 0 1.25rem;
+}
+
+.button {
+  display: inline-block;
+  background: var(--accent);
+  color: #fff;
+  padding: 0.6rem 1.15rem;
+  border-radius: 8px;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+button.link {
+  background: none;
+  border: 0;
+  padding: 0;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.925rem;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+/* --- server picker --- */
+.servers {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
+  gap: 1.25rem;
+}
+
+.server { text-align: center; }
+
+.server a,
+.server > .icon {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+
+.icon {
+  display: block;
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 0.5rem;
+  border-radius: 50%;
+  overflow: hidden;
+  background: var(--line);
+}
+
+.icon img { display: block; width: 64px; height: 64px; border-radius: 50%; }
+
+.initial {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: 1.5rem;
+  font-weight: 650;
+  color: var(--muted);
+}
+
+.name {
+  display: block;
+  font-size: 0.925rem;
+  overflow-wrap: anywhere;
+}
+
+.state { display: block; font-size: 0.8rem; color: var(--muted); }
+
+/* Servers the bot isn't in. Greyscale reads as "available but not set up",
+ * which is why the whole tile is the install link. */
+.server.absent .icon img { filter: grayscale(1); opacity: 0.55; }
+.server.absent .name { color: var(--muted); }
+.server.absent .state { color: var(--accent); }
+
+footer {
+  max-width: 60rem;
+  margin: 0 auto;
+  padding: 0 1.25rem 2rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+}

--- a/src/dashboard/templates/base.html
+++ b/src/dashboard/templates/base.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}VRCVerify{% endblock %}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  {# No <script> anywhere in this app. The CSP forbids inline script, and
+     nothing here needs JavaScript to work. #}
+</head>
+<body>
+  <header class="bar">
+    <a class="brand" href="{{ url_for('index') }}">VRCVerify</a>
+    {% if csrf_token %}
+      <form method="post" action="{{ url_for('logout') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+        <button type="submit" class="link">Sign out</button>
+      </form>
+    {% endif %}
+  </header>
+
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+
+  <footer>
+    <p>Core 18+ verification is free, forever.</p>
+  </footer>
+</body>
+</html>

--- a/src/dashboard/templates/error.html
+++ b/src/dashboard/templates/error.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block title %}VRCVerify{% endblock %}
+
+{% block content %}
+<section class="panel centered">
+  <h1>Sorry</h1>
+  <p>{{ message }}</p>
+  <p><a class="button" href="{{ url_for('index') }}">Back to your servers</a></p>
+</section>
+{% endblock %}

--- a/src/dashboard/templates/login.html
+++ b/src/dashboard/templates/login.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}Sign in — VRCVerify{% endblock %}
+
+{% block content %}
+<section class="panel centered">
+  <h1>Server settings</h1>
+  <p>
+    Sign in with Discord to configure VRCVerify on the servers you administer.
+  </p>
+  <p class="muted">
+    You'll be asked for your identity and your server list, and nothing else.
+    We don't keep your Discord token after you sign in, and this site can't
+    see who has verified — only your server's settings.
+  </p>
+  <p>
+    <a class="button" href="{{ url_for('login') }}">Sign in with Discord</a>
+  </p>
+  <p class="muted">
+    You can configure everything here from inside Discord instead, with
+    <code>/vrcverify_settings</code>. This site is an alternative, not a
+    replacement.
+  </p>
+</section>
+{% endblock %}

--- a/src/dashboard/templates/picker.html
+++ b/src/dashboard/templates/picker.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+{% block title %}Your servers — VRCVerify{% endblock %}
+
+{% block content %}
+<section class="panel">
+  <h1>Your servers</h1>
+
+  {% if not reachable %}
+    <p class="notice">
+      Can't reach the bot right now, so we can't tell which of these it's in.
+      Your settings are safe — nothing here has changed. Try again shortly.
+    </p>
+  {% endif %}
+
+  {% if not servers %}
+    <p class="muted">
+      No servers to show. This page lists servers where you have the
+      Administrator permission; if you manage one and don't see it, sign out
+      and back in to refresh the list.
+    </p>
+  {% else %}
+    <ul class="servers">
+      {% for server in servers %}
+        <li class="server {% if not server.installed %}absent{% endif %}">
+          {% if server.installed %}
+            {# Settings pages land in step 4; the tile is not a link yet. #}
+            <span class="icon" aria-hidden="true">
+              {% if server.icon_url %}
+                <img src="{{ server.icon_url }}" alt="" width="64" height="64" loading="lazy">
+              {% else %}
+                <span class="initial">{{ server.name[:1] | upper }}</span>
+              {% endif %}
+            </span>
+            <span class="name">{{ server.name }}</span>
+            <span class="state">Installed</span>
+          {% else %}
+            <a href="{{ server.invite_url }}" rel="noopener">
+              <span class="icon" aria-hidden="true">
+                {% if server.icon_url %}
+                  <img src="{{ server.icon_url }}" alt="" width="64" height="64" loading="lazy">
+                {% else %}
+                  <span class="initial">{{ server.name[:1] | upper }}</span>
+                {% endif %}
+              </span>
+              <span class="name">{{ server.name }}</span>
+              <span class="state">Add to this server</span>
+            </a>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+</section>
+{% endblock %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,517 @@
+"""Unit tests for the web dashboard (issue #65, step 3).
+
+This is the internet-facing half of the system, so the tests are mostly about
+the ways a login can be subverted rather than the happy path:
+
+- the Discord access token must never be persisted anywhere
+- a callback whose `state` doesn't match ours is refused
+- the session id changes at the moment privilege is granted
+- authority is never taken from OAuth data or from Cf-Access-* headers
+- the app refuses to start on a weak or missing secret
+- nothing here can write: the read-only phase is pinned
+"""
+
+import json
+import sqlite3
+import time
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("flask")
+
+from dashboard import oauth  # noqa: E402
+from dashboard.app import CSP, SESSION_COOKIE, create_app  # noqa: E402
+from dashboard.botapi import BotAPIError  # noqa: E402
+from dashboard.config import DashboardConfig, DashboardConfigError  # noqa: E402
+from dashboard.sessions import SessionStore  # noqa: E402
+
+ACTOR = "424242424242"
+GUILD_IN = "111111111111"
+GUILD_OUT = "222222222222"
+GUILD_NOT_ADMIN = "333333333333"
+
+SIGNING_KEY = "s" * 48
+SECRET_KEY = "k" * 48
+ACCESS_TOKEN = "discord-access-token-that-must-never-be-stored"
+
+
+# -------------------------------------------------------------------
+# Fixtures
+# -------------------------------------------------------------------
+@pytest.fixture
+def certs(tmp_path):
+    for name in ("client.pem", "client.key", "ca.pem"):
+        (tmp_path / name).write_text("placeholder")
+    return tmp_path
+
+
+@pytest.fixture
+def config(tmp_path, certs):
+    return DashboardConfig(
+        discord_client_id="1335738139825799188",
+        discord_client_secret="client-secret",
+        oauth_redirect_uri="https://dashboard.vrcverify.com/callback",
+        secret_key=SECRET_KEY,
+        session_db_path=str(tmp_path / "sessions.db"),
+        bot_api_url="https://100.117.6.99:5002",
+        bot_api_client_cert=str(certs / "client.pem"),
+        bot_api_client_key=str(certs / "client.key"),
+        bot_api_ca=str(certs / "ca.pem"),
+        bot_api_signing_key=SIGNING_KEY.encode(),
+    )
+
+
+class FakeBotAPI:
+    """Stands in for the bot. Records what it was asked."""
+
+    def __init__(self, installed=(GUILD_IN,), fail=False):
+        self.installed = {str(g) for g in installed}
+        self.fail = fail
+        self.calls = []
+
+    def admin_guild_ids(self, actor_id, guild_ids):
+        self.calls.append((actor_id, list(guild_ids)))
+        if self.fail:
+            raise BotAPIError("bot unreachable")
+        return {g for g in map(str, guild_ids) if g in self.installed}
+
+
+@pytest.fixture
+def store(config):
+    return SessionStore(config.session_db_path, config.session_max_age)
+
+
+@pytest.fixture
+def bot_api():
+    return FakeBotAPI()
+
+
+@pytest.fixture
+def app(config, store, bot_api):
+    application = create_app(config, store=store, client=bot_api)
+    application.config.update(TESTING=True)
+    return application
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+GUILDS = [
+    {"id": GUILD_IN, "name": "Alpha Club", "icon": "abc123", "admin_hint": True},
+    {"id": GUILD_OUT, "name": "Beta Lounge", "icon": None, "admin_hint": True},
+    {"id": GUILD_NOT_ADMIN, "name": "Gamma Hall", "icon": None, "admin_hint": False},
+]
+
+
+def login_as(client, store, guilds=None):
+    """Put an authenticated session in place without walking the OAuth flow."""
+    pending = store.begin_login("unused-state")
+    session = store.complete_login(pending.sid, ACTOR, guilds or GUILDS)
+    client.set_cookie(SESSION_COOKIE, session.sid, domain="localhost")
+    return session
+
+
+# -------------------------------------------------------------------
+# Configuration
+# -------------------------------------------------------------------
+class TestConfig:
+    @pytest.fixture(autouse=True)
+    def clean_env(self, monkeypatch):
+        for name in (
+            "DISCORD_CLIENT_ID",
+            "DISCORD_CLIENT_SECRET",
+            "OAUTH_REDIRECT_URI",
+            "DASHBOARD_SECRET_KEY",
+            "BOT_API_URL",
+            "BOT_API_CLIENT_CERT",
+            "BOT_API_CLIENT_KEY",
+            "BOT_API_CA",
+            "BOT_API_TOKEN_SIGNING_KEY",
+            "SESSION_DB_PATH",
+        ):
+            monkeypatch.delenv(name, raising=False)
+
+    def env(self, monkeypatch, certs, **overrides):
+        values = {
+            "DISCORD_CLIENT_ID": "123",
+            "DISCORD_CLIENT_SECRET": "shh",
+            "OAUTH_REDIRECT_URI": "https://dashboard.vrcverify.com/callback",
+            "DASHBOARD_SECRET_KEY": SECRET_KEY,
+            "BOT_API_URL": "https://100.117.6.99:5002",
+            "BOT_API_CLIENT_CERT": str(certs / "client.pem"),
+            "BOT_API_CLIENT_KEY": str(certs / "client.key"),
+            "BOT_API_CA": str(certs / "ca.pem"),
+            "BOT_API_TOKEN_SIGNING_KEY": SIGNING_KEY,
+        }
+        values.update(overrides)
+        for name, value in values.items():
+            if value is None:
+                monkeypatch.delenv(name, raising=False)
+            else:
+                monkeypatch.setenv(name, value)
+
+    def test_happy_path(self, monkeypatch, certs):
+        self.env(monkeypatch, certs)
+        assert DashboardConfig.from_env().discord_client_id == "123"
+
+    @pytest.mark.parametrize(
+        "missing",
+        [
+            "DISCORD_CLIENT_ID",
+            "DISCORD_CLIENT_SECRET",
+            "OAUTH_REDIRECT_URI",
+            "DASHBOARD_SECRET_KEY",
+            "BOT_API_URL",
+            "BOT_API_TOKEN_SIGNING_KEY",
+        ],
+    )
+    def test_missing_settings_refuse_to_start(self, monkeypatch, certs, missing):
+        self.env(monkeypatch, certs, **{missing: None})
+        with pytest.raises(DashboardConfigError):
+            DashboardConfig.from_env()
+
+    def test_a_weak_session_key_refuses_to_start(self, monkeypatch, certs):
+        self.env(monkeypatch, certs, DASHBOARD_SECRET_KEY="short")
+        with pytest.raises(DashboardConfigError):
+            DashboardConfig.from_env()
+
+    def test_reusing_one_key_for_both_purposes_refuses_to_start(
+        self, monkeypatch, certs
+    ):
+        """Cookie signing and API authorisation are separate trust domains."""
+        self.env(
+            monkeypatch,
+            certs,
+            DASHBOARD_SECRET_KEY=SIGNING_KEY,
+            BOT_API_TOKEN_SIGNING_KEY=SIGNING_KEY,
+        )
+        with pytest.raises(DashboardConfigError):
+            DashboardConfig.from_env()
+
+    def test_plaintext_bot_api_refuses_to_start(self, monkeypatch, certs):
+        self.env(monkeypatch, certs, BOT_API_URL="http://100.117.6.99:5002")
+        with pytest.raises(DashboardConfigError):
+            DashboardConfig.from_env()
+
+    def test_a_plaintext_redirect_refuses_to_start(self, monkeypatch, certs):
+        """An authorisation code over http can be stolen in flight."""
+        self.env(
+            monkeypatch, certs, OAUTH_REDIRECT_URI="http://dashboard.vrcverify.com/callback"
+        )
+        with pytest.raises(DashboardConfigError):
+            DashboardConfig.from_env()
+
+    def test_localhost_http_is_allowed_for_development(self, monkeypatch, certs):
+        self.env(monkeypatch, certs, OAUTH_REDIRECT_URI="http://localhost:8000/callback")
+        assert DashboardConfig.from_env() is not None
+
+    def test_a_missing_client_certificate_refuses_to_start(self, monkeypatch, certs):
+        self.env(monkeypatch, certs, BOT_API_CLIENT_CERT=str(certs / "absent.pem"))
+        with pytest.raises(DashboardConfigError):
+            DashboardConfig.from_env()
+
+
+# -------------------------------------------------------------------
+# Sessions
+# -------------------------------------------------------------------
+class TestSessions:
+    def test_a_pre_auth_session_is_not_authenticated(self, store):
+        pending = store.begin_login("state-123")
+        assert pending.authenticated is False
+        assert store.load(pending.sid).oauth_state == "state-123"
+
+    def test_completing_login_issues_a_new_id(self, store):
+        """Session fixation: the id must change when privilege is granted."""
+        pending = store.begin_login("state-123")
+        session = store.complete_login(pending.sid, ACTOR, GUILDS)
+
+        assert session.sid != pending.sid
+        assert session.authenticated is True
+        # And the old row is gone, not merely superseded.
+        assert store.load(pending.sid) is None
+
+    def test_expired_sessions_are_refused_and_removed(self, store):
+        pending = store.begin_login("state-123")
+        session = store.complete_login(pending.sid, ACTOR, GUILDS)
+        later = time.time() + store.max_age + 1
+
+        assert store.load(session.sid, now=later) is None
+        assert store.load(session.sid) is None  # removed on sight
+
+    def test_logout_destroys_the_row(self, store):
+        pending = store.begin_login("s")
+        session = store.complete_login(pending.sid, ACTOR, GUILDS)
+        store.destroy(session.sid)
+        assert store.load(session.sid) is None
+
+    def test_guild_cache_freshness(self, store):
+        pending = store.begin_login("s")
+        session = store.complete_login(pending.sid, ACTOR, GUILDS)
+        assert session.guilds_fresh(900) is True
+        assert session.guilds_fresh(900, now=time.time() + 901) is False
+
+    def test_purge_removes_only_expired_rows(self, store):
+        live = store.complete_login(store.begin_login("a").sid, ACTOR, GUILDS)
+        stale = store.begin_login("b")
+        assert store.purge_expired(now=time.time() + 601) == 1
+        assert store.load(live.sid) is not None
+        assert store.load(stale.sid) is None
+
+
+class TestTokenIsNeverStored:
+    """The single most important property of the whole login flow.
+
+    The public host is assumed to be compromised eventually. A stored Discord
+    token would let whoever compromised it act as every user who ever logged
+    in, indefinitely, against Discord itself. An id and a stale guild list are
+    worth far less -- so the token is read once and dropped.
+    """
+
+    def test_login_returns_only_identity_and_guilds(self, monkeypatch):
+        captured = {}
+
+        def fake_exchange(code, **kwargs):
+            captured["code"] = code
+            return ACCESS_TOKEN
+
+        def fake_identity(token, **kwargs):
+            captured["token_seen"] = token
+            return ACTOR, GUILDS
+
+        monkeypatch.setattr(oauth, "exchange_code", fake_exchange)
+        monkeypatch.setattr(oauth, "fetch_identity", fake_identity)
+
+        result = oauth.login(
+            "the-code",
+            client_id="1",
+            client_secret="2",
+            redirect_uri="https://x/callback",
+        )
+        assert result == (ACTOR, GUILDS)
+        # It was used, and it is not in what came back.
+        assert captured["token_seen"] == ACCESS_TOKEN
+        assert ACCESS_TOKEN not in json.dumps(result)
+
+    def test_no_session_row_ever_contains_the_token(self, store, config):
+        pending = store.begin_login("state")
+        store.complete_login(pending.sid, ACTOR, GUILDS)
+
+        with sqlite3.connect(config.session_db_path) as conn:
+            dump = "".join(
+                str(row) for row in conn.execute("SELECT * FROM sessions").fetchall()
+            )
+        assert ACCESS_TOKEN not in dump
+        assert "access_token" not in dump
+        assert "refresh_token" not in dump
+
+    def test_the_session_schema_has_nowhere_to_put_one(self, store, config):
+        with sqlite3.connect(config.session_db_path) as conn:
+            columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(sessions)").fetchall()
+            }
+        assert not any("token" in c for c in columns if c != "csrf_token")
+
+
+# -------------------------------------------------------------------
+# The OAuth flow
+# -------------------------------------------------------------------
+class TestOAuthFlow:
+    def test_login_redirects_to_discord_with_state(self, client, store):
+        response = client.get("/login")
+        assert response.status_code == 302
+        location = response.headers["Location"]
+        assert location.startswith("https://discord.com/oauth2/authorize")
+        assert "scope=identify+guilds" in location
+        assert "state=" in location
+
+    def test_only_identity_and_guilds_are_requested(self):
+        assert oauth.SCOPES == "identify guilds"
+
+    def test_a_mismatched_state_is_refused(self, client, store, monkeypatch):
+        """Without this check, an attacker can have you log in as them."""
+        client.get("/login")
+
+        def should_not_run(*args, **kwargs):
+            raise AssertionError("the code must not be exchanged on a bad state")
+
+        monkeypatch.setattr(oauth, "login", should_not_run)
+        response = client.get("/callback?code=abc&state=not-the-one")
+        assert response.status_code == 400
+
+    def test_a_callback_without_a_session_is_refused(self, client, monkeypatch):
+        monkeypatch.setattr(
+            oauth, "login", lambda *a, **k: (_ for _ in ()).throw(AssertionError)
+        )
+        response = client.get("/callback?code=abc&state=whatever")
+        assert response.status_code == 400
+
+    def test_a_declined_authorisation_is_handled_quietly(self, client):
+        client.get("/login")
+        response = client.get("/callback?error=access_denied")
+        assert response.status_code == 400
+        assert b"declined" in response.data
+
+    def test_a_successful_callback_signs_you_in(self, client, store, monkeypatch):
+        client.get("/login")
+        monkeypatch.setattr(oauth, "login", lambda *a, **k: (ACTOR, GUILDS))
+
+        response = client.get("/callback?code=abc&state=" + _pending_state(store))
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/")
+
+    def test_the_session_cookie_is_locked_down(self, client, store, monkeypatch):
+        client.get("/login")
+        monkeypatch.setattr(oauth, "login", lambda *a, **k: (ACTOR, GUILDS))
+        response = client.get("/callback?code=abc&state=" + _pending_state(store))
+
+        cookie = response.headers.get("Set-Cookie", "")
+        assert "HttpOnly" in cookie
+        assert "Secure" in cookie
+        assert "SameSite=Lax" in cookie
+
+
+def _pending_state(store):
+    """The state of the one outstanding pre-auth row."""
+    with sqlite3.connect(store.path) as conn:
+        row = conn.execute(
+            "SELECT oauth_state FROM sessions WHERE oauth_state IS NOT NULL"
+        ).fetchone()
+    return row[0]
+
+
+# -------------------------------------------------------------------
+# The picker
+# -------------------------------------------------------------------
+class TestPicker:
+    def test_signed_out_visitors_get_the_login_page(self, client):
+        response = client.get("/")
+        assert response.status_code == 200
+        assert b"Sign in with Discord" in response.data
+
+    def test_the_bot_decides_which_servers_are_installed(
+        self, client, store, bot_api
+    ):
+        login_as(client, store)
+        response = client.get("/")
+        assert response.status_code == 200
+        assert b"Alpha Club" in response.data
+        assert b"Installed" in response.data
+        assert b"Add to this server" in response.data
+
+    def test_servers_without_the_bot_offer_a_targeted_invite(self, client, store):
+        login_as(client, store)
+        page = client.get("/").data.decode()
+        assert f"guild_id={GUILD_OUT}" in page
+        assert "disable_guild_select=true" in page
+
+    def test_non_admin_guilds_are_not_shown_at_all(self, client, store, bot_api):
+        login_as(client, store)
+        page = client.get("/").data.decode()
+        assert "Gamma Hall" not in page
+        # And they are never even mentioned to the bot.
+        _actor, asked = bot_api.calls[-1]
+        assert GUILD_NOT_ADMIN not in asked
+
+    def test_the_actor_sent_to_the_bot_is_the_session_owner(
+        self, client, store, bot_api
+    ):
+        login_as(client, store)
+        client.get("/")
+        actor, _asked = bot_api.calls[-1]
+        assert str(actor) == ACTOR
+
+    def test_an_unreachable_bot_still_renders_a_useful_page(
+        self, client, store, config
+    ):
+        app = create_app(config, store=store, client=FakeBotAPI(fail=True))
+        app.config.update(TESTING=True)
+        test_client = app.test_client()
+        login_as(test_client, store)
+
+        response = test_client.get("/")
+        assert response.status_code == 200
+        assert b"Can&#39;t reach the bot" in response.data or b"Can't reach the bot" in response.data
+
+
+# -------------------------------------------------------------------
+# Hardening
+# -------------------------------------------------------------------
+class TestHardening:
+    def test_security_headers_on_every_response(self, client):
+        headers = client.get("/").headers
+        assert headers["X-Content-Type-Options"] == "nosniff"
+        assert headers["X-Frame-Options"] == "DENY"
+        assert headers["Referrer-Policy"] == "no-referrer"
+        assert headers["Cache-Control"] == "no-store"
+        assert "max-age=31536000" in headers["Strict-Transport-Security"]
+
+    def test_the_csp_allows_no_external_script_or_style(self, client):
+        policy = client.get("/").headers["Content-Security-Policy"]
+        assert "script-src 'self'" in policy
+        assert "style-src 'self'" in policy
+        assert "default-src 'none'" in policy
+        assert "frame-ancestors 'none'" in policy
+        # The one deliberate exception, and it is images only.
+        assert "img-src 'self' https://cdn.discordapp.com" in policy
+        assert "unsafe-inline" not in policy
+        assert "unsafe-eval" not in policy
+
+    def test_no_page_carries_inline_script(self, client, store):
+        login_as(client, store)
+        for path in ("/", "/nonexistent"):
+            assert b"<script" not in client.get(path).data
+
+    def test_logout_requires_the_csrf_token(self, client, store):
+        session = login_as(client, store)
+        assert client.post("/logout", data={"csrf_token": "wrong"}).status_code == 400
+        # The session survived the failed attempt.
+        assert store.load(session.sid) is not None
+
+    def test_logout_with_the_token_destroys_the_session(self, client, store):
+        session = login_as(client, store)
+        response = client.post("/logout", data={"csrf_token": session.csrf_token})
+        assert response.status_code == 302
+        assert store.load(session.sid) is None
+
+    def test_cf_access_headers_grant_nothing(self, client, store):
+        """The Access policy comes off at launch (A-14).
+
+        Any code that authorised on these headers would silently become a
+        complete authentication bypass on that day, with no error and no
+        deploy to correlate against. So they must do nothing, ever.
+        """
+        response = client.get(
+            "/",
+            headers={
+                "Cf-Access-Authenticated-User-Email": "sasha-1221@hotmail.com",
+                "Cf-Access-Jwt-Assertion": "eyJhbGciOiJSUzI1NiJ9.fake.fake",
+            },
+        )
+        assert response.status_code == 200
+        assert b"Sign in with Discord" in response.data
+
+    def test_healthz_says_nothing_useful(self, client):
+        assert client.get("/healthz").get_json() == {"ok": True}
+
+
+class TestReadOnlyPhase:
+    """Step 3 is login and a picker. Nothing here may change a server."""
+
+    def test_the_only_post_route_is_logout(self, app):
+        posts = {
+            rule.rule
+            for rule in app.url_map.iter_rules()
+            if "POST" in (rule.methods or set())
+        }
+        assert posts == {"/logout"}, f"an unexpected write route appeared: {posts}"
+
+    def test_the_dashboard_holds_no_database_credential(self):
+        """A compromise of the public host must not reach the users table."""
+        import dashboard.app as module
+
+        source = open(module.__file__, encoding="utf-8").read()
+        for forbidden in ("DATABASE_URL", "psycopg2", "sqlalchemy", "DISCORD_BOT_TOKEN"):
+            assert forbidden not in source


### PR DESCRIPTION
Step 3 of #65. Proves the whole chain end to end — browser → Cloudflare → tunnel → Flask → mTLS → bot — before any write path exists.

**Read-only.** The only `POST` route is logout, and the bot API it talks to has no write endpoint to call even if there were more. A test pins both.

Depends on #69 (small config passthrough) but doesn't conflict with it.

## The token format moved to `src/api_tokens.py`

Imported by both the bot and the dashboard. The dashboard has to sign *exactly* what the bot verifies, and a signer and a verifier that drift apart is the classic way an auth scheme quietly stops meaning anything. Keeping it stdlib-only means the dashboard doesn't take on aiohttp just to share it.

The operation strings live there too — they're the aiohttp route templates verbatim, and getting one wrong surfaces as a `403 wrong_operation`, which reads like a permissions bug rather than a typo.

`bot_api.py` re-exports everything, so nothing else changed and the existing 799 tests were untouched.

## The Discord token is never stored

It's exchanged, used once to read the user's id and guild list, and dropped. The public host is assumed to be compromised eventually; a stored token would let whoever compromised it act as **every user who ever logged in**, against Discord, indefinitely. An id and a stale guild list are worth far less.

Tests assert the token never reaches the database and that the schema has nowhere to put one. Refreshing the guild list means logging in again — that's the trade, not an oversight.

## Sessions

Server-side SQLite, so logout can actually destroy one rather than waiting for a cookie to expire. The session id is **regenerated at the moment privilege is granted**, so a fixated session can't be authenticated on an attacker's behalf. Cookie is `HttpOnly`, `Secure`, `SameSite=Lax`.

## Authority still belongs to the bot

The picker filters on the `permissions` Discord returned at authorisation time — but only to decide which tiles to draw. That data is stale the moment it arrives, and a user demoted since would still see the tile. Which servers are actually *installed* comes from the bot, and the bot re-checks Administrator itself.

**Nothing reads `Cf-Access-*` headers, and a test pins that.** Cloudflare Access guards the site while this is half-built and comes off at launch (A-14) — code that authorised on those headers would silently become a complete authentication bypass that day, with no error and no deploy to correlate against.

## Hardening

CSP is `default-src 'none'` with one deliberate exception: `img-src` allows Discord's icon CDN. Proxying icons instead would mean the dashboard fetching arbitrary URLs on a user's behalf, which is the worse trade. No script or style may come from anywhere but here, and no page carries inline script — tests assert both.

Plus HSTS, `nosniff`, `frame-ancestors 'none'`, `Referrer-Policy: no-referrer` (the URL identifies which server an admin is looking at), and `Cache-Control: no-store`.

## Deployment shape

The image carries **no database driver, no discord.py, no bot token** — a compromise of the public box yields no route to the `users` table, which is the whole reason the bot API exists. The compose file publishes **no port**; cloudflared reaches it over the Docker network.

That last one is load-bearing rather than tidy: published Docker ports are DNAT'd in `PREROUTING` and never traverse the host firewall's `INPUT` chain, so the *absence* of `ports:` is the actual control. Container runs read-only, `cap_drop: ALL`, `no-new-privileges`, non-root.

## Verification

843 tests pass (44 new). Beyond that, the image was built and run: it starts as uid 10001, imports cleanly under the container's `PYTHONPATH`, contains none of the bot's dependencies, and **refuses to start with no config** rather than serving in a weaker shape.

Not yet deployed — the VPS still runs the whoami placeholder.