### PR TITLE
Teach the build tooling about the dashboard image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,6 +22,21 @@ venv/
 # Environment files
 .env
 
+# mTLS material for the bot API (scripts/gen_bot_api_certs.*). These must never
+# enter the build context at all -- not merely "never be COPYed". Anything in
+# the context is uploaded to the Docker daemon, ends up in the build cache, and
+# is one careless `COPY . .` away from being baked into a published image.
+# ca.key in particular can mint a client the bot will trust.
+certs/
+*.key
+*.pem
+*.csr
+*.srl
+
+# Local security documentation (gitignored too, but belt and braces)
+SECURITY_AUDIT.md
+VPS_RUNBOOK.md
+
 # Tests and local assets not needed in images
 tests/
 Logos/

--- a/config/other_configs/docker-compose.yml
+++ b/config/other_configs/docker-compose.yml
@@ -58,6 +58,22 @@ services:
       - vrchat-session:/data
     restart: unless-stopped
 
+  # BUILD TARGET ONLY -- do not `up` this here.
+  #
+  # The dashboard runs on the public VPS, not the homelab, and it needs
+  # DISCORD_CLIENT_SECRET, the mTLS client certificate and a session volume
+  # that only exist there. It lives in this file so `docker compose build`
+  # produces the image alongside the other two and the version tags stay in
+  # step; run it from docker-compose.dashboard.yml on the VPS.
+  #
+  # Started here by accident it would simply refuse to boot -- DashboardConfig
+  # fails closed on the first missing setting -- which is the intended failure.
+  dashboard:
+    build:
+      context: ../../
+      dockerfile: docker/Dockerfile-dashboard
+    image: dashboard
+
 volumes:
   # Persists the VRChat auth cookie so restarts skip re-authentication.
   vrchat-session:

--- a/tag_and_push_images.ps1
+++ b/tag_and_push_images.ps1
@@ -12,13 +12,14 @@ function GetVersion {
 $menu = @"
 1. Bot
 2. VRC Online Checker
-3. All
+3. Dashboard (runs on the VPS, not the homelab)
+4. All
 0. Exit
 "@
 
 Write-Host "Select an option to tag and upload:"
 Write-Host $menu
-$choice = Read-Host "Enter your choice (0-3)"
+$choice = Read-Host "Enter your choice (0-4)"
 
 function TagAndPush($imageName, $version) {
 
@@ -68,8 +69,12 @@ switch ($choice) {
         TagAndPush "vrc-online-checker" $version
     }
     3 {
+        TagAndPush "dashboard" $version
+    }
+    4 {
         TagAndPush "discord-bot" $version
         TagAndPush "vrc-online-checker" $version
+        TagAndPush "dashboard" $version
     }
     0 {
         Write-Host "Exiting script."

--- a/tag_and_push_images.sh
+++ b/tag_and_push_images.sh
@@ -49,9 +49,10 @@ build_docker_images() {
 echo "Select an option to tag and upload:"
 echo "1. Bot"
 echo "2. VRC Online Checker"
-echo "3. All"
+echo "3. Dashboard (runs on the VPS, not the homelab)"
+echo "4. All"
 echo "0. Exit"
-read -p "Enter your choice (0-3): " choice
+read -p "Enter your choice (0-4): " choice
 
 # Collect version number and build option
 get_version
@@ -66,8 +67,12 @@ case "$choice" in
         tag_and_push "vrc-online-checker" "$version"
         ;;
     3)
+        tag_and_push "dashboard" "$version"
+        ;;
+    4)
         tag_and_push "discord-bot" "$version"
         tag_and_push "vrc-online-checker" "$version"
+        tag_and_push "dashboard" "$version"
         ;;
     0)
         echo "Exiting script."


### PR DESCRIPTION
#70 added `src/dashboard/` and `docker/Dockerfile-dashboard`, but nothing knew how to build or publish the result.

**This is a deploy blocker.** `docker-compose.dashboard.yml` on the VPS pulls `italiandogs/vrcverify-dashboard:${VRCVERIFY_VERSION}` — a tag that has never existed, because `docker compose build` only ever produced two images and the tag-and-push scripts only ever offered two options. The first attempt to bring the dashboard up fails on the pull.

## Changes

- **Build compose** gains a `dashboard` build target, so all three images build together and their version tags stay in step.
- **Both tag-and-push scripts** gain a third option (and a fourth for "All").
- **`.dockerignore` now excludes certificate material.**

The compose entry is deliberately marked build-only. The dashboard runs on the VPS, where its client certificate and Discord client secret live; started on the homelab it would fail closed on the first missing setting, which is the correct behaviour but not a useful thing to do by accident.

## On the `.dockerignore` change

`scripts/gen_bot_api_certs.sh` writes `certs/` into the repo root. Nothing `COPY`s it today — but everything in the build context is uploaded to the Docker daemon and cached there regardless, and is one careless `COPY . .` away from being baked into a published image. The images are public. `ca.key` is the single thing that can mint a client certificate the bot will trust, so a public image is precisely where it must never end up.

Cheaper to exclude it now than to notice later.

## Verification

843 tests pass. `docker compose config --services` lists all three, and the dashboard image builds clean with the new ignore rules in place.