### PR TITLE
Give the internal CA a keyUsage extension

### DIFF
--- a/scripts/gen_bot_api_certs.ps1
+++ b/scripts/gen_bot_api_certs.ps1
@@ -47,13 +47,39 @@ if (-not (Test-Path $OutDir)) { New-Item -ItemType Directory -Path $OutDir | Out
 Push-Location $OutDir
 
 try {
+    # A CA with no keyUsage is accepted by openssl, by curl, and by the bot's own
+    # server context -- and rejected by the dashboard, because Python 3.13 turned
+    # on ssl.VERIFY_X509_STRICT by default in create_default_context(). Under RFC
+    # 5280 strict checking a CA must say keyCertSign, so an extension-free CA
+    # fails with "CA cert does not include key usage extension", client side only.
+    $caExts = @(
+        "-addext", "basicConstraints=critical,CA:TRUE",
+        "-addext", "keyUsage=critical,keyCertSign,cRLSign",
+        "-addext", "subjectKeyIdentifier=hash"
+    )
+
     Write-Host "==> Certificate authority"
-    if (Test-Path ca.key) {
-        Write-Host "    ca.key exists; reusing it (rotating leaves only)."
-    } else {
-        openssl genrsa -out ca.key 4096
+    $issueCa = $true
+    if ((Test-Path ca.key) -and (Test-Path ca.pem)) {
+        # Prints nothing and exits 0 when the extension is absent, which is
+        # precisely the case being detected.
+        $caKeyUsage = openssl x509 -in ca.pem -noout -ext keyUsage
+        if ($caKeyUsage -match "Certificate Sign") {
+            Write-Host "    ca.key exists; reusing it (rotating leaves only)."
+            $issueCa = $false
+        } else {
+            # Re-signing with the SAME key and the SAME subject: the CA
+            # certificate only publishes a public key and a set of extensions,
+            # so every certificate the old one signed still verifies against the
+            # new one. Nothing needs reissuing and the hosts update in either
+            # order.
+            Write-Host "    ca.pem predates the keyUsage fix; re-issuing it from the existing key."
+        }
+    }
+    if ($issueCa) {
+        if (-not (Test-Path ca.key)) { openssl genrsa -out ca.key 4096 }
         openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 `
-            -subj "/CN=VRCVerify Internal CA" -out ca.pem
+            -subj "/CN=VRCVerify Internal CA" @caExts -out ca.pem
     }
 
     Write-Host "==> Server certificate for the bot API ($san)"
@@ -61,7 +87,10 @@ try {
     @(
         "subjectAltName=$san",
         "extendedKeyUsage=serverAuth",
-        "basicConstraints=CA:FALSE"
+        "basicConstraints=critical,CA:FALSE",
+        "keyUsage=critical,digitalSignature,keyEncipherment",
+        "subjectKeyIdentifier=hash",
+        "authorityKeyIdentifier=keyid:always"
     ) | Set-Content -Path $serverExt -Encoding ascii
 
     openssl genrsa -out bot-api.key 4096
@@ -74,7 +103,10 @@ try {
     $clientExt = New-TemporaryFile
     @(
         "extendedKeyUsage=clientAuth",
-        "basicConstraints=CA:FALSE"
+        "basicConstraints=critical,CA:FALSE",
+        "keyUsage=critical,digitalSignature",
+        "subjectKeyIdentifier=hash",
+        "authorityKeyIdentifier=keyid:always"
     ) | Set-Content -Path $clientExt -Encoding ascii
 
     openssl genrsa -out dashboard.key 4096
@@ -83,6 +115,16 @@ try {
         -out dashboard.pem -days 825 -sha256 -extfile $clientExt
 
     Remove-Item bot-api.csr, dashboard.csr, $serverExt, $clientExt -Force
+
+    # Run the strict check here rather than suggesting it, because the lenient
+    # one is worse than no check at all: `openssl verify` passes on a chain the
+    # dashboard will reject, so it reads as proof the certificates are good. The
+    # failure it hides surfaces later as a TLS error at request time, on the box
+    # where the CA key isn't, with no matching log line on the bot.
+    Write-Host ""
+    Write-Host "==> Verifying the chain the way Python will"
+    openssl verify -x509_strict -CAfile ca.pem bot-api.pem dashboard.pem
+    if ($LASTEXITCODE -ne 0) { throw "Strict verification failed; do not deploy these." }
 
     Write-Host ""
     Write-Host "Done. Files are in $(Get-Location)"
@@ -103,9 +145,6 @@ try {
     Write-Host ""
     Write-Host "The .key files carry no ACL restriction on Windows — this machine is"
     Write-Host "the CA host, not a deploy target. Move them over SSH, don't sync them."
-    Write-Host ""
-    Write-Host "Verify the pair before deploying:"
-    Write-Host "  openssl verify -CAfile ca.pem bot-api.pem dashboard.pem"
 }
 finally {
     Pop-Location

--- a/scripts/gen_bot_api_certs.sh
+++ b/scripts/gen_bot_api_certs.sh
@@ -79,21 +79,40 @@ cd "$OUT"
 
 umask 077  # keys are created unreadable to anyone else, from the start
 
+# A CA with no keyUsage is accepted by openssl, by curl, and by the bot's own
+# server context -- and rejected by the dashboard, because Python 3.13 turned on
+# ssl.VERIFY_X509_STRICT by default in create_default_context(). Under RFC 5280
+# strict checking a CA must say keyCertSign, so an extension-free CA fails with
+# "CA cert does not include key usage extension" on the client side only.
+CA_EXTS=(
+    -addext "basicConstraints=critical,CA:TRUE"
+    -addext "keyUsage=critical,keyCertSign,cRLSign"
+    -addext "subjectKeyIdentifier=hash"
+)
+
 echo "==> Certificate authority"
-if [ -f ca.key ]; then
-    echo "    ca.key exists; reusing it (rotating leaves only)."
-else
+if [ ! -f ca.key ]; then
     openssl genrsa -out ca.key 4096
     openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 \
-        -subj "/CN=VRCVerify Internal CA" -out ca.pem
+        -subj "/CN=VRCVerify Internal CA" "${CA_EXTS[@]}" -out ca.pem
+elif ! openssl x509 -in ca.pem -noout -ext keyUsage 2>/dev/null | grep -q "Certificate Sign"; then
+    # Re-signing with the SAME key and the SAME subject: the CA certificate only
+    # publishes a public key and a set of extensions, so every certificate the
+    # old one signed still verifies against the new one. Nothing needs reissuing
+    # and the two hosts can be updated in either order.
+    echo "    ca.pem predates the keyUsage fix; re-issuing it from the existing key."
+    openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 \
+        -subj "/CN=VRCVerify Internal CA" "${CA_EXTS[@]}" -out ca.pem
+else
+    echo "    ca.key exists; reusing it (rotating leaves only)."
 fi
 
 # Real files rather than <(...) process substitution: under Git Bash the latter
 # hands openssl.exe a /dev/fd/63 path a Windows binary cannot open.
 trap 'rm -f server.ext client.ext bot-api.csr dashboard.csr' EXIT
 
-printf 'subjectAltName=%s\nextendedKeyUsage=serverAuth\nbasicConstraints=CA:FALSE\n' "$SAN" > server.ext
-printf 'extendedKeyUsage=clientAuth\nbasicConstraints=CA:FALSE\n' > client.ext
+printf 'subjectAltName=%s\nextendedKeyUsage=serverAuth\nbasicConstraints=critical,CA:FALSE\nkeyUsage=critical,digitalSignature,keyEncipherment\nsubjectKeyIdentifier=hash\nauthorityKeyIdentifier=keyid:always\n' "$SAN" > server.ext
+printf 'extendedKeyUsage=clientAuth\nbasicConstraints=critical,CA:FALSE\nkeyUsage=critical,digitalSignature\nsubjectKeyIdentifier=hash\nauthorityKeyIdentifier=keyid:always\n' > client.ext
 
 echo "==> Server certificate for the bot API ($SAN)"
 openssl genrsa -out bot-api.key 4096
@@ -108,6 +127,15 @@ openssl req -new -key dashboard.key -subj "/CN=vrcverify-dashboard" -out dashboa
 openssl x509 -req -in dashboard.csr -CA ca.pem -CAkey ca.key -CAcreateserial \
     -out dashboard.pem -days 825 -sha256 -extfile client.ext
 chmod 600 ./*.key
+
+# Run the strict check here rather than suggesting it, because the lenient one
+# is worse than no check at all: `openssl verify` passes on a chain the
+# dashboard will reject, so it reads as proof the certificates are good. The
+# failure it hides surfaces later as a TLS error at request time, on the box
+# where the CA key isn't, with no matching log line on the bot.
+echo
+echo "==> Verifying the chain the way Python will"
+openssl verify -x509_strict -CAfile ca.pem bot-api.pem dashboard.pem
 
 echo
 echo "Done. Files are in $(pwd)"
@@ -125,6 +153,3 @@ echo "  BOT_API_CLIENT_KEY=/certs/dashboard.key"
 echo
 echo "Keep ca.key here. It is the only thing that can mint a client the bot"
 echo "will trust, and neither host ever needs it."
-echo
-echo "Verify the pair before deploying:"
-echo "  openssl verify -CAfile ca.pem bot-api.pem dashboard.pem"


### PR DESCRIPTION
The dashboard could not reach the bot API. The certificates were fine by every check we had:

```
openssl verify -CAfile ca.pem bot-api.pem
bot-api.pem: OK
```

but the dashboard reported

```
TLS failure talking to the bot API: ... SSLCertVerificationError(1,
'[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
CA cert does not include key usage extension')
```

## Cause

`gen_bot_api_certs.sh` self-signed the CA with no extensions whatsoever. That is a valid CA to `openssl verify`, to `curl`, and to the bot — but **Python 3.13 enabled `ssl.VERIFY_X509_STRICT` by default in `create_default_context()`**, and the dashboard image is `python:3.14.6-slim`. Under RFC 5280 strict checking a CA must assert `keyCertSign`.

Only one half of the mTLS pair is strict, and it is the half nothing tested. `bot_api.py` builds its `SSLContext` by hand rather than from `create_default_context`, so the bot verifies the dashboard's client certificate against this same CA without complaint. The failure could only appear on the VPS, at request time, with no matching line in the bot's log.

## Changes

- CA gets `basicConstraints=critical,CA:TRUE`, `keyUsage=critical,keyCertSign,cRLSign`, `subjectKeyIdentifier=hash`.
- Both leaves get key identifiers and a `keyUsage`.
- An existing `ca.key` is detected and its certificate **re-issued in place** — same key, same subject, so certificates it already signed still verify. Only `ca.pem` has to be redistributed, and the hosts can be updated in either order.
- The scripts run `openssl verify -x509_strict` themselves rather than printing the lenient form as a suggestion. The lenient check was worse than none: it passes on exactly the chain that fails in production, so it reads as proof the certificates are good.

## Verification

Reproduced the old failure and confirmed the repair, with real certificates:

| check | old CA | re-issued CA |
|---|---|---|
| `openssl verify` | `OK` | `OK` |
| `openssl verify -x509_strict` | `error 92 ... CA cert does not include key usage extension` | `OK` |
| original leaf vs. re-issued CA, strict | — | `OK` |

That last row is what makes this a one-file redeploy rather than a full reissue.