### PR TITLE
Show one server's settings on the dashboard, read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,34 @@ This phase is **read-only by construction**: the API is handed a set of reader
 callables and nothing else, so it cannot express a write at all.
 `tests/test_bot_api.py` pins both that and the absence of any non-GET route.
 
+### The dashboard itself
+
+`src/dashboard/` is a small Flask app that signs an admin in with Discord OAuth,
+lists the servers they administer, and shows one server's settings. It holds no
+database credential and no bot token: everything it knows it asks the bot for
+over mTLS, and the bot decides what it is allowed to know. It is still
+**read-only** — the only `POST` route is sign-out, which `tests/test_dashboard.py`
+pins.
+
+Two rules the settings page exists to honour:
+
+- **It mirrors the bot field for field, including the inconsistencies.** Some
+  settings a lapsed plan refuses to *save* (nickname sync, panel branding); some
+  it saves for anyone and simply doesn't *act* on (the unverified role, the
+  custom DM). Those get different badges, because rendering the second as the
+  first would leave the website refusing to show something an admin can plainly
+  set with a slash command. `SETTINGS_FIELDS` in `bot.py` is the single source
+  of that distinction, and a test fails if a field it defines goes unrendered.
+- **A 403 and a 404 from the bot are one indistinguishable answer.** The
+  difference is meaningful behind mTLS and dangerous on the open web: shown
+  separately, a signed-in user could walk guild ids and enumerate which servers
+  run 18+ gating.
+
+It also surfaces things the bot could previously only discover mid-verification
+— a verified role the bot cannot grant, a log channel it cannot post in, an
+announcement channel other servers could follow — while an admin is looking at
+the setting rather than when a member is waiting.
+
 ---
 
 ## Tech Stack

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,8 +1,13 @@
-"""The dashboard web app — step 3 of issue #65: login, session, picker.
+"""The dashboard web app — steps 3 and 4 of issue #65: login, picker, settings.
 
 Read-only. There is no route here that changes anything about a server; the
 bot API it talks to has no write endpoint to call even if there were. Saving
 settings is step 5, and it arrives with the audit trail.
+
+* **The page must say exactly what the bot would.** Two settings a lapsed plan
+  saves but does not act on, three it refuses to save at all. Collapsing that
+  into one "premium" state would make the website stricter than the slash
+  commands; `settings_view` keeps them apart.
 
 Design notes worth keeping in view while reading:
 
@@ -36,7 +41,7 @@ from flask import (
 )
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-from dashboard import oauth
+from dashboard import oauth, settings_view
 from dashboard.botapi import BotAPIClient, BotAPIError
 from dashboard.config import DashboardConfig
 from dashboard.sessions import SessionStore
@@ -278,6 +283,52 @@ def _register_routes(app: Flask) -> None:
             redirect(url_for("index")), session.sid, config.session_max_age
         )
 
+    @app.get("/guild/<int:guild_id>")
+    def guild_settings(guild_id: int):
+        """One server's settings, read-only.
+
+        Authority is the bot's, on every one of the calls below: each mints its
+        own token and the bot re-checks Administrator before answering. The
+        session is what proves who is asking, never what they may see -- so a
+        stale OAuth guild list cannot widen access, and a demotion in Discord
+        takes effect on the next page load rather than at session expiry.
+        """
+        session = _require_login()
+        if session is None:
+            return redirect(url_for("index"))
+
+        actor = int(session.discord_id)
+        try:
+            settings = _bot_api().settings(actor, guild_id)
+        except BotAPIError as error:
+            return _settings_unavailable(error, guild_id, session)
+
+        # Names for ids, and the panel's whereabouts. Best-effort on purpose:
+        # an unresolved id renders as an id, which is less useful but still
+        # true, and that is a better page than an error over a secondary read.
+        # The settings themselves are not optional -- rendering defaults an
+        # admin never chose would be a lie the step-5 save path could persist.
+        roles = _optional_read(lambda: _bot_api().roles(actor, guild_id), "roles", guild_id)
+        channels = _optional_read(
+            lambda: _bot_api().channels(actor, guild_id), "channels", guild_id
+        )
+        panel = _optional_read(
+            lambda: _bot_api().panel(actor, guild_id), "panel", guild_id
+        )
+
+        guild = _session_guild(session, guild_id)
+        return render_template(
+            "settings.html",
+            guild_name=(guild or {}).get("name") or f"Server {guild_id}",
+            guild_icon=oauth.icon_url(guild) if guild else None,
+            guild_id=str(guild_id),
+            groups=settings_view.build_groups(settings, roles, channels, panel),
+            premium=settings.get("premium") or {},
+            names_resolved=roles is not None and channels is not None,
+            auto_verify_column_present=settings.get("auto_verify_column_present", True),
+            csrf_token=session.csrf_token,
+        )
+
     @app.post("/logout")
     def logout():
         session = _require_login()
@@ -297,6 +348,78 @@ def _register_routes(app: Flask) -> None:
     @app.errorhandler(500)
     def server_error(_error):  # pragma: no cover - defensive
         return render_template("error.html", message="Something went wrong."), 500
+
+
+def _session_guild(session, guild_id: int) -> Optional[dict]:
+    """The OAuth record for this guild, for its name and icon only.
+
+    Display, never authority -- the bot has already decided whether this page
+    may be rendered at all. A guild missing from the list still renders, because
+    an admin promoted since login has a stale list and is nonetheless entitled
+    to the page.
+    """
+    target = str(guild_id)
+    for guild in session.guilds or []:
+        if str(guild.get("id")) == target:
+            return guild
+    return None
+
+
+def _settings_unavailable(error: BotAPIError, guild_id: int, session):
+    """Turn a refusal into a page, without saying which refusal it was.
+
+    The bot distinguishes 404 "not in that guild" from 403 "you do not
+    administer it", which is right inside the mTLS boundary and wrong on the
+    open web. Rendered differently, a signed-in user could walk arbitrary guild
+    ids and learn which servers run VRCVerify -- a census of communities
+    operating 18+ gating, from a browser, with nothing compromised. It is the
+    same oracle handle_list_guilds was hardened against, arriving by a
+    different door.
+
+    503 is kept separate: it says the bot cannot answer right now, which
+    discloses nothing about any particular guild, and telling an admin to try
+    again is far better than telling them the server does not exist.
+    """
+    if error.status in (403, 404):
+        logger.info(
+            "settings page refused for actor=%s guild=%s (status %s)",
+            session.discord_id,
+            guild_id,
+            error.status,
+        )
+        return (
+            render_template(
+                "error.html",
+                message=(
+                    "That server isn't available. Either VRCVerify isn't in it, "
+                    "or you don't have the Administrator permission there."
+                ),
+                csrf_token=session.csrf_token,
+            ),
+            404,
+        )
+
+    logger.warning("settings read failed for guild %s: %s", guild_id, error)
+    return (
+        render_template(
+            "error.html",
+            message=(
+                "Can't reach the bot right now, so this server's settings can't "
+                "be shown. Nothing has changed. Try again shortly."
+            ),
+            csrf_token=session.csrf_token,
+        ),
+        503,
+    )
+
+
+def _optional_read(call, what: str, guild_id: int):
+    """A secondary read whose failure must not cost the whole page."""
+    try:
+        return call()
+    except BotAPIError as error:
+        logger.warning("could not read %s for guild %s: %s", what, guild_id, error)
+        return None
 
 
 def _invite_url(client_id: str, guild_id: str) -> str:

--- a/src/dashboard/settings_view.py
+++ b/src/dashboard/settings_view.py
@@ -1,0 +1,421 @@
+"""Turns the bot API's settings payload into something a template can render.
+
+Pure: no Flask, no network, no clock. Everything it needs arrives as arguments,
+which is what lets the awkward cases -- a role that was deleted, a log channel
+the bot can no longer post in, a plan that lapsed -- be tested directly instead
+of through a request.
+
+TWO KINDS OF "not on your plan", AND THE DIFFERENCE MATTERS
+-----------------------------------------------------------
+The bot gates in two different places, and `SettingsField` in bot.py records
+which is which. This module must render both honestly:
+
+* `locked` -- the bot refuses the *save*. PagedSettingsView disables the
+  control and leaves the stored value alone, so a later subscriber gets their
+  original choice back. Shown as "Premium only".
+* `active: false` but not locked -- the value saves fine for anyone, and the
+  bot simply doesn't act on it. /vrcverify_setup stores an unverified role for
+  a free server quite happily. Shown as "saved, not applied".
+
+Rendering the second as though it were the first would make the website
+stricter than the slash commands, and an admin would find the site refusing to
+show them something they can plainly set in Discord. That is the specific
+failure this module exists to avoid.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# Display names only. The authoritative list is locales.LANGUAGE_CODES in the
+# bot, which this image deliberately does not carry -- it ships api_tokens.py
+# and this package, nothing else. An unrecognised code renders as itself, so
+# the two drifting apart degrades to showing "pt-BR" instead of "Portuguese".
+#
+# Step 5 must NOT build its locale <select> from this dict. The choices have to
+# come from the bot, or the dashboard could offer a language the bot cannot
+# render.
+LOCALE_NAMES = {
+    "en-US": "English",
+    "es-ES": "Spanish",
+    "zh-CN": "Chinese (Simplified)",
+    "ja": "Japanese",
+    "de": "German",
+    "nl": "Dutch",
+    "hi-IN": "Hindi",
+    "ar": "Arabic",
+    "bn": "Bengali",
+    "pt-BR": "Portuguese (Brazil)",
+    "ru": "Russian",
+    "pa-IN": "Punjabi",
+}
+
+
+class Field:
+    """One rendered setting. Attributes, because Jinja reads them cleanly."""
+
+    def __init__(
+        self,
+        name: str,
+        label: str,
+        description: str,
+        kind: str,
+        display: str,
+        *,
+        empty: bool = False,
+        feature: Optional[str] = None,
+        active: bool = True,
+        locked: bool = False,
+        swatch: Optional[str] = None,
+        warnings: Optional[list] = None,
+    ):
+        self.name = name
+        self.label = label
+        self.description = description
+        self.kind = kind
+        self.display = display
+        self.empty = empty
+        self.feature = feature
+        self.active = active
+        self.locked = locked
+        self.swatch = swatch
+        self.warnings = warnings or []
+
+    @property
+    def badge(self) -> Optional[str]:
+        """Which of the two plan states to show, if either."""
+        if self.locked:
+            return "premium"
+        if not self.active:
+            return "inactive"
+        return None
+
+
+def _state(settings: dict, name: str) -> dict:
+    return (settings.get("fields") or {}).get(name) or {}
+
+
+def _value(settings: dict, name: str):
+    return _state(settings, name).get("value")
+
+
+def _plan(state: dict) -> dict:
+    return {
+        "feature": state.get("feature"),
+        "active": bool(state.get("active", True)),
+        "locked": bool(state.get("locked", False)),
+    }
+
+
+def _role_field(
+    settings: dict,
+    roles: Optional[list],
+    name: str,
+    label: str,
+    description: str,
+    *,
+    unassignable_hint: str,
+    empty_warning: Optional[str] = None,
+) -> Field:
+    state = _state(settings, name)
+    raw = state.get("value")
+    warnings = []
+    swatch = None
+
+    if raw is None or str(raw) == "":
+        display, empty = "Not set", True
+        if empty_warning:
+            warnings.append(empty_warning)
+    else:
+        empty = False
+        role = _lookup(roles, raw)
+        if role is None:
+            # roles is None when the read failed; that is "we could not check",
+            # which is a different claim from "this role is gone".
+            display = f"Unknown role ({raw})"
+            if roles is not None:
+                warnings.append(
+                    "This role no longer exists in the server. VRCVerify will "
+                    "not be able to use it."
+                )
+        else:
+            display = role.get("name") or f"Role {raw}"
+            # Colour 0 is Discord's "no colour", which renders as default grey.
+            if role.get("color"):
+                swatch = _hex(role["color"])
+            assignable = role.get("assignable")
+            if assignable is False:
+                warnings.append(unassignable_hint)
+            elif assignable is None and roles is not None:
+                warnings.append(
+                    "Couldn't check whether VRCVerify can manage this role."
+                )
+
+    return Field(
+        name,
+        label,
+        description,
+        "role",
+        display,
+        empty=empty,
+        swatch=swatch,
+        warnings=warnings,
+        **_plan(state),
+    )
+
+
+def _lookup(entries: Optional[list], wanted) -> Optional[dict]:
+    if not entries or wanted is None:
+        return None
+    target = str(wanted)
+    for entry in entries:
+        if str(entry.get("id")) == target:
+            return entry
+    return None
+
+
+def _hex(color) -> Optional[str]:
+    """Always '#' plus exactly six hex digits, or None.
+
+    The result lands in an SVG fill attribute, so the shape of it is the
+    guarantee that matters: masking to 24 bits means no value can widen it into
+    anything but a colour, whatever arrives.
+    """
+    try:
+        return "#{:06x}".format(int(color) & 0xFFFFFF)
+    except (TypeError, ValueError):
+        return None
+
+
+def _bool_field(
+    settings: dict, name: str, label: str, description: str, *, on: str, off: str
+) -> Field:
+    state = _state(settings, name)
+    value = bool(state.get("value"))
+    return Field(
+        name, label, description, "bool", on if value else off, **_plan(state)
+    )
+
+
+def build_groups(
+    settings: dict,
+    roles: Optional[list],
+    channels: Optional[list],
+    panel: Optional[dict] = None,
+) -> list:
+    """The settings page, grouped the way an admin thinks about them.
+
+    The panel's whereabouts rides along with the panel's appearance, because
+    "what does it look like" and "where is it, and can the bot still reach it"
+    are one question to the person reading. It stays a separate key rather than
+    a tenth field: it is a status, not a setting, and nothing will ever save it.
+    """
+    verified = _role_field(
+        settings,
+        roles,
+        "role_id",
+        "Verified role",
+        "Granted once a member's VRChat account is confirmed as 18+.",
+        unassignable_hint=(
+            "VRCVerify cannot grant this role. Move the VRCVerify role above it "
+            "in Server Settings -> Roles, or verification will fail for every "
+            "member."
+        ),
+        empty_warning=(
+            "No verified role is set, so verification cannot complete. Members "
+            "are told to contact an admin."
+        ),
+    )
+
+    unverified = _role_field(
+        settings,
+        roles,
+        "unverified_role_id",
+        "Unverified role",
+        "Removed automatically once a member verifies.",
+        unassignable_hint=(
+            "VRCVerify cannot remove this role. Move the VRCVerify role above "
+            "it in Server Settings -> Roles."
+        ),
+    )
+
+    auto_verify = _bool_field(
+        settings,
+        "auto_verify_new_members",
+        "Auto-verify on join",
+        "Members already verified with VRCVerify elsewhere get the role as soon "
+        "as they join. Free for every server, always.",
+        on="On",
+        off="Off",
+    )
+
+    nickname = _bool_field(
+        settings,
+        "auto_nickname_change",
+        "Nickname sync",
+        "Sets a member's server nickname to their VRChat display name.",
+        on="On",
+        off="Off",
+    )
+
+    custom_dm = _custom_dm_field(settings)
+    locale = _locale_field(settings)
+    log_channel = _log_channel_field(settings, channels)
+    color, icon = _panel_fields(settings)
+
+    return [
+        {
+            "title": "Verification",
+            "blurb": "The core of the bot. These are free for every server.",
+            "fields": [verified, unverified, auto_verify],
+        },
+        {
+            "title": "After verifying",
+            "blurb": "What happens once a member is confirmed.",
+            "fields": [nickname, custom_dm],
+        },
+        {
+            "title": "Instructions panel",
+            "blurb": "The message members use to start verification.",
+            "fields": [locale, color, icon],
+            "panel": panel_summary(panel),
+        },
+        {
+            "title": "Logging",
+            "blurb": "A record of verification activity for your moderators.",
+            "fields": [log_channel],
+        },
+    ]
+
+
+def _custom_dm_field(settings: dict) -> Field:
+    state = _state(settings, "custom_verification_requested_message")
+    raw = state.get("value")
+    if raw:
+        display, empty = str(raw), False
+    else:
+        display, empty = "Using the default message", True
+    return Field(
+        "custom_verification_requested_message",
+        "Custom verification message",
+        "Replaces the default DM a member gets when they start verifying.",
+        "text",
+        display,
+        empty=empty,
+        **_plan(state),
+    )
+
+
+def _locale_field(settings: dict) -> Field:
+    state = _state(settings, "instructions_locale")
+    code = state.get("value") or "en-US"
+    name = LOCALE_NAMES.get(code)
+    display = f"{name} ({code})" if name else str(code)
+    return Field(
+        "instructions_locale",
+        "Language",
+        "The language of the instructions panel and the bot's replies to members.",
+        "locale",
+        display,
+        **_plan(state),
+    )
+
+
+def _panel_fields(settings: dict):
+    color_state = _state(settings, "panel_embed_color")
+    swatch = _hex(color_state.get("value"))
+    color = Field(
+        "panel_embed_color",
+        "Panel colour",
+        "The colour bar down the side of the instructions panel.",
+        "color",
+        swatch or "Default blue",
+        empty=swatch is None,
+        swatch=swatch,
+        **_plan(color_state),
+    )
+
+    icon = _bool_field(
+        settings,
+        "panel_show_icon",
+        "Server icon on the panel",
+        "Shows your server's icon as the panel's thumbnail.",
+        on="Shown",
+        off="Hidden",
+    )
+    return color, icon
+
+
+def _log_channel_field(settings: dict, channels: Optional[list]) -> Field:
+    state = _state(settings, "verification_log_channel_id")
+    raw = state.get("value")
+    warnings = []
+
+    if raw is None or str(raw) == "":
+        display, empty = "Not set", True
+    else:
+        empty = False
+        channel = _lookup(channels, raw)
+        if channel is None:
+            display = f"Unknown channel ({raw})"
+            if channels is not None:
+                warnings.append("This channel no longer exists in the server.")
+        else:
+            display = f"#{channel.get('name') or raw}"
+            if channel.get("is_news"):
+                # The bot refuses these outright. Other servers can follow an
+                # announcement channel, which would republish an age disclosure
+                # about a named member into servers they have no relationship
+                # with.
+                warnings.append(
+                    "This is an announcement channel. Other servers can follow "
+                    "it, which would republish age disclosures about your "
+                    "members. VRCVerify will not log here."
+                )
+            if channel.get("can_send") is False:
+                warnings.append("VRCVerify cannot post in this channel.")
+
+    return Field(
+        "verification_log_channel_id",
+        "Verification log channel",
+        "Every verification attempt, including the ones that fail silently.",
+        "channel",
+        display,
+        empty=empty,
+        warnings=warnings,
+        **_plan(state),
+    )
+
+
+def panel_summary(panel: Optional[dict]) -> dict:
+    """The instructions panel's whereabouts, as a template-ready dict.
+
+    `posted: false` is not proof there is no panel -- load_instruction_panel in
+    the bot returns None both for "never posted" and for "the row could not be
+    read". The copy says "no panel found" rather than "no panel exists" for
+    exactly that reason, and step 6 must confirm before it offers to post one.
+    """
+    if panel is None:
+        return {"known": False}
+    if not panel.get("posted"):
+        return {"known": True, "posted": False}
+
+    warnings = []
+    if panel.get("channel_exists") is False:
+        warnings.append(
+            "The channel this panel was posted in no longer exists, so members "
+            "have no way to start verifying."
+        )
+    elif panel.get("channel_reachable") is False:
+        warnings.append(
+            "VRCVerify can no longer post in that channel, so it cannot refresh "
+            "this panel."
+        )
+
+    name = panel.get("channel_name")
+    return {
+        "known": True,
+        "posted": True,
+        "channel": f"#{name}" if name else f"channel {panel.get('channel_id')}",
+        "warnings": warnings,
+    }

--- a/src/dashboard/static/style.css
+++ b/src/dashboard/static/style.css
@@ -153,6 +153,98 @@ button.link {
 .server.absent .name { color: var(--muted); }
 .server.absent .state { color: var(--accent); }
 
+/* --- one server's settings --- */
+.crumb { margin: 0 0 1rem; font-size: 0.925rem; }
+.crumb a { color: var(--muted); text-decoration: none; }
+
+.guild-head {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.guild-head .icon { margin: 0; flex: 0 0 auto; }
+.guild-head h1 { margin: 0; }
+.guild-head p { margin: 0.15rem 0 0; }
+
+.notice.read-only { background: none; color: var(--muted); border: 1px dashed var(--line); }
+
+.group { margin-top: 2rem; }
+.group h2 { font-size: 1.05rem; margin: 0; }
+.blurb { margin: 0.1rem 0 0.85rem; }
+
+.settings { margin: 0; }
+
+.setting {
+  padding: 0.9rem 0;
+  border-top: 1px solid var(--line);
+}
+
+.setting dt {
+  font-weight: 600;
+  font-size: 0.95rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.setting dd { margin: 0.3rem 0 0; }
+
+.value {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  overflow-wrap: anywhere;
+  /* The custom DM is free text an admin wrote; preserve their line breaks
+     rather than reflowing it into something they did not write. */
+  white-space: pre-wrap;
+}
+
+.value.empty { color: var(--muted); font-style: italic; }
+
+.swatch { flex: 0 0 auto; vertical-align: middle; }
+
+.desc, .plan { margin: 0.2rem 0 0; font-size: 0.875rem; }
+.plan { font-style: italic; }
+
+/* Locked means the bot refuses the save, so the row is visibly inert. Fields
+ * that merely aren't acted on are NOT dimmed -- they are editable in Discord
+ * today, and dimming them would tell an admin something untrue. */
+.setting.locked .value { color: var(--muted); }
+
+.badge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+}
+
+.badge.premium { color: var(--accent); }
+.badge.inactive { color: var(--muted); }
+
+.warn {
+  margin: 0.45rem 0 0;
+  padding: 0.5rem 0.7rem;
+  border-radius: 6px;
+  background: var(--notice-bg);
+  color: var(--notice);
+  font-size: 0.875rem;
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.9em;
+  background: var(--bg);
+  padding: 0.05rem 0.3rem;
+  border-radius: 4px;
+}
+
 footer {
   max-width: 60rem;
   margin: 0 auto;

--- a/src/dashboard/templates/picker.html
+++ b/src/dashboard/templates/picker.html
@@ -23,16 +23,17 @@
       {% for server in servers %}
         <li class="server {% if not server.installed %}absent{% endif %}">
           {% if server.installed %}
-            {# Settings pages land in step 4; the tile is not a link yet. #}
-            <span class="icon" aria-hidden="true">
-              {% if server.icon_url %}
-                <img src="{{ server.icon_url }}" alt="" width="64" height="64" loading="lazy">
-              {% else %}
-                <span class="initial">{{ server.name[:1] | upper }}</span>
-              {% endif %}
-            </span>
-            <span class="name">{{ server.name }}</span>
-            <span class="state">Installed</span>
+            <a href="{{ url_for('guild_settings', guild_id=server.id) }}">
+              <span class="icon" aria-hidden="true">
+                {% if server.icon_url %}
+                  <img src="{{ server.icon_url }}" alt="" width="64" height="64" loading="lazy">
+                {% else %}
+                  <span class="initial">{{ server.name[:1] | upper }}</span>
+                {% endif %}
+              </span>
+              <span class="name">{{ server.name }}</span>
+              <span class="state">Settings</span>
+            </a>
           {% else %}
             <a href="{{ server.invite_url }}" rel="noopener">
               <span class="icon" aria-hidden="true">

--- a/src/dashboard/templates/settings.html
+++ b/src/dashboard/templates/settings.html
@@ -1,0 +1,133 @@
+{% extends "base.html" %}
+{% block title %}{{ guild_name }} — VRCVerify{% endblock %}
+
+{% block content %}
+<p class="crumb"><a href="{{ url_for('index') }}">&larr; All servers</a></p>
+
+<section class="panel">
+  <header class="guild-head">
+    <span class="icon" aria-hidden="true">
+      {% if guild_icon %}
+        <img src="{{ guild_icon }}" alt="" width="64" height="64">
+      {% else %}
+        <span class="initial">{{ guild_name[:1] | upper }}</span>
+      {% endif %}
+    </span>
+    <div>
+      <h1>{{ guild_name }}</h1>
+      <p class="muted">
+        {% if premium.premium %}
+          VRCVerify Premium is active on this server.
+        {% elif premium.grandfathered %}
+          This server was set up before Premium launched, so it keeps several
+          extras free, permanently.
+        {% else %}
+          18+ verification is free on this server, and always will be.
+        {% endif %}
+      </p>
+    </div>
+  </header>
+
+  <p class="notice read-only">
+    This page is read-only for now. To change any of these, use
+    <code>/vrcverify_settings</code> in your server.
+  </p>
+
+  {% if not names_resolved %}
+    <p class="notice">
+      Couldn't load this server's roles and channels just now, so some settings
+      below show an ID instead of a name. The values themselves are correct.
+    </p>
+  {% endif %}
+
+  {% if not auto_verify_column_present %}
+    <p class="notice">
+      This bot's database is missing the auto-verify column, so that setting
+      isn't in effect regardless of what it shows. Contact the bot operator.
+    </p>
+  {% endif %}
+
+  {% for group in groups %}
+    <section class="group">
+      <h2>{{ group.title }}</h2>
+      <p class="muted blurb">{{ group.blurb }}</p>
+
+      <dl class="settings">
+        {% if group.panel %}
+          <div class="setting">
+            <dt>Where it's posted</dt>
+            <dd>
+              {% if not group.panel.known %}
+                <p class="value empty">Couldn't check</p>
+                <p class="muted desc">The bot didn't answer this one. Try again shortly.</p>
+              {% elif not group.panel.posted %}
+                <p class="value empty">No panel found</p>
+                <p class="muted desc">
+                  Post one with <code>/vrcverify_panel</code> so members have
+                  somewhere to start.
+                </p>
+              {% else %}
+                <p class="value">{{ group.panel.channel }}</p>
+                <p class="muted desc">Members use this message to begin verification.</p>
+                {% for warning in group.panel.warnings %}
+                  <p class="warn">{{ warning }}</p>
+                {% endfor %}
+              {% endif %}
+            </dd>
+          </div>
+        {% endif %}
+        {% for field in group.fields %}
+          <div class="setting{% if field.locked %} locked{% endif %}">
+            <dt>
+              {{ field.label }}
+              {% if field.badge == 'premium' %}
+                <span class="badge premium">Premium</span>
+              {% elif field.badge == 'inactive' %}
+                <span class="badge inactive">Not applied</span>
+              {% endif %}
+            </dt>
+            <dd>
+              <p class="value{% if field.empty %} empty{% endif %}">
+                {% if field.swatch %}
+                  {# An SVG, not a styled span: the CSP is style-src 'self',
+                     which blocks inline style attributes, and adding
+                     'unsafe-inline' to paint a square would be a poor trade.
+                     `fill` is a presentation attribute, not CSS. #}
+                  <svg class="swatch" width="14" height="14" aria-hidden="true">
+                    <rect width="14" height="14" rx="3" fill="{{ field.swatch }}"></rect>
+                  </svg>
+                {% endif %}
+                {{ field.display }}
+              </p>
+              <p class="muted desc">{{ field.description }}</p>
+
+              {% if field.badge == 'premium' %}
+                <p class="muted plan">
+                  Premium only.
+                  {%- if not field.empty %}
+                    Your saved value is kept, and comes back if the
+                    subscription is renewed.
+                  {%- endif %}
+                </p>
+              {% elif field.badge == 'inactive' %}
+                {# The distinction that keeps this site from being stricter
+                   than the slash commands: saved by anyone, acted on only
+                   with the feature. #}
+                <p class="muted plan">
+                  Saved, but not acted on without Premium. Anyone can set this;
+                  the bot just won't use it until the feature is active.
+                </p>
+              {% endif %}
+
+              {% for warning in field.warnings %}
+                <p class="warn">{{ warning }}</p>
+              {% endfor %}
+            </dd>
+          </div>
+        {% endfor %}
+      </dl>
+    </section>
+  {% endfor %}
+
+</section>
+{% endblock %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,4 +1,4 @@
-"""Unit tests for the web dashboard (issue #65, step 3).
+"""Unit tests for the web dashboard (issue #65, steps 3 and 4).
 
 This is the internet-facing half of the system, so the tests are mostly about
 the ways a login can be subverted rather than the happy path:
@@ -9,6 +9,14 @@ the ways a login can be subverted rather than the happy path:
 - authority is never taken from OAuth data or from Cf-Access-* headers
 - the app refuses to start on a weak or missing secret
 - nothing here can write: the read-only phase is pinned
+
+Step 4 adds one server's settings, where the recurring theme is that the page
+must say exactly what the bot would:
+
+- "refused at save time" and "saved but not acted on" are different badges
+- a 403 and a 404 from the bot are one indistinguishable answer, or the page
+  becomes an oracle for which servers run 18+ gating
+- a failed read shows an id or an apology, never a default nobody chose
 """
 
 import json
@@ -20,7 +28,7 @@ import pytest
 
 pytest.importorskip("flask")
 
-from dashboard import oauth  # noqa: E402
+from dashboard import oauth, settings_view  # noqa: E402
 from dashboard.app import CSP, SESSION_COOKIE, create_app  # noqa: E402
 from dashboard.botapi import BotAPIError  # noqa: E402
 from dashboard.config import DashboardConfig, DashboardConfigError  # noqa: E402
@@ -62,19 +70,159 @@ def config(tmp_path, certs):
     )
 
 
+VERIFIED_ROLE = "900000000001"
+UNVERIFIED_ROLE = "900000000002"
+UNASSIGNABLE_ROLE = "900000000003"
+LOG_CHANNEL = "800000000001"
+NEWS_CHANNEL = "800000000002"
+
+# What a free server looks like: the three write-locked features refused, the
+# two badge-only ones inactive but unlocked. Straight out of SETTINGS_FIELDS.
+FREE_PLAN = {
+    "role_id": (None, True, False),
+    "unverified_role_id": ("unverified_role_removal", False, False),
+    "auto_verify_new_members": (None, True, False),
+    "auto_nickname_change": ("nickname_sync", False, True),
+    "custom_verification_requested_message": ("custom_dm", False, False),
+    "instructions_locale": (None, True, False),
+    "panel_embed_color": ("branded_panel", False, True),
+    "panel_show_icon": ("branded_panel", False, True),
+    "verification_log_channel_id": ("activity_log", False, True),
+}
+
+DEFAULT_VALUES = {
+    "role_id": VERIFIED_ROLE,
+    "unverified_role_id": None,
+    "auto_verify_new_members": True,
+    "auto_nickname_change": False,
+    "custom_verification_requested_message": None,
+    "instructions_locale": "en-US",
+    "panel_embed_color": None,
+    "panel_show_icon": False,
+    "verification_log_channel_id": None,
+}
+
+
+def make_settings(premium=False, values=None, auto_verify_column=True):
+    """A settings payload shaped exactly like read_dashboard_settings returns."""
+    merged = dict(DEFAULT_VALUES)
+    merged.update(values or {})
+    fields = {}
+    for name, (feature, active, locked) in FREE_PLAN.items():
+        fields[name] = {
+            "value": merged[name],
+            "feature": feature,
+            "active": True if premium else active,
+            "locked": False if premium else locked,
+        }
+    return {
+        "guild_id": GUILD_IN,
+        "premium": {"enforced": True, "premium": premium, "grandfathered": False},
+        "auto_verify_column_present": auto_verify_column,
+        "fields": fields,
+    }
+
+
+DEFAULT_ROLES = [
+    {
+        "id": VERIFIED_ROLE,
+        "name": "Verified",
+        "position": 5,
+        "color": 0x5865F2,
+        "managed": False,
+        "assignable": True,
+    },
+    {
+        "id": UNVERIFIED_ROLE,
+        "name": "Unverified",
+        "position": 4,
+        "color": 0,
+        "managed": False,
+        "assignable": True,
+    },
+    {
+        "id": UNASSIGNABLE_ROLE,
+        "name": "Above The Bot",
+        "position": 90,
+        "color": 0,
+        "managed": False,
+        "assignable": False,
+    },
+]
+
+DEFAULT_CHANNELS = [
+    {
+        "id": LOG_CHANNEL,
+        "name": "verify-log",
+        "category": "Staff",
+        "position": 1,
+        "is_news": False,
+        "can_send": True,
+    },
+    {
+        "id": NEWS_CHANNEL,
+        "name": "announcements",
+        "category": None,
+        "position": 2,
+        "is_news": True,
+        "can_send": True,
+    },
+]
+
+
 class FakeBotAPI:
     """Stands in for the bot. Records what it was asked."""
 
-    def __init__(self, installed=(GUILD_IN,), fail=False):
+    def __init__(
+        self,
+        installed=(GUILD_IN,),
+        fail=False,
+        settings=None,
+        roles=None,
+        channels=None,
+        panel=None,
+        errors=None,
+    ):
         self.installed = {str(g) for g in installed}
         self.fail = fail
         self.calls = []
+        self.reads = []
+        self._settings = settings
+        self._roles = DEFAULT_ROLES if roles is None else roles
+        self._channels = DEFAULT_CHANNELS if channels is None else channels
+        self._panel = {"posted": False} if panel is None else panel
+        # {"settings": BotAPIError(...), ...} -- per-endpoint failures, so a
+        # secondary read can be broken without breaking the page.
+        self.errors = errors or {}
 
     def admin_guild_ids(self, actor_id, guild_ids):
         self.calls.append((actor_id, list(guild_ids)))
         if self.fail:
             raise BotAPIError("bot unreachable")
         return {g for g in map(str, guild_ids) if g in self.installed}
+
+    def _answer(self, what, actor_id, guild_id, payload):
+        self.reads.append((what, str(actor_id), str(guild_id)))
+        if what in self.errors:
+            raise self.errors[what]
+        return payload
+
+    def settings(self, actor_id, guild_id):
+        return self._answer(
+            "settings",
+            actor_id,
+            guild_id,
+            self._settings if self._settings is not None else make_settings(),
+        )
+
+    def roles(self, actor_id, guild_id):
+        return self._answer("roles", actor_id, guild_id, self._roles)
+
+    def channels(self, actor_id, guild_id):
+        return self._answer("channels", actor_id, guild_id, self._channels)
+
+    def panel(self, actor_id, guild_id):
+        return self._answer("panel", actor_id, guild_id, self._panel)
 
 
 @pytest.fixture
@@ -398,8 +546,11 @@ class TestPicker:
         response = client.get("/")
         assert response.status_code == 200
         assert b"Alpha Club" in response.data
-        assert b"Installed" in response.data
         assert b"Add to this server" in response.data
+        # Installed servers link into their settings; absent ones link to the
+        # invite instead.
+        assert f'href="/guild/{GUILD_IN}"'.encode() in response.data
+        assert f'href="/guild/{GUILD_OUT}"'.encode() not in response.data
 
     def test_servers_without_the_bot_offer_a_targeted_invite(self, client, store):
         login_as(client, store)
@@ -437,6 +588,260 @@ class TestPicker:
 
 
 # -------------------------------------------------------------------
+# One server's settings (step 4)
+# -------------------------------------------------------------------
+def settings_client(config, store, **kwargs):
+    """A logged-in client whose bot API is configured for these tests."""
+    api = FakeBotAPI(**kwargs)
+    app = create_app(config, store=store, client=api)
+    app.config.update(TESTING=True)
+    test_client = app.test_client()
+    login_as(test_client, store)
+    return test_client, api
+
+
+class TestSettingsPage:
+    def test_signed_out_visitors_are_sent_to_the_login_page(self, client):
+        response = client.get(f"/guild/{GUILD_IN}")
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/")
+
+    def test_values_are_shown_with_names_not_ids(self, config, store):
+        test_client, _api = settings_client(config, store)
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "Verified" in page
+        assert VERIFIED_ROLE not in page
+
+    def test_every_read_is_scoped_to_the_session_owner_and_that_guild(
+        self, config, store
+    ):
+        test_client, api = settings_client(config, store)
+        test_client.get(f"/guild/{GUILD_IN}")
+        assert {what for what, _, _ in api.reads} == {
+            "settings",
+            "roles",
+            "channels",
+            "panel",
+        }
+        for _what, actor, guild in api.reads:
+            assert actor == ACTOR
+            assert guild == GUILD_IN
+
+    def test_the_guild_name_comes_from_the_session_not_the_bot(self, config, store):
+        test_client, _api = settings_client(config, store)
+        assert b"Alpha Club" in test_client.get(f"/guild/{GUILD_IN}").data
+
+    def test_a_guild_missing_from_a_stale_oauth_list_still_renders(
+        self, config, store
+    ):
+        """Promotion to Administrator since login must not lock someone out.
+
+        The OAuth guild list is a display hint that ages; the bot has already
+        said yes by the time we get here.
+        """
+        api = FakeBotAPI()
+        app = create_app(config, store=store, client=api)
+        app.config.update(TESTING=True)
+        test_client = app.test_client()
+        login_as(test_client, store, guilds=[])
+
+        response = test_client.get(f"/guild/{GUILD_IN}")
+        assert response.status_code == 200
+        assert b"Verified" in response.data
+
+
+class TestSettingsDoesNotLeakWhichServersRunTheBot:
+    """403 and 404 must be one indistinguishable answer.
+
+    The bot separates "not in that guild" from "you are not an administrator",
+    which is correct behind mTLS and dangerous on the open web: rendered
+    differently, any signed-in user could walk guild ids and enumerate the
+    servers running 18+ gating.
+    """
+
+    def _response(self, config, store, status):
+        test_client, _api = settings_client(
+            config, store, errors={"settings": BotAPIError("nope", status)}
+        )
+        return test_client.get(f"/guild/{GUILD_IN}")
+
+    def test_403_and_404_are_byte_identical(self, config, store):
+        # One client, so the comparison isn't confounded by the per-session
+        # CSRF token in the sign-out form.
+        test_client, api = settings_client(
+            config, store, errors={"settings": BotAPIError("nope", 403)}
+        )
+        forbidden = test_client.get(f"/guild/{GUILD_IN}")
+
+        api.errors = {"settings": BotAPIError("nope", 404)}
+        missing = test_client.get(f"/guild/{GUILD_IN}")
+
+        assert forbidden.status_code == missing.status_code == 404
+        assert forbidden.data == missing.data
+
+    def test_neither_names_the_reason(self, config, store):
+        page = self._response(config, store, 403).data.decode().lower()
+        # Both possibilities are offered and neither is confirmed.
+        assert "administrator permission there" in page
+        assert "vrcverify isn" in page
+        assert "403" not in page
+        assert "not_administrator" not in page
+
+    def test_an_unavailable_bot_is_a_different_answer(self, config, store):
+        """503 discloses nothing about a guild, so it may be honest."""
+        response = self._response(config, store, 503)
+        assert response.status_code == 503
+        assert b"Can&#39;t reach the bot" in response.data
+
+    def test_a_failed_settings_read_never_renders_defaults(self, config, store):
+        page = self._response(config, store, 503).data.decode()
+        for never in ("Not set", "Default blue", "en-US"):
+            assert never not in page
+
+
+class TestPlanBadgesMirrorTheBot:
+    """The site must be neither stricter nor looser than the slash commands."""
+
+    def test_write_locked_fields_are_marked_premium(self, config, store):
+        test_client, _api = settings_client(config, store)
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "Nickname sync" in page
+        assert "Premium</span>" in page
+
+    def test_badge_only_fields_are_not_shown_as_locked(self, config, store):
+        """/vrcverify_setup stores these for a free server quite happily.
+
+        Rendering them as Premium-locked would make the website refuse to show
+        something an admin can plainly set in Discord.
+        """
+        test_client, _api = settings_client(
+            config,
+            store,
+            settings=make_settings(
+                values={
+                    "unverified_role_id": UNVERIFIED_ROLE,
+                    "custom_verification_requested_message": "Welcome aboard!",
+                }
+            ),
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        # The values are shown, not hidden or replaced with an upsell.
+        assert "Unverified" in page
+        assert "Welcome aboard!" in page
+        assert "Not applied</span>" in page
+        assert "Saved, but not acted on without Premium" in page
+
+    def test_a_premium_server_sees_no_badges(self, config, store):
+        test_client, _api = settings_client(
+            config, store, settings=make_settings(premium=True)
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "Premium</span>" not in page
+        assert "Not applied</span>" not in page
+        assert "VRCVerify Premium is active" in page
+
+    def test_auto_verify_is_never_gated(self, config, store):
+        """Free for everyone, forever -- mirrors TestAutoVerifyOnJoinIsFree."""
+        test_client, _api = settings_client(config, store)
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        section = page.split("Auto-verify on join")[1].split("</div>")[0]
+        assert "badge" not in section
+
+    def test_a_missing_auto_verify_column_is_declared(self, config, store):
+        test_client, _api = settings_client(
+            config, store, settings=make_settings(auto_verify_column=False)
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "missing the auto-verify column" in page
+
+
+class TestSettingsWarnings:
+    """The point of the dashboard: say it now, not at verification time."""
+
+    def test_an_unassignable_verified_role_is_called_out(self, config, store):
+        test_client, _api = settings_client(
+            config, store, settings=make_settings(values={"role_id": UNASSIGNABLE_ROLE})
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "cannot grant this role" in page
+        assert "Server Settings -&gt; Roles" in page
+
+    def test_a_deleted_role_is_called_out(self, config, store):
+        test_client, _api = settings_client(
+            config, store, settings=make_settings(values={"role_id": "404404404404"})
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "no longer exists" in page
+
+    def test_no_verified_role_is_called_out(self, config, store):
+        test_client, _api = settings_client(
+            config, store, settings=make_settings(values={"role_id": None})
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "verification cannot complete" in page
+
+    def test_an_announcement_log_channel_is_called_out(self, config, store):
+        """A followed channel republishes an age disclosure to strangers."""
+        test_client, _api = settings_client(
+            config,
+            store,
+            settings=make_settings(
+                premium=True, values={"verification_log_channel_id": NEWS_CHANNEL}
+            ),
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "republish age disclosures" in page
+
+    def test_an_unreachable_panel_channel_is_called_out(self, config, store):
+        test_client, _api = settings_client(
+            config,
+            store,
+            panel={
+                "posted": True,
+                "channel_id": "123",
+                "message_id": "456",
+                "channel_name": "verify",
+                "channel_exists": True,
+                "channel_reachable": False,
+                "locale": "en-US",
+            },
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "can no longer post in that channel" in page
+
+
+class TestSecondaryReadsDegradeGracefully:
+    """A name lookup failing must not cost the whole page."""
+
+    def test_the_page_renders_without_roles(self, config, store):
+        test_client, _api = settings_client(
+            config, store, errors={"roles": BotAPIError("unavailable", 503)}
+        )
+        response = test_client.get(f"/guild/{GUILD_IN}")
+        assert response.status_code == 200
+        page = response.data.decode()
+        assert f"Unknown role ({VERIFIED_ROLE})" in page
+        assert "show an ID instead of a name" in page
+
+    def test_an_unresolved_id_is_not_reported_as_deleted(self, config, store):
+        """"We could not check" and "it is gone" are different claims."""
+        test_client, _api = settings_client(
+            config, store, errors={"roles": BotAPIError("unavailable", 503)}
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "no longer exists" not in page
+
+    def test_the_page_renders_without_the_panel_read(self, config, store):
+        test_client, _api = settings_client(
+            config, store, errors={"panel": BotAPIError("unavailable", 503)}
+        )
+        response = test_client.get(f"/guild/{GUILD_IN}")
+        assert response.status_code == 200
+        # Literal template text, so the apostrophe is not entity-escaped here.
+        assert b"Couldn't check" in response.data
+
+
+# -------------------------------------------------------------------
 # Hardening
 # -------------------------------------------------------------------
 class TestHardening:
@@ -463,6 +868,24 @@ class TestHardening:
         login_as(client, store)
         for path in ("/", "/nonexistent"):
             assert b"<script" not in client.get(path).data
+
+    def test_no_page_carries_an_inline_style_attribute(self, config, store):
+        """style-src 'self' blocks these, and it blocks them *silently*.
+
+        Nothing errors -- the browser just drops the declaration and the page
+        renders subtly wrong, which is a bad way to find out. The role and panel
+        colour swatches are SVG fill attributes for exactly this reason.
+        """
+        test_client, _api = settings_client(
+            config,
+            store,
+            settings=make_settings(premium=True, values={"panel_embed_color": 0xFF00FF}),
+        )
+        for path in ("/", f"/guild/{GUILD_IN}"):
+            page = test_client.get(path).data
+            assert b"style=" not in page, f"inline style on {path}"
+        # The swatch still rendered; it just isn't CSS.
+        assert b'fill="#ff00ff"' in test_client.get(f"/guild/{GUILD_IN}").data
 
     def test_logout_requires_the_csrf_token(self, client, store):
         session = login_as(client, store)
@@ -495,6 +918,78 @@ class TestHardening:
 
     def test_healthz_says_nothing_useful(self, client):
         assert client.get("/healthz").get_json() == {"ok": True}
+
+
+class TestSettingsViewModel:
+    """The rendering rules, without a request in the way."""
+
+    def test_no_field_from_the_api_is_silently_dropped(self):
+        """Adding a setting to the bot must not quietly skip the website.
+
+        SETTINGS_FIELDS in bot.py is the allowlist for both ends. If a field
+        appears there and nothing renders it, an admin sees a page that claims
+        to be their settings and isn't -- so this fails rather than omitting.
+        """
+        settings = make_settings()
+        rendered = {
+            field.name
+            for group in settings_view.build_groups(
+                settings, DEFAULT_ROLES, DEFAULT_CHANNELS
+            )
+            for field in group["fields"]
+        }
+        assert rendered == set(settings["fields"])
+
+    def test_locked_beats_inactive_on_the_badge(self):
+        """A locked field is always inactive too; the stronger claim wins."""
+        field = settings_view.Field(
+            "x", "X", "", "bool", "On", active=False, locked=True
+        )
+        assert field.badge == "premium"
+
+    def test_inactive_but_unlocked_is_its_own_badge(self):
+        field = settings_view.Field(
+            "x", "X", "", "bool", "On", active=False, locked=False
+        )
+        assert field.badge == "inactive"
+
+    def test_an_available_field_has_no_badge(self):
+        assert settings_view.Field("x", "X", "", "bool", "On").badge is None
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (0x5865F2, "#5865f2"),
+            (0, "#000000"),
+            (0xFFFFFFFF, "#ffffff"),  # masked to 24 bits
+            (-1, "#ffffff"),
+            (None, None),
+            ("#ff0000; --x: url(evil)", None),
+        ],
+    )
+    def test_colours_can_only_ever_be_a_colour(self, value, expected):
+        """The result lands in an SVG fill attribute, so shape is the guard."""
+        assert settings_view._hex(value) == expected
+
+    def test_an_unknown_locale_renders_as_itself(self):
+        settings = make_settings(values={"instructions_locale": "xx-YY"})
+        groups = settings_view.build_groups(settings, DEFAULT_ROLES, DEFAULT_CHANNELS)
+        locale = next(
+            field
+            for group in groups
+            for field in group["fields"]
+            if field.name == "instructions_locale"
+        )
+        assert locale.display == "xx-YY"
+
+    def test_an_unread_panel_is_not_reported_as_absent(self):
+        """"Never posted" and "could not read" must not look the same.
+
+        load_instruction_panel returns None for both, so step 6 has to confirm
+        before it offers to post a duplicate.
+        """
+        assert settings_view.panel_summary(None) == {"known": False}
+        assert settings_view.panel_summary({"posted": False})["posted"] is False
 
 
 class TestReadOnlyPhase:


### PR DESCRIPTION
Step 4 of #65. Installed tiles in the picker become links; each leads to a read-only page showing every setting in `SETTINGS_FIELDS`, with ids resolved to names.

Still read-only — the only `POST` route in the app is sign-out, and the bot API has no write endpoint to call even if there were.

## The page mirrors the bot, including where the bot is inconsistent

Gating bites in two places, and `SettingsField` in `bot.py` already records which is which:

| | behaviour | badge |
|---|---|---|
| nickname sync, panel colour, panel icon, log channel | the bot refuses the **save** | **Premium** |
| unverified role, custom DM | saves for anyone, the bot just doesn't **act** on it | **Not applied** |
| auto-verify on join | never gated, for anyone | none |

Collapsing the first two rows into one "premium" state would leave the website refusing to show an admin something they can plainly set with `/vrcverify_setup`. A test fails if a field the API reports goes unrendered, so adding a setting to the bot cannot quietly skip the website.

## 403 and 404 are one answer

The bot separates "not in that guild" from "you are not an administrator". Correct behind mTLS, dangerous on the open web — rendered differently, any signed-in user could walk guild ids and enumerate which servers run 18+ gating. That is the oracle `handle_list_guilds` was hardened against, arriving by a different door. The two are now byte-identical, asserted in the same session so the CSRF token doesn't confound the comparison.

`503` stays honest: "the bot cannot answer right now" discloses nothing about a particular guild, and it beats telling an admin their server doesn't exist.

## Failure behaviour

- **Settings read fails** → an apology, never defaults. Rendering values nobody chose is precisely what step 5 would save back.
- **Roles/channels/panel fail** → page still renders, ids shown instead of names, with a notice. "We couldn't check" and "it's gone" are kept as separate claims.

## CSP

Colour swatches are SVG `fill` attributes, not styled spans. `style-src 'self'` blocks inline style attributes *silently* — nothing errors, the declaration is dropped, the page renders subtly wrong. A test now asserts no page carries one, and `_hex` masks to 24 bits so nothing but a colour can reach that attribute.

## Also surfaced

Things the bot could previously only discover mid-verification, now visible while an admin is looking at the setting rather than when a member is waiting: a verified role the bot cannot grant, a log channel it cannot post in, an announcement channel other servers could follow and thereby republish an age disclosure about a named member.

## Tests

878 passing, up from 846.