### PR TITLE
Let the dashboard save the instructions panel group

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,9 +326,32 @@ callables and nothing else, so it cannot express a write at all.
 `src/dashboard/` is a small Flask app that signs an admin in with Discord OAuth,
 lists the servers they administer, and shows one server's settings. It holds no
 database credential and no bot token: everything it knows it asks the bot for
-over mTLS, and the bot decides what it is allowed to know. It is still
-**read-only** — the only `POST` route is sign-out, which `tests/test_dashboard.py`
-pins.
+over mTLS, and the bot decides what it is allowed to know.
+
+It can now **save the instructions panel group** — language, colour, server
+icon — and nothing else. That boundary is enforced in the bot by
+`DASHBOARD_WRITABLE_FIELDS`, not by which controls the website chose to draw,
+and the payload tells the dashboard which fields are open so the two cannot
+drift. The website renders a control only where the bot has said it would
+accept the value.
+
+The write path adds one route on each side, and both are pinned by tests:
+
+- `PATCH /api/v1/guilds/{id}/settings` on the bot, the only non-GET route.
+  Because the signed operation includes the **method**, a token minted to read
+  a guild's settings cannot be replayed to write them.
+- `POST /guild/<id>/panel` on the dashboard, behind a CSRF token and a
+  `SameSite=Lax` cookie — though the check that matters is the bot's, which
+  re-runs Administrator, re-runs the plan gate, and validates every value
+  against its own allowlist. Nothing the website sends is trusted by the thing
+  that writes the row.
+
+Every change that actually alters a value is recorded in `dashboard_audit`
+with the actor, the field, and both values. The actor comes from the verified
+token claims, never from the request body. Nothing in this codebase updates or
+deletes a row in that table: an audit trail exists to disagree with someone's
+account of events, which it cannot do if the code that made the change can
+rewrite the record of it.
 
 Two rules the settings page exists to honour:
 

--- a/src/api_tokens.py
+++ b/src/api_tokens.py
@@ -39,6 +39,9 @@ OP_GUILD_SETTINGS = "GET /api/v1/guilds/{guild_id}/settings"
 OP_GUILD_ROLES = "GET /api/v1/guilds/{guild_id}/roles"
 OP_GUILD_CHANNELS = "GET /api/v1/guilds/{guild_id}/channels"
 OP_GUILD_PANEL = "GET /api/v1/guilds/{guild_id}/panel"
+# The method is part of the operation, so a token minted to read a guild's
+# settings cannot be replayed to write them.
+OP_UPDATE_SETTINGS = "PATCH /api/v1/guilds/{guild_id}/settings"
 
 # Tokens are minted per request and used immediately. Thirty seconds is
 # generous for a call across a tunnel and short enough that a captured token is

--- a/src/bot.py
+++ b/src/bot.py
@@ -396,6 +396,41 @@ class VerificationLogChannel(Base):
     updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
 
+class DashboardAudit(Base):
+    """Who changed which setting, from the website, and to what.
+
+    The bot's own slash commands are already accountable: Discord records who
+    ran one, and an admin has to be in the server holding Administrator to do
+    it. The dashboard is different in kind — it is reachable from the public
+    internet, and the only thing standing between a stolen session and a
+    settings change is a cookie. So the first write path gets a durable record
+    in the same change that introduces it.
+
+    Deliberately append-only in use: nothing in this codebase updates or
+    deletes a row here. The value of an audit trail is precisely that it
+    disagrees with someone's account of events, which it cannot do if the code
+    that made the change can also rewrite the record of it.
+
+    Old and new values are stored as text, and are the *settings* only. No
+    member data, no VRChat identity, nothing about who is verified — this table
+    is about administrators changing configuration, and it should stay boring
+    enough that its own disclosure would not matter much.
+    """
+
+    __tablename__ = "dashboard_audit"
+    id = Column(Integer, primary_key=True)
+    server_id = Column(String, index=True, nullable=False)
+    # The Discord user the request was scoped to, taken from the verified token
+    # claims rather than from anything the dashboard put in a body.
+    actor_id = Column(String, nullable=False)
+    field = Column(String, nullable=False)
+    old_value = Column(String, nullable=True)
+    new_value = Column(String, nullable=True)
+    changed_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+
 # Creates any missing tables. Note this does NOT add columns to tables that
 # already exist — those still need a manual ALTER.
 Base.metadata.create_all(engine)
@@ -712,6 +747,62 @@ SETTINGS_FIELDS = (
     SettingsField("panel_show_icon", FEATURE_BRANDED_PANEL, write_locked=True),
     SettingsField("verification_log_channel_id", FEATURE_ACTIVITY_LOG, write_locked=True),
 )
+
+SETTINGS_FIELDS_BY_NAME = {field.name: field for field in SETTINGS_FIELDS}
+
+# Which of those the dashboard may WRITE today. Everything else is readable and
+# refused on save, including fields that will open later.
+#
+# Step 5 of issue #65 opens the instructions panel group and nothing else. The
+# order is deliberate: every value here is a constrained type — one of a fixed
+# set of language codes, a 24-bit integer, a boolean — so the first write path
+# this project has ever had can be about the plumbing (authorisation, the audit
+# record, refusing a locked field) rather than about validating free text or
+# reasoning about role hierarchies at the same time.
+#
+# This list is the enforcement point, not the dashboard's form. The website is
+# untrusted: it renders whatever it likes, and the bot decides.
+DASHBOARD_WRITABLE_FIELDS = frozenset(
+    {"instructions_locale", "panel_embed_color", "panel_show_icon"}
+)
+
+
+# Raised by the writer below, mapped to a status by bot_api. It lives over
+# there because it is the contract between the two halves, not a detail of
+# either.
+SettingRejected = bot_api.SettingRejected
+
+
+def _coerce_locale(value):
+    if not isinstance(value, str) or value not in LANGUAGE_CODES:
+        raise SettingRejected("instructions_locale", "unsupported_language")
+    return value
+
+
+def _coerce_embed_color(value):
+    if value is None:
+        return None  # Explicitly back to the default blue.
+    # bool is a subclass of int, and True would otherwise sail through as the
+    # colour #000001.
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise SettingRejected("panel_embed_color", "not_a_colour")
+    if not 0 <= value <= 0xFFFFFF:
+        raise SettingRejected("panel_embed_color", "colour_out_of_range")
+    return value
+
+
+def _coerce_show_icon(value):
+    if not isinstance(value, bool):
+        raise SettingRejected("panel_show_icon", "not_a_boolean")
+    return value
+
+
+SETTING_COERCERS = {
+    "instructions_locale": _coerce_locale,
+    "panel_embed_color": _coerce_embed_color,
+    "panel_show_icon": _coerce_show_icon,
+}
+
 
 # The grandfather line is drawn on the servers table's autoincrementing primary
 # key: servers at or below it keep GRANDFATHERED_FEATURES for free, forever.
@@ -4555,8 +4646,21 @@ async def read_dashboard_settings(guild_id) -> Optional[dict]:
             # A column the deployed database is missing is reported as such
             # rather than silently rendered as a working toggle.
             "auto_verify_column_present": has_auto_verify,
+            # The allowed values for anything the website renders as a choice.
+            # Sent rather than duplicated over there: a dashboard building its
+            # own language list could offer one the bot cannot render, and the
+            # admin would only find out when the panel came out in English.
+            "choices": {"instructions_locale": list(LANGUAGE_CODES)},
             "fields": {
-                field.name: {"value": values.get(field.name), **field.state(flags)}
+                field.name: {
+                    "value": values.get(field.name),
+                    # Whether the save path accepts this field yet. The bot is
+                    # the one phasing the write path in, so it is the one that
+                    # says so -- the website drawing its own conclusion is how
+                    # the two drift apart.
+                    "writable": field.name in DASHBOARD_WRITABLE_FIELDS,
+                    **field.state(flags),
+                }
                 for field in SETTINGS_FIELDS
             },
         }
@@ -4695,8 +4799,141 @@ async def read_dashboard_panel(guild_id) -> Optional[dict]:
         return None
 
 
+def _record_dashboard_audit(session, guild_id, actor_id, changed: list) -> None:
+    """Append one row per field that actually moved.
+
+    Only real changes are recorded. A form that posts every field on every save
+    would otherwise bury the one line that matters under identical no-ops, and
+    an audit trail nobody can read is not one.
+    """
+    key = panel_view_key(guild_id)
+    for field, old, new in changed:
+        session.add(
+            DashboardAudit(
+                server_id=key,
+                actor_id=str(actor_id),
+                field=field,
+                old_value=None if old is None else str(old),
+                new_value=None if new is None else str(new),
+            )
+        )
+
+
+async def write_dashboard_settings(guild_id, actor_id, changes: dict):
+    """Apply settings changes from the dashboard. The first write path here.
+
+    Raises SettingRejected for anything the caller did wrong -- an unknown
+    field, a field not yet open for writing, a bad value, or one their plan
+    does not include. Returns None if the write could not be completed, which
+    the API turns into a 503; returns the freshly re-read settings on success,
+    so the page an admin lands on is what is actually stored rather than what
+    they submitted.
+
+    Everything is validated before anything is applied. A batch with one bad
+    field changes nothing at all, rather than saving the first two and failing
+    on the third.
+    """
+    if not isinstance(changes, dict) or not changes:
+        raise SettingRejected("", "no_changes")
+
+    # --- Validate the whole batch first ---
+    coerced = {}
+    for name, value in changes.items():
+        if name not in SETTINGS_FIELDS_BY_NAME:
+            raise SettingRejected(str(name), "unknown_field")
+        if name not in DASHBOARD_WRITABLE_FIELDS:
+            raise SettingRejected(name, "not_writable_yet")
+        coerced[name] = SETTING_COERCERS[name](value)
+
+    # --- The plan gate, decided here and never by the website ---
+    try:
+        flags = await resolve_premium_flags(guild_id)
+    except Exception:
+        logger.warning(
+            "Could not resolve premium flags while saving guild %s.",
+            guild_id,
+            exc_info=True,
+        )
+        return None
+    for name in coerced:
+        field = SETTINGS_FIELDS_BY_NAME[name]
+        state = field.state(flags)
+        # Only write_locked fields are refused. The others save for anyone and
+        # simply are not acted on, which is what /vrcverify_setup already does
+        # -- see SettingsField.
+        if state["locked"]:
+            raise SettingRejected(name, "requires_premium", locked=True)
+
+    try:
+        changed = []
+
+        # --- Panel branding: one row, so read-modify-write as a whole ---
+        panel_names = {"panel_embed_color", "panel_show_icon"}
+        if panel_names & set(coerced):
+            branding = load_panel_branding(guild_id)
+            if branding is BRANDING_UNREADABLE:
+                # Writing a merged row on top of a value we could not read would
+                # silently reset whichever half was not submitted.
+                return None
+            old_color, old_icon = branding if branding else (None, False)
+            new_color = coerced.get("panel_embed_color", old_color)
+            new_icon = coerced.get("panel_show_icon", old_icon)
+            if "panel_embed_color" in coerced and new_color != old_color:
+                changed.append(("panel_embed_color", old_color, new_color))
+            if "panel_show_icon" in coerced and bool(new_icon) != bool(old_icon):
+                changed.append(("panel_show_icon", old_icon, new_icon))
+            save_panel_branding(guild_id, new_color, bool(new_icon))
+
+        # --- The locale lives on the servers row ---
+        if "instructions_locale" in coerced:
+            with session_scope() as session:
+                srv = (
+                    session.query(Server)
+                    .filter_by(server_id=panel_view_key(guild_id))
+                    .first()
+                )
+                if srv is None:
+                    # owner_id is NOT NULL and the dashboard has no honest value
+                    # for it -- the acting admin is not necessarily the owner.
+                    # Inserting a row here would also mint a fresh servers.id,
+                    # placing the guild above the grandfather line as a side
+                    # effect of changing its language.
+                    raise SettingRejected("instructions_locale", "server_not_set_up")
+                old_locale = srv.instructions_locale or "en-US"
+                if old_locale != coerced["instructions_locale"]:
+                    changed.append(
+                        ("instructions_locale", old_locale, coerced["instructions_locale"])
+                    )
+                    srv.instructions_locale = coerced["instructions_locale"]
+
+        if changed:
+            with session_scope() as session:
+                _record_dashboard_audit(session, guild_id, actor_id, changed)
+            logger.info(
+                "dashboard WRITE actor=%s guild=%s fields=%s",
+                actor_id,
+                guild_id,
+                ",".join(name for name, _old, _new in changed),
+            )
+    except SettingRejected:
+        raise
+    except Exception:
+        logger.warning(
+            "Could not save dashboard settings for guild %s.", guild_id, exc_info=True
+        )
+        return None
+
+    return await read_dashboard_settings(guild_id)
+
+
 def build_bot_api_deps() -> bot_api.BotAPIDeps:
-    """Hand the API its complete set of capabilities. All of them reads."""
+    """Hand the API its complete set of capabilities.
+
+    One writer, named. `write_settings` is the only way the API can change a
+    row, and it can only change the fields DASHBOARD_WRITABLE_FIELDS names --
+    so widening what the website may touch is an edit to this file, reviewable
+    on its own, rather than a query string nobody noticed.
+    """
     return bot_api.BotAPIDeps(
         is_ready=bot.is_ready,
         guild_present=dashboard_guild_present,
@@ -4706,6 +4943,7 @@ def build_bot_api_deps() -> bot_api.BotAPIDeps:
         read_roles=read_dashboard_roles,
         read_channels=read_dashboard_channels,
         read_panel=read_dashboard_panel,
+        write_settings=write_dashboard_settings,
     )
 
 

--- a/src/bot_api.py
+++ b/src/bot_api.py
@@ -88,6 +88,30 @@ class BotAPIConfigError(RuntimeError):
     """The API was switched on but cannot be started safely."""
 
 
+class SettingRejected(Exception):
+    """A submitted setting cannot be stored, with the reason a caller may see.
+
+    Defined here rather than in bot.py because it is the contract between the
+    two: the bot raises it from its writer, and this module maps it to a
+    status. It carries no data the caller did not already send.
+
+    `locked` separates "your plan does not include this" (403) from "that is
+    not a valid value" (400). Collapsing them would leave the website unable to
+    tell an admin which of the two happened.
+    """
+
+    def __init__(self, field: str, reason: str, *, locked: bool = False):
+        super().__init__(reason)
+        self.field = field
+        self.reason = reason
+        self.locked = locked
+
+
+# One call may not carry more fields than exist. Bounded here as well as by
+# client_max_size, because the cheap check is the one that runs first.
+MAX_SETTINGS_FIELDS = 32
+
+
 # Typed keys rather than bare strings, so a handler reaching for something the
 # app was never given fails at the lookup instead of at whatever it does with
 # the None it got back.
@@ -105,8 +129,14 @@ GLOBAL_RATE_KEY: "web.AppKey" = web.AppKey("global_rate_limiter")
 class BotAPIDeps:
     """The complete list of things the API can do to the bot.
 
-    Every entry is a reader. Keep it that way: `tests/test_bot_api.py` pins the
-    exact field set, so a writer cannot be added by accident.
+    All readers but one. `tests/test_bot_api.py` pins the exact field set, so a
+    second writer cannot be added by accident — adding one means editing that
+    test on purpose, which is a reviewable diff rather than a quiet widening.
+
+    `write_settings` is the whole write surface. It is a single named callable
+    that validates against its own allowlist inside the bot, not a generic
+    column setter, so the worst a compromised dashboard can do is submit valid
+    values for the handful of fields the bot has decided are writable.
 
     Readers take and return plain data — ids, dicts, lists — never discord.py
     objects. Shaping a Guild into JSON is the bot's job, not this module's,
@@ -130,6 +160,10 @@ class BotAPIDeps:
     read_roles: Callable[[int], Awaitable[Optional[list]]]
     read_channels: Callable[[int], Awaitable[Optional[list]]]
     read_panel: Callable[[int], Awaitable[Optional[dict]]]
+    # The only writer. Takes (guild_id, actor_id, changes) and either returns
+    # the re-read settings, returns None because it could not complete, or
+    # raises the bot's SettingRejected for anything the caller got wrong.
+    write_settings: Callable[[int, int, dict], Awaitable[Optional[dict]]]
 
 
 # -------------------------------------------------------------------
@@ -574,8 +608,63 @@ def _guild_reader(read: str):
     return handler
 
 
+async def handle_update_settings(request: web.Request) -> web.Response:
+    """The one route that changes anything. Same three gates as every read.
+
+    The token that authorises this is bound to `PATCH /...`, not just to the
+    path, so a token minted for the settings *read* cannot be replayed to write
+    them -- see `_operation_for`, which takes the method from the route the
+    router actually matched.
+
+    What may be written is decided entirely inside the bot. This handler does
+    not know which fields exist, which are premium, or what values are legal;
+    it validates the envelope, hands the body to the one writer in BotAPIDeps,
+    and turns a refusal into a status. That is deliberate: the dashboard is the
+    internet-facing half and is assumed to be compromised eventually, so the
+    list of writable fields must not live on that side of the wire, nor in a
+    module that could be talked into a generic update.
+    """
+    try:
+        claims = await _authorize(request, guild_scoped=True)
+    except _Denied as denied:
+        return denied.response
+
+    deps: BotAPIDeps = request.app[DEPS_KEY]
+    guild_id = int(request.match_info["guild_id"])
+
+    try:
+        body = await request.json()
+    except (ValueError, UnicodeDecodeError):
+        return _deny(request, 400, "bad_json", actor=claims.actor_id)
+
+    if not isinstance(body, dict):
+        return _deny(request, 400, "bad_json", actor=claims.actor_id)
+    changes = body.get("fields")
+    if not isinstance(changes, dict) or not changes:
+        return _deny(request, 400, "bad_fields", actor=claims.actor_id)
+    if len(changes) > MAX_SETTINGS_FIELDS:
+        return _deny(request, 400, "too_many_fields", actor=claims.actor_id)
+
+    try:
+        payload = await deps.write_settings(guild_id, claims.actor_id, changes)
+    except SettingRejected as rejected:
+        # 403 for "not on your plan", 400 for "that is not a valid value".
+        return _deny(
+            request,
+            403 if rejected.locked else 400,
+            rejected.reason,
+            actor=claims.actor_id,
+        )
+
+    if payload is None:
+        return _deny(request, 503, "unavailable", actor=claims.actor_id)
+    # The stored state, re-read, rather than an echo of the request. What the
+    # admin sees next is then what is actually saved.
+    return _json(payload)
+
+
 def create_app(config: BotAPIConfig, deps: BotAPIDeps) -> web.Application:
-    """Wire the routes. Every route here is a GET, and that is load-bearing."""
+    """Wire the routes. One PATCH, everything else a GET."""
     app = web.Application(client_max_size=MAX_REQUEST_BYTES)
     app[CONFIG_KEY] = config
     app[DEPS_KEY] = deps
@@ -593,6 +682,9 @@ def create_app(config: BotAPIConfig, deps: BotAPIDeps) -> web.Application:
         "/api/v1/guilds/{guild_id}/channels", _guild_reader("read_channels")
     )
     app.router.add_get("/api/v1/guilds/{guild_id}/panel", _guild_reader("read_panel"))
+    app.router.add_patch(
+        "/api/v1/guilds/{guild_id}/settings", handle_update_settings
+    )
 
     app.on_response_prepare.append(_harden_response)
     return app

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,8 +1,15 @@
-"""The dashboard web app — steps 3 and 4 of issue #65: login, picker, settings.
+"""The dashboard web app — steps 3 to 5 of issue #65: login, picker, settings.
 
-Read-only. There is no route here that changes anything about a server; the
-bot API it talks to has no write endpoint to call even if there were. Saving
-settings is step 5, and it arrives with the audit trail.
+One write path, opened in step 5: the instructions panel group, and nothing
+else. Which fields that covers is the bot's decision, reported per field in the
+settings payload, so this app renders a control only where the bot has already
+said it would accept the value. It does not hold a copy of that list, because
+a second copy is a thing that can disagree with the enforcing one.
+
+Nothing here validates a value it sends. The bot re-checks Administrator,
+re-checks the plan, validates against its own allowlist, and records the change
+— which is the arrangement that lets this process be the one assumed to fall
+over.
 
 * **The page must say exactly what the bot would.** Two settings a lapsed plan
   saves but does not act on, three it refuses to save at all. Collapsing that
@@ -326,8 +333,78 @@ def _register_routes(app: Flask) -> None:
             premium=settings.get("premium") or {},
             names_resolved=roles is not None and channels is not None,
             auto_verify_column_present=settings.get("auto_verify_column_present", True),
+            saved=request.args.get("saved") == "1",
+            save_error=_save_error_message(request.args.get("error")),
             csrf_token=session.csrf_token,
         )
+
+    @app.post("/guild/<int:guild_id>/panel")
+    def save_panel_settings(guild_id: int):
+        """Save the instructions panel group. The only write in the app.
+
+        Three things guard it, and the third is the only one that counts:
+
+        1. A session cookie, `SameSite=Lax` and `HttpOnly`.
+        2. A CSRF token compared with `compare_digest`. The cookie policy
+           already stops a cross-site POST, so this is the second line.
+        3. The bot, which re-checks Administrator, re-checks the plan, and
+           validates every value against its own allowlist. Nothing below is
+           trusted by the thing that actually writes the row.
+
+        Values are turned into JSON types here because HTML forms only carry
+        strings, and the bot's API takes an int for a colour and a bool for a
+        toggle. That conversion is not validation -- a colour that survives it
+        can still be refused, and the refusal is what decides.
+        """
+        session = _require_login()
+        if session is None:
+            return redirect(url_for("index"))
+
+        submitted = request.form.get("csrf_token", "")
+        if not secrets.compare_digest(session.csrf_token, submitted):
+            abort(400)
+
+        changes = {}
+
+        locale = request.form.get("instructions_locale")
+        if locale:
+            changes["instructions_locale"] = locale
+
+        if request.form.get("panel_fields_present"):
+            # A checkbox that is off sends nothing at all, so the form declares
+            # that its branding controls were on the page. Without this, an
+            # unticked "show icon" would be indistinguishable from a free
+            # server whose controls were never rendered, and the save would
+            # quietly turn the icon off.
+            changes["panel_show_icon"] = bool(request.form.get("panel_show_icon"))
+            if request.form.get("panel_color_default"):
+                changes["panel_embed_color"] = None
+            else:
+                changes["panel_embed_color"] = _colour_to_int(
+                    request.form.get("panel_embed_color")
+                )
+
+        if not changes:
+            return redirect(url_for("guild_settings", guild_id=guild_id))
+
+        try:
+            _bot_api().update_settings(int(session.discord_id), guild_id, changes)
+        except BotAPIError as error:
+            logger.warning("save refused for guild %s: %s", guild_id, error)
+            # A code, never the bot's text. What comes back is a fixed reason
+            # string today, but round-tripping it through a URL and into a page
+            # would make the bot's error strings part of this app's HTML, and
+            # the day one of them carries something a caller influenced is not
+            # the day to find that out.
+            return redirect(
+                url_for(
+                    "guild_settings",
+                    guild_id=guild_id,
+                    error=_save_error_code(error),
+                )
+            )
+
+        return redirect(url_for("guild_settings", guild_id=guild_id, saved=1))
 
     @app.post("/logout")
     def logout():
@@ -348,6 +425,59 @@ def _register_routes(app: Flask) -> None:
     @app.errorhandler(500)
     def server_error(_error):  # pragma: no cover - defensive
         return render_template("error.html", message="Something went wrong."), 500
+
+
+# The refusals worth explaining differently, and the copy for each. Anything
+# not listed falls through to the generic message, so an unrecognised reason
+# can never reach the page as text.
+SAVE_ERRORS = {
+    "requires_premium": (
+        "That setting needs VRCVerify Premium. Nothing was changed."
+    ),
+    "unsupported_language": (
+        "That language isn't one VRCVerify supports. Nothing was changed."
+    ),
+    "server_not_set_up": (
+        "Run /vrcverify_setup in your server first -- VRCVerify needs a "
+        "verified role before it can store anything else."
+    ),
+    "not_writable_yet": (
+        "That setting can't be changed from the website yet. Use "
+        "/vrcverify_settings in your server."
+    ),
+    "unavailable": (
+        "The bot couldn't complete the save, so nothing was changed. Try again "
+        "shortly."
+    ),
+}
+GENERIC_SAVE_ERROR = "That change couldn't be saved, so nothing was changed."
+
+
+def _save_error_code(error: BotAPIError) -> str:
+    reason = str(error)
+    return reason if reason in SAVE_ERRORS else "unknown"
+
+
+def _save_error_message(code: Optional[str]) -> Optional[str]:
+    """Copy for a refusal, chosen by us -- the code is only ever a lookup key."""
+    if not code:
+        return None
+    return SAVE_ERRORS.get(code, GENERIC_SAVE_ERROR)
+
+
+def _colour_to_int(raw: Optional[str]) -> Optional[int]:
+    """`#rrggbb` from a colour input, as the integer the bot stores.
+
+    Returns None for anything that is not that shape, which the bot then
+    refuses -- rather than guessing at a colour the admin did not pick.
+    """
+    text = (raw or "").strip().lstrip("#")
+    if len(text) != 6:
+        return None
+    try:
+        return int(text, 16)
+    except ValueError:
+        return None
 
 
 def _session_guild(session, guild_id: int) -> Optional[dict]:

--- a/src/dashboard/botapi.py
+++ b/src/dashboard/botapi.py
@@ -30,6 +30,7 @@ from api_tokens import (
     OP_GUILD_ROLES,
     OP_GUILD_SETTINGS,
     OP_LIST_GUILDS,
+    OP_UPDATE_SETTINGS,
     mint_token,
 )
 
@@ -158,6 +159,51 @@ class BotAPIClient:
             actor_id,
             guild_id,
         )
+
+    # ----- the one write -----
+    def update_settings(self, actor_id: int, guild_id, changes: dict) -> dict:
+        """Ask the bot to store these settings. It decides whether to.
+
+        Nothing here validates the values. The bot owns the allowlist, the
+        types and the plan gate, and duplicating any of that on this side would
+        create a second opinion that can drift from the enforcing one -- while
+        adding nothing, because this process is the one an attacker would be
+        standing in.
+        """
+        token = mint_token(
+            self.signing_key,
+            actor_id=int(actor_id),
+            operation=OP_UPDATE_SETTINGS,
+            guild_id=int(guild_id),
+        )
+        try:
+            response = self._session.patch(
+                f"{self.base_url}/api/v1/guilds/{int(guild_id)}/settings",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"fields": changes},
+                timeout=self.timeout,
+            )
+        except requests.exceptions.SSLError as error:
+            raise BotAPIError(f"TLS failure talking to the bot API: {error}") from error
+        except requests.RequestException as error:
+            raise BotAPIError(f"could not reach the bot API: {error}") from error
+
+        if response.status_code == 200:
+            return response.json()
+
+        reason = ""
+        try:
+            reason = response.json().get("error", "")
+        except ValueError:
+            pass
+        logger.warning(
+            "bot API refused a save for actor=%s guild=%s: %s %s",
+            actor_id,
+            guild_id,
+            response.status_code,
+            reason,
+        )
+        raise BotAPIError(reason or "bot API refused the save", response.status_code)
 
     def panel(self, actor_id: int, guild_id) -> dict:
         return self._get(

--- a/src/dashboard/settings_view.py
+++ b/src/dashboard/settings_view.py
@@ -35,6 +35,10 @@ from typing import Optional
 # Step 5 must NOT build its locale <select> from this dict. The choices have to
 # come from the bot, or the dashboard could offer a language the bot cannot
 # render.
+# Shown in the colour picker when a server has chosen nothing. Cosmetic only:
+# what "no colour" means is the bot's business, and it stores NULL either way.
+DEFAULT_PANEL_SWATCH = "#5865f2"
+
 LOCALE_NAMES = {
     "en-US": "English",
     "es-ES": "Spanish",
@@ -68,6 +72,9 @@ class Field:
         locked: bool = False,
         swatch: Optional[str] = None,
         warnings: Optional[list] = None,
+        writable: bool = False,
+        choices: Optional[list] = None,
+        value=None,
     ):
         self.name = name
         self.label = label
@@ -80,6 +87,22 @@ class Field:
         self.locked = locked
         self.swatch = swatch
         self.warnings = warnings or []
+        self.writable = writable
+        self.choices = choices or []
+        # The raw value a form control needs, as distinct from `display`, which
+        # is prose for a human.
+        self.value = value
+
+    @property
+    def editable(self) -> bool:
+        """Render a control, rather than just the value.
+
+        Both halves come from the bot: `writable` is which fields the save path
+        accepts in this phase, `locked` is whether the plan allows it. The
+        website never decides either, and it renders a control only when the
+        bot would actually accept the value it produces.
+        """
+        return self.writable and not self.locked
 
     @property
     def badge(self) -> Optional[str]:
@@ -104,6 +127,10 @@ def _plan(state: dict) -> dict:
         "feature": state.get("feature"),
         "active": bool(state.get("active", True)),
         "locked": bool(state.get("locked", False)),
+        # Absent means no: a bot that has not said a field is writable has not
+        # said it, and defaulting the other way would render controls that the
+        # save path then refuses.
+        "writable": bool(state.get("writable", False)),
     }
 
 
@@ -193,7 +220,7 @@ def _bool_field(
     state = _state(settings, name)
     value = bool(state.get("value"))
     return Field(
-        name, label, description, "bool", on if value else off, **_plan(state)
+        name, label, description, "bool", on if value else off, value=value, **_plan(state)
     )
 
 
@@ -279,6 +306,11 @@ def build_groups(
             "blurb": "The message members use to start verification.",
             "fields": [locale, color, icon],
             "panel": panel_summary(panel),
+            # The only group with a save path so far. The template renders a
+            # form when a group names an endpoint AND the bot said at least one
+            # of its fields is writable, so opening the next group is a change
+            # here and in DASHBOARD_WRITABLE_FIELDS, not in the template.
+            "save_endpoint": "save_panel_settings",
         },
         {
             "title": "Logging",
@@ -306,17 +338,26 @@ def _custom_dm_field(settings: dict) -> Field:
     )
 
 
+def locale_label(code: str) -> str:
+    name = LOCALE_NAMES.get(code)
+    return f"{name} ({code})" if name else str(code)
+
+
 def _locale_field(settings: dict) -> Field:
     state = _state(settings, "instructions_locale")
     code = state.get("value") or "en-US"
-    name = LOCALE_NAMES.get(code)
-    display = f"{name} ({code})" if name else str(code)
+    # The options come from the bot, never from LOCALE_NAMES above -- that dict
+    # is for display, and a select built from it could offer a language the bot
+    # cannot render.
+    codes = (settings.get("choices") or {}).get("instructions_locale") or []
     return Field(
         "instructions_locale",
         "Language",
         "The language of the instructions panel and the bot's replies to members.",
         "locale",
-        display,
+        locale_label(code),
+        choices=[(one, locale_label(one)) for one in codes],
+        value=code,
         **_plan(state),
     )
 
@@ -332,6 +373,9 @@ def _panel_fields(settings: dict):
         swatch or "Default blue",
         empty=swatch is None,
         swatch=swatch,
+        # A colour input cannot be empty, so it needs something to show while
+        # the "use the default" box is ticked.
+        value=swatch or DEFAULT_PANEL_SWATCH,
         **_plan(color_state),
     )
 

--- a/src/dashboard/static/style.css
+++ b/src/dashboard/static/style.css
@@ -215,6 +215,37 @@ button.link {
  * today, and dimming them would tell an admin something untrue. */
 .setting.locked .value { color: var(--muted); }
 
+.notice.ok {
+  background: none;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+}
+
+.check {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.95rem;
+  margin-bottom: 0.35rem;
+}
+
+select,
+input[type="color"] {
+  font: inherit;
+  color: var(--ink);
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0.3rem 0.4rem;
+  max-width: 100%;
+}
+
+input[type="color"] { padding: 0.15rem; width: 3.5rem; height: 2rem; }
+
+.actions { margin: 1.1rem 0 0; }
+
+button.button { border: 0; cursor: pointer; font: inherit; font-weight: 600; }
+
 .badge {
   font-size: 0.7rem;
   font-weight: 700;

--- a/src/dashboard/templates/settings.html
+++ b/src/dashboard/templates/settings.html
@@ -28,9 +28,16 @@
     </div>
   </header>
 
+  {% if saved %}
+    <p class="notice ok">Saved.</p>
+  {% endif %}
+  {% if save_error %}
+    <p class="notice">{{ save_error }}</p>
+  {% endif %}
+
   <p class="notice read-only">
-    This page is read-only for now. To change any of these, use
-    <code>/vrcverify_settings</code> in your server.
+    Only the instructions panel settings can be changed here so far. For
+    everything else, use <code>/vrcverify_settings</code> in your server.
   </p>
 
   {% if not names_resolved %}
@@ -48,9 +55,16 @@
   {% endif %}
 
   {% for group in groups %}
+    {% set editable = group.fields | selectattr('editable') | list %}
     <section class="group">
       <h2>{{ group.title }}</h2>
       <p class="muted blurb">{{ group.blurb }}</p>
+
+      {% if group.save_endpoint and editable %}
+        <form method="post"
+              action="{{ url_for(group.save_endpoint, guild_id=guild_id) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+      {% endif %}
 
       <dl class="settings">
         {% if group.panel %}
@@ -87,6 +101,33 @@
               {% endif %}
             </dt>
             <dd>
+              {% if field.editable %}
+                {% if field.kind == 'locale' %}
+                  <select name="{{ field.name }}" id="f-{{ field.name }}">
+                    {% for code, label in field.choices %}
+                      <option value="{{ code }}"
+                        {%- if code == field.value %} selected{% endif %}>{{ label }}</option>
+                    {% endfor %}
+                  </select>
+                {% elif field.kind == 'color' %}
+                  {# A colour input cannot be empty, so "no colour" is its own
+                     checkbox rather than a sentinel value pretending to be one. #}
+                  <input type="hidden" name="panel_fields_present" value="1">
+                  <label class="check">
+                    <input type="checkbox" name="panel_color_default"
+                           {%- if field.empty %} checked{% endif %}>
+                    Use the default blue
+                  </label>
+                  <input type="color" name="{{ field.name }}"
+                         value="{{ field.value }}" aria-label="Panel colour">
+                {% elif field.kind == 'bool' %}
+                  <label class="check">
+                    <input type="checkbox" name="{{ field.name }}"
+                           {%- if field.value %} checked{% endif %}>
+                    {{ field.label }}
+                  </label>
+                {% endif %}
+              {% else %}
               <p class="value{% if field.empty %} empty{% endif %}">
                 {% if field.swatch %}
                   {# An SVG, not a styled span: the CSP is style-src 'self',
@@ -99,6 +140,7 @@
                 {% endif %}
                 {{ field.display }}
               </p>
+              {% endif %}
               <p class="muted desc">{{ field.description }}</p>
 
               {% if field.badge == 'premium' %}
@@ -126,6 +168,11 @@
           </div>
         {% endfor %}
       </dl>
+
+      {% if group.save_endpoint and editable %}
+        <p class="actions"><button type="submit" class="button">Save changes</button></p>
+        </form>
+      {% endif %}
     </section>
   {% endfor %}
 

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -1,4 +1,4 @@
-"""Unit tests for the bot's internal API (issue #65, step 1).
+"""Unit tests for the bot's internal API (issue #65, steps 1 and 5).
 
 This is the first inbound surface the project has ever had, on a bot whose
 database links Discord identities to VRChat accounts and 18+ status, so these
@@ -8,8 +8,9 @@ should not be able to open it:
 - a token is good for one actor, one guild and one operation, once
 - authority is the bot's answer about Administrator, never the caller's claim
 - a misconfigured listener refuses to start rather than binding wider than asked
-- the phase itself is pinned: no write route and no writer capability can land
-  here without deliberately editing this file
+- the phase itself is pinned: the write surface is exactly one route and one
+  capability, and widening it means deliberately editing this file
+- a token minted to READ a guild's settings cannot be replayed to write them
 
 TLS is configured at the socket, not in the application, so the mTLS chain is
 verified by hand against a real listener (see the issue's step-1 checklist).
@@ -48,8 +49,14 @@ def run(coro):
 # -------------------------------------------------------------------
 # Fakes
 # -------------------------------------------------------------------
-def make_deps(**overrides) -> bot_api.BotAPIDeps:
-    """A permissive set of readers, so each test can break exactly one thing."""
+def make_deps(written=None, **overrides) -> bot_api.BotAPIDeps:
+    """A permissive set of capabilities, so each test breaks exactly one thing.
+
+    `written` collects what reached the writer, so a test can assert the
+    handler passed the body through unchanged -- and, more usefully, that a
+    refused request never reached it at all.
+    """
+    written = [] if written is None else written
 
     async def is_admin(guild_id, user_id):
         return int(user_id) == ADMIN_ID
@@ -71,6 +78,10 @@ def make_deps(**overrides) -> bot_api.BotAPIDeps:
     async def read_panel(guild_id):
         return {"posted": False}
 
+    async def write_settings(guild_id, actor_id, changes):
+        written.append((int(guild_id), int(actor_id), dict(changes)))
+        return {"guild_id": str(guild_id), "fields": {}, "written": dict(changes)}
+
     defaults = dict(
         is_ready=lambda: True,
         guild_present=lambda guild_id: int(guild_id) == GUILD_ID,
@@ -80,6 +91,7 @@ def make_deps(**overrides) -> bot_api.BotAPIDeps:
         read_roles=read_roles,
         read_channels=read_channels,
         read_panel=read_panel,
+        write_settings=write_settings,
     )
     defaults.update(overrides)
     return bot_api.BotAPIDeps(**defaults)
@@ -118,6 +130,13 @@ def serve(scenario, *, config=None, deps=None):
 async def get(client, path, token=None):
     headers = {"Authorization": f"Bearer {token}"} if token else {}
     response = await client.get(path, headers=headers)
+    return response.status, await response.json()
+
+
+async def patch(client, path, token=None, json=None, data=None):
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    kwargs = {"data": data} if data is not None else {"json": json}
+    response = await client.patch(path, headers=headers, **kwargs)
     return response.status, await response.json()
 
 
@@ -693,15 +712,272 @@ class TestGuildList:
 # -------------------------------------------------------------------
 # Pinning the phase
 # -------------------------------------------------------------------
-class TestReadOnlyPhase:
-    """Step 1 is read-only. Both guards below have to be edited on purpose."""
+WRITE_OP = "PATCH /api/v1/guilds/{guild_id}/settings"
 
-    def test_no_route_can_change_anything(self):
+
+class TestTheWritePath:
+    """The one route that changes something gets the same gates as the reads."""
+
+    def path(self, guild_id=GUILD_ID):
+        return f"/api/v1/guilds/{guild_id}/settings"
+
+    def test_an_administrator_can_write(self):
+        written = []
+
+        async def scenario(client):
+            return await patch(
+                client,
+                self.path(),
+                token_for(WRITE_OP),
+                json={"fields": {"instructions_locale": "de"}},
+            )
+
+        status, body = serve(scenario, deps=make_deps(written=written))
+        assert status == 200
+        assert written == [(GUILD_ID, ADMIN_ID, {"instructions_locale": "de"})]
+
+    def test_a_read_token_cannot_be_replayed_as_a_write(self):
+        """The single most important property of this endpoint.
+
+        Both are `/api/v1/guilds/{id}/settings`; only the method differs, and
+        the method is inside the signed operation.
+        """
+        written = []
+
+        async def scenario(client):
+            return await patch(
+                client,
+                self.path(),
+                token_for(SETTINGS_OP),  # the GET token
+                json={"fields": {"instructions_locale": "de"}},
+            )
+
+        status, body = serve(scenario, deps=make_deps(written=written))
+        assert status == 403
+        assert body["error"] == "wrong_operation"
+        assert written == []
+
+    def test_a_write_token_for_one_guild_does_not_work_on_another(self):
+        written = []
+
+        async def scenario(client):
+            return await patch(
+                client,
+                self.path(),
+                token_for(WRITE_OP, guild_id=GUILD_ID + 1),
+                json={"fields": {"instructions_locale": "de"}},
+            )
+
+        status, body = serve(scenario, deps=make_deps(written=written))
+        assert status == 403
+        assert body["error"] == "wrong_guild"
+        assert written == []
+
+    def test_a_non_administrator_cannot_write(self):
+        written = []
+
+        async def scenario(client):
+            return await patch(
+                client,
+                self.path(),
+                token_for(WRITE_OP, actor_id=ADMIN_ID + 1),
+                json={"fields": {"instructions_locale": "de"}},
+            )
+
+        status, body = serve(scenario, deps=make_deps(written=written))
+        assert status == 403
+        assert body["error"] == "not_administrator"
+        assert written == []
+
+    def test_a_write_token_cannot_be_used_twice(self):
+        written = []
+        token = token_for(WRITE_OP)
+
+        async def scenario(client):
+            first = await patch(
+                client, self.path(), token, json={"fields": {"instructions_locale": "de"}}
+            )
+            second = await patch(
+                client, self.path(), token, json={"fields": {"instructions_locale": "ja"}}
+            )
+            return first, second
+
+        (first_status, _), (second_status, second_body) = serve(
+            scenario, deps=make_deps(written=written)
+        )
+        assert first_status == 200
+        # 401, same as a replayed read token: the token is simply no longer
+        # valid. 403 is reserved for a token that is valid but not for this.
+        assert second_status == 401
+        assert second_body["error"] == "replayed"
+        # And the replay never reached the database.
+        assert len(written) == 1
+
+    def test_no_token_is_a_401_and_writes_nothing(self):
+        written = []
+
+        async def scenario(client):
+            return await patch(
+                client, self.path(), json={"fields": {"instructions_locale": "de"}}
+            )
+
+        status, body = serve(scenario, deps=make_deps(written=written))
+        assert status == 401
+        assert written == []
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {},                       # no fields key
+            {"fields": {}},           # empty
+            {"fields": "everything"}, # not an object
+            {"fields": None},
+            ["fields"],               # not an object at the top level
+        ],
+    )
+    def test_a_malformed_body_is_refused(self, body):
+        written = []
+
+        async def scenario(client):
+            return await patch(client, self.path(), token_for(WRITE_OP), json=body)
+
+        status, _body = serve(scenario, deps=make_deps(written=written))
+        assert status == 400
+        assert written == []
+
+    def test_a_body_that_is_not_json_is_refused(self):
+        written = []
+
+        async def scenario(client):
+            return await patch(
+                client, self.path(), token_for(WRITE_OP), data=b"{not json"
+            )
+
+        status, body = serve(scenario, deps=make_deps(written=written))
+        assert status == 400
+        assert body["error"] == "bad_json"
+        assert written == []
+
+    def test_too_many_fields_is_refused_before_the_bot_is_asked(self):
+        written = []
+        crowd = {f"field_{n}": n for n in range(bot_api.MAX_SETTINGS_FIELDS + 1)}
+
+        async def scenario(client):
+            return await patch(
+                client, self.path(), token_for(WRITE_OP), json={"fields": crowd}
+            )
+
+        status, body = serve(scenario, deps=make_deps(written=written))
+        assert status == 400
+        assert body["error"] == "too_many_fields"
+        assert written == []
+
+    def test_a_rejected_setting_becomes_a_400(self):
+        async def refuse(guild_id, actor_id, changes):
+            raise bot_api.SettingRejected("instructions_locale", "unsupported_language")
+
+        async def scenario(client):
+            return await patch(
+                client,
+                self.path(),
+                token_for(WRITE_OP),
+                json={"fields": {"instructions_locale": "kl"}},
+            )
+
+        status, body = serve(scenario, deps=make_deps(write_settings=refuse))
+        assert status == 400
+        assert body["error"] == "unsupported_language"
+
+    def test_a_locked_setting_becomes_a_403(self):
+        async def refuse(guild_id, actor_id, changes):
+            raise bot_api.SettingRejected(
+                "panel_embed_color", "requires_premium", locked=True
+            )
+
+        async def scenario(client):
+            return await patch(
+                client,
+                self.path(),
+                token_for(WRITE_OP),
+                json={"fields": {"panel_embed_color": 255}},
+            )
+
+        status, body = serve(scenario, deps=make_deps(write_settings=refuse))
+        assert status == 403
+        assert body["error"] == "requires_premium"
+
+    def test_a_writer_that_cannot_complete_is_a_503(self):
+        async def give_up(guild_id, actor_id, changes):
+            return None
+
+        async def scenario(client):
+            return await patch(
+                client,
+                self.path(),
+                token_for(WRITE_OP),
+                json={"fields": {"instructions_locale": "de"}},
+            )
+
+        status, body = serve(scenario, deps=make_deps(write_settings=give_up))
+        assert status == 503
+        assert body["error"] == "unavailable"
+
+    def test_a_guild_the_bot_is_not_in_is_a_404(self):
+        written = []
+        other = GUILD_ID + 99
+
+        async def scenario(client):
+            return await patch(
+                client,
+                self.path(other),
+                token_for(WRITE_OP, guild_id=other),
+                json={"fields": {"instructions_locale": "de"}},
+            )
+
+        status, _body = serve(scenario, deps=make_deps(written=written))
+        assert status == 404
+        assert written == []
+
+    def test_the_actor_written_is_the_one_in_the_token(self):
+        """Not anything the dashboard put in the body."""
+        written = []
+
+        async def scenario(client):
+            return await patch(
+                client,
+                self.path(),
+                token_for(WRITE_OP),
+                json={
+                    "fields": {"instructions_locale": "de"},
+                    "actor_id": ADMIN_ID + 5000,
+                },
+            )
+
+        serve(scenario, deps=make_deps(written=written))
+        _guild, actor, _changes = written[0]
+        assert actor == ADMIN_ID
+
+
+class TestWriteSurfaceIsExactlyOneThing:
+    """Step 5 opens a write path. These pin how far it opens, and no further.
+
+    Editing any of them is how you widen what the website can do to a server,
+    which is the point: it cannot happen as a side effect of adding a route or
+    a dependency.
+    """
+
+    def test_the_only_write_route_is_the_settings_patch(self):
         app = bot_api.create_app(make_config(), make_deps())
-        methods = {route.method for route in app.router.routes()}
-        assert methods <= {"GET", "HEAD"}, f"a write route appeared: {methods}"
+        writes = {
+            (route.method, route.resource.canonical)
+            for route in app.router.routes()
+            if route.method not in {"GET", "HEAD"}
+        }
+        assert writes == {("PATCH", "/api/v1/guilds/{guild_id}/settings")}, (
+            f"an unexpected write route appeared: {writes}"
+        )
 
-    def test_the_api_holds_no_writer(self):
+    def test_the_api_holds_exactly_one_writer(self):
         assert bot_api.deps_field_names() == frozenset(
             {
                 "is_ready",
@@ -712,12 +988,24 @@ class TestReadOnlyPhase:
                 "read_roles",
                 "read_channels",
                 "read_panel",
+                "write_settings",
             }
         )
 
-    def test_every_capability_is_named_as_a_read(self):
+    def test_every_capability_is_named_for_what_it_does(self):
         for field in dataclass_fields(bot_api.BotAPIDeps):
-            assert field.name.startswith(("read_", "is_", "guild_"))
+            assert field.name.startswith(("read_", "is_", "guild_", "write_"))
+
+    def test_the_module_decides_nothing_about_which_fields_are_writable(self):
+        """The allowlist lives in the bot, not in the internet-facing path.
+
+        bot_api is imported by the dashboard's half of the contract and is the
+        module a compromised request reaches first. If it knew the field names
+        it would be a place to negotiate about them.
+        """
+        source = open(bot_api.__file__, encoding="utf-8").read()
+        for field_name in ("instructions_locale", "panel_embed_color", "panel_show_icon"):
+            assert field_name not in source
 
 
 # -------------------------------------------------------------------
@@ -796,6 +1084,7 @@ def clean_db():
             session.query(bot.VerificationLogChannel).delete()
             session.query(bot.PremiumGrandfatherLine).delete()
             session.query(bot.InstructionPanelView).delete()
+            session.query(bot.DashboardAudit).delete()
 
     wipe()
     bot.premium_status_cache.clear()
@@ -927,6 +1216,254 @@ class TestSettingsReader:
 
         monkeypatch.setattr(bot, "session_scope", boom)
         assert run(bot.read_dashboard_settings(GUILD_ID)) is None
+
+
+def audit_rows():
+    with bot.session_scope() as session:
+        return [
+            (row.field, row.old_value, row.new_value, row.actor_id)
+            for row in session.query(bot.DashboardAudit)
+            .order_by(bot.DashboardAudit.id)
+            .all()
+        ]
+
+
+def write(changes, guild_id=GUILD_ID, actor_id=ADMIN_ID):
+    return run(bot.write_dashboard_settings(guild_id, actor_id, changes))
+
+
+class TestSettingsWriter:
+    """The bot side of the first write path. Validation lives here, not on the
+    website, because the website is the half assumed to fall over eventually."""
+
+    def test_a_locale_is_stored_and_audited(self, subscribed):
+        make_server()
+        result = write({"instructions_locale": "de"})
+        assert result["fields"]["instructions_locale"]["value"] == "de"
+        assert audit_rows() == [
+            ("instructions_locale", "en-US", "de", str(ADMIN_ID))
+        ]
+
+    def test_branding_is_stored_and_audited(self, subscribed):
+        make_server()
+        write({"panel_embed_color": 0xFF0000, "panel_show_icon": True})
+        assert bot.load_panel_branding(GUILD_ID) == (0xFF0000, True)
+        assert {row[0] for row in audit_rows()} == {
+            "panel_embed_color",
+            "panel_show_icon",
+        }
+
+    def test_a_no_op_write_is_not_audited(self):
+        """A form posting every field must not bury the one line that matters."""
+        make_server(instructions_locale="en-US")
+        write({"instructions_locale": "en-US"})
+        assert audit_rows() == []
+
+    def test_half_a_branding_change_keeps_the_other_half(self, subscribed):
+        make_server()
+        write({"panel_embed_color": 0x00FF00, "panel_show_icon": True})
+        write({"panel_embed_color": 0x0000FF})
+        # The icon was not submitted, so it must survive the merge.
+        assert bot.load_panel_branding(GUILD_ID) == (0x0000FF, True)
+
+    @pytest.mark.parametrize(
+        "changes",
+        [
+            {"instructions_locale": "kl"},        # not a supported language
+            {"instructions_locale": 5},
+            {"panel_embed_color": -1},
+            {"panel_embed_color": 0x1000000},     # 25 bits
+            {"panel_embed_color": "red"},
+            {"panel_embed_color": True},          # bool is an int; not a colour
+            {"panel_show_icon": "yes"},
+            {"panel_show_icon": 1},
+        ],
+    )
+    def test_a_bad_value_is_rejected(self, changes, subscribed):
+        make_server()
+        with pytest.raises(bot.SettingRejected) as caught:
+            write(changes)
+        assert caught.value.locked is False
+        assert audit_rows() == []
+
+    @pytest.mark.parametrize(
+        "changes",
+        [
+            {"role_id": "1"},                     # writable later, not now
+            {"auto_verify_new_members": False},
+            {"custom_verification_requested_message": "hi"},
+            {"verification_log_channel_id": "5"},
+        ],
+    )
+    def test_a_field_not_yet_open_is_refused(self, changes, subscribed):
+        make_server()
+        with pytest.raises(bot.SettingRejected) as caught:
+            write(changes)
+        assert caught.value.reason == "not_writable_yet"
+        assert audit_rows() == []
+
+    def test_an_unknown_field_is_refused(self, subscribed):
+        make_server()
+        with pytest.raises(bot.SettingRejected) as caught:
+            write({"is_admin": True})
+        assert caught.value.reason == "unknown_field"
+
+    def test_a_free_server_cannot_write_branding(self, free):
+        """The gate is here, not in whatever the website chose to render."""
+        make_server(row_id=500)
+        with pytest.raises(bot.SettingRejected) as caught:
+            write({"panel_embed_color": 0xFF0000})
+        assert caught.value.reason == "requires_premium"
+        assert caught.value.locked is True
+        assert bot.load_panel_branding(GUILD_ID) is None
+        assert audit_rows() == []
+
+    def test_a_free_server_can_still_write_its_language(self, free):
+        """instructions_locale is not a premium feature, and must not become one."""
+        make_server(row_id=500)
+        write({"instructions_locale": "ja"})
+        assert audit_rows()[0][:3] == ("instructions_locale", "en-US", "ja")
+
+    def test_one_bad_field_saves_none_of_them(self, subscribed):
+        make_server()
+        with pytest.raises(bot.SettingRejected):
+            write({"instructions_locale": "de", "panel_embed_color": "nope"})
+        with bot.session_scope() as session:
+            srv = session.query(bot.Server).filter_by(server_id=str(GUILD_ID)).first()
+            assert srv.instructions_locale == "en-US"
+        assert audit_rows() == []
+
+    def test_a_guild_that_never_ran_setup_cannot_set_a_language(self, subscribed):
+        """servers.owner_id is NOT NULL and the dashboard has no honest value.
+
+        Inserting a row would also mint a fresh servers.id, pushing the guild
+        above the grandfather line as a side effect of a language change.
+        """
+        with pytest.raises(bot.SettingRejected) as caught:
+            write({"instructions_locale": "de"})
+        assert caught.value.reason == "server_not_set_up"
+
+    def test_unreadable_branding_is_refused_rather_than_overwritten(
+        self, monkeypatch, subscribed
+    ):
+        make_server()
+        monkeypatch.setattr(
+            bot, "load_panel_branding", lambda guild_id: bot.BRANDING_UNREADABLE
+        )
+        assert write({"panel_embed_color": 0xFF0000}) is None
+        assert audit_rows() == []
+
+    def test_an_empty_change_set_is_refused(self, subscribed):
+        make_server()
+        for empty in ({}, None, "fields"):
+            with pytest.raises(bot.SettingRejected):
+                write(empty)
+
+    def test_the_writer_reports_the_stored_state_not_the_request(self, subscribed):
+        """What the admin sees next is what is saved, not what they submitted."""
+        make_server()
+        result = write({"instructions_locale": "ja"})
+        assert result == run(bot.read_dashboard_settings(GUILD_ID))
+
+
+class TestBothHalvesTogether:
+    """The dashboard's real client against the bot's real handler and writer.
+
+    Everything else in this file fakes one side or the other, which cannot
+    catch the seam between them: an operation string only one end updated, a
+    body key spelled differently on each side, a colour that survives one
+    validator and not the other. Here the only fake is the transport, which is
+    plain HTTP because TLS is configured at the socket rather than in either
+    application.
+    """
+
+    @pytest.fixture(autouse=True)
+    def placeholder_certs(self, tmp_path):
+        """requests stats these even for http, so they have to exist."""
+        for name in ("client.pem", "client.key", "ca.pem"):
+            (tmp_path / name).write_text("placeholder")
+        self.certs = tmp_path
+
+    def client_for(self, server):
+        botapi = pytest.importorskip("dashboard.botapi")
+        return botapi.BotAPIClient(
+            str(server.make_url("")).rstrip("/"),
+            client_cert=str(self.certs / "client.pem"),
+            client_key=str(self.certs / "client.key"),
+            ca_bundle=str(self.certs / "ca.pem"),
+            signing_key=SIGNING_KEY,
+        )
+
+    def run_against_bot(self, call):
+        """Drive the sync client from inside the loop running the server."""
+        app = bot_api.create_app(
+            make_config(),
+            make_deps(write_settings=bot.write_dashboard_settings,
+                      read_settings=bot.read_dashboard_settings),
+        )
+
+        async def runner():
+            server = TestServer(app)
+            await server.start_server()
+            try:
+                client = self.client_for(server)
+                loop = asyncio.get_running_loop()
+                return await loop.run_in_executor(None, lambda: call(client))
+            finally:
+                await server.close()
+
+        return asyncio.run(runner())
+
+    def test_a_save_travels_end_to_end(self, subscribed):
+        make_server()
+        result = self.run_against_bot(
+            lambda client: client.update_settings(
+                ADMIN_ID,
+                GUILD_ID,
+                {"instructions_locale": "ja", "panel_embed_color": 0x00FF00},
+            )
+        )
+        assert result["fields"]["instructions_locale"]["value"] == "ja"
+        assert bot.load_panel_branding(GUILD_ID) == (0x00FF00, False)
+        assert {row[0] for row in audit_rows()} == {
+            "instructions_locale",
+            "panel_embed_color",
+        }
+
+    def test_the_read_the_dashboard_gets_carries_what_it_needs_to_render(self):
+        """The two keys step 5 added, over the wire rather than in a fixture."""
+        make_server()
+        payload = self.run_against_bot(
+            lambda client: client.settings(ADMIN_ID, GUILD_ID)
+        )
+        assert payload["choices"]["instructions_locale"]
+        assert payload["fields"]["instructions_locale"]["writable"] is True
+        assert payload["fields"]["role_id"]["writable"] is False
+
+    def test_a_refusal_arrives_as_its_reason(self, free):
+        """The dashboard maps these to copy, so the string has to survive."""
+        botapi = pytest.importorskip("dashboard.botapi")
+        make_server(row_id=500)
+        with pytest.raises(botapi.BotAPIError) as caught:
+            self.run_against_bot(
+                lambda client: client.update_settings(
+                    ADMIN_ID, GUILD_ID, {"panel_embed_color": 0xFF0000}
+                )
+            )
+        assert str(caught.value) == "requires_premium"
+        assert caught.value.status == 403
+
+    def test_a_non_administrator_is_refused_end_to_end(self, subscribed):
+        botapi = pytest.importorskip("dashboard.botapi")
+        make_server()
+        with pytest.raises(botapi.BotAPIError) as caught:
+            self.run_against_bot(
+                lambda client: client.update_settings(
+                    MEMBER_ID, GUILD_ID, {"instructions_locale": "ja"}
+                )
+            )
+        assert caught.value.status == 403
+        assert audit_rows() == []
 
 
 class TestRoleReader:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -103,10 +103,19 @@ DEFAULT_VALUES = {
 }
 
 
-def make_settings(premium=False, values=None, auto_verify_column=True):
+# What the bot currently lets the website write. Mirrors
+# bot.DASHBOARD_WRITABLE_FIELDS -- the payload carries it so the dashboard
+# never has to know.
+WRITABLE = {"instructions_locale", "panel_embed_color", "panel_show_icon"}
+
+LOCALES = ["en-US", "es-ES", "ja", "de"]
+
+
+def make_settings(premium=False, values=None, auto_verify_column=True, writable=None):
     """A settings payload shaped exactly like read_dashboard_settings returns."""
     merged = dict(DEFAULT_VALUES)
     merged.update(values or {})
+    open_fields = WRITABLE if writable is None else set(writable)
     fields = {}
     for name, (feature, active, locked) in FREE_PLAN.items():
         fields[name] = {
@@ -114,11 +123,13 @@ def make_settings(premium=False, values=None, auto_verify_column=True):
             "feature": feature,
             "active": True if premium else active,
             "locked": False if premium else locked,
+            "writable": name in open_fields,
         }
     return {
         "guild_id": GUILD_IN,
         "premium": {"enforced": True, "premium": premium, "grandfathered": False},
         "auto_verify_column_present": auto_verify_column,
+        "choices": {"instructions_locale": list(LOCALES)},
         "fields": fields,
     }
 
@@ -187,6 +198,7 @@ class FakeBotAPI:
         self.fail = fail
         self.calls = []
         self.reads = []
+        self.saves = []
         self._settings = settings
         self._roles = DEFAULT_ROLES if roles is None else roles
         self._channels = DEFAULT_CHANNELS if channels is None else channels
@@ -223,6 +235,12 @@ class FakeBotAPI:
 
     def panel(self, actor_id, guild_id):
         return self._answer("panel", actor_id, guild_id, self._panel)
+
+    def update_settings(self, actor_id, guild_id, changes):
+        self.saves.append((str(actor_id), str(guild_id), dict(changes)))
+        if "update_settings" in self.errors:
+            raise self.errors["update_settings"]
+        return self._settings if self._settings is not None else make_settings()
 
 
 @pytest.fixture
@@ -841,6 +859,210 @@ class TestSecondaryReadsDegradeGracefully:
         assert b"Couldn't check" in response.data
 
 
+class TestSavingThePanelGroup:
+    """The app's only write. The bot re-decides everything below regardless."""
+
+    def post(self, test_client, session, **form):
+        form.setdefault("csrf_token", session.csrf_token)
+        return test_client.post(f"/guild/{GUILD_IN}/panel", data=form)
+
+    def logged_in(self, config, store, **kwargs):
+        api = FakeBotAPI(**kwargs)
+        app = create_app(config, store=store, client=api)
+        app.config.update(TESTING=True)
+        test_client = app.test_client()
+        session = login_as(test_client, store)
+        return test_client, api, session
+
+    def test_a_save_reaches_the_bot_and_redirects(self, config, store):
+        test_client, api, session = self.logged_in(config, store)
+        response = self.post(
+            test_client,
+            session,
+            instructions_locale="ja",
+            panel_fields_present="1",
+            panel_embed_color="#ff0000",
+            panel_show_icon="on",
+        )
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("saved=1")
+        actor, guild, changes = api.saves[-1]
+        assert (actor, guild) == (ACTOR, GUILD_IN)
+        assert changes == {
+            "instructions_locale": "ja",
+            "panel_embed_color": 0xFF0000,
+            "panel_show_icon": True,
+        }
+
+    def test_the_colour_is_sent_as_an_integer(self, config, store):
+        test_client, api, session = self.logged_in(config, store)
+        self.post(
+            test_client,
+            session,
+            panel_fields_present="1",
+            panel_embed_color="#0a0b0c",
+        )
+        assert api.saves[-1][2]["panel_embed_color"] == 0x0A0B0C
+
+    def test_the_default_checkbox_clears_the_colour(self, config, store):
+        test_client, api, session = self.logged_in(config, store)
+        self.post(
+            test_client,
+            session,
+            panel_fields_present="1",
+            panel_color_default="on",
+            panel_embed_color="#ff0000",
+        )
+        assert api.saves[-1][2]["panel_embed_color"] is None
+
+    def test_an_unticked_checkbox_is_a_false_not_a_missing_field(
+        self, config, store
+    ):
+        """A checkbox that is off sends nothing, which is why the form declares
+        that its branding controls were rendered at all."""
+        test_client, api, session = self.logged_in(config, store)
+        self.post(test_client, session, panel_fields_present="1")
+        assert api.saves[-1][2]["panel_show_icon"] is False
+
+    def test_branding_is_untouched_when_its_controls_were_not_rendered(
+        self, config, store
+    ):
+        """A free server posts only its language.
+
+        Without the declaration, a form with no branding controls would look
+        exactly like one whose icon box was unticked, and saving the language
+        would silently turn the icon off.
+        """
+        test_client, api, session = self.logged_in(config, store)
+        self.post(test_client, session, instructions_locale="de")
+        assert api.saves[-1][2] == {"instructions_locale": "de"}
+
+    def test_a_save_with_no_changes_touches_nothing(self, config, store):
+        test_client, api, session = self.logged_in(config, store)
+        response = self.post(test_client, session)
+        assert response.status_code == 302
+        assert api.saves == []
+
+    # ----- the guards -----
+    def test_a_save_without_the_csrf_token_is_refused(self, config, store):
+        test_client, api, session = self.logged_in(config, store)
+        response = test_client.post(
+            f"/guild/{GUILD_IN}/panel",
+            data={"csrf_token": "wrong", "instructions_locale": "ja"},
+        )
+        assert response.status_code == 400
+        assert api.saves == []
+
+    def test_a_signed_out_visitor_cannot_save(self, client, bot_api):
+        response = client.post(
+            f"/guild/{GUILD_IN}/panel", data={"instructions_locale": "ja"}
+        )
+        assert response.status_code == 302
+        assert not getattr(bot_api, "saves", [])
+
+    def test_the_actor_is_the_session_owner_not_the_form(self, config, store):
+        test_client, api, session = self.logged_in(config, store)
+        self.post(
+            test_client, session, instructions_locale="ja", actor_id="999999999999"
+        )
+        assert api.saves[-1][0] == ACTOR
+
+    # ----- refusals -----
+    @pytest.mark.parametrize(
+        "reason, expected",
+        [
+            ("requires_premium", "needs VRCVerify Premium"),
+            ("unsupported_language", "isn&#39;t one VRCVerify supports"),
+            ("server_not_set_up", "vrcverify_setup"),
+            ("unavailable", "couldn&#39;t complete the save"),
+        ],
+    )
+    def test_a_refusal_is_explained_in_our_own_words(
+        self, config, store, reason, expected
+    ):
+        test_client, _api, session = self.logged_in(
+            config, store, errors={"update_settings": BotAPIError(reason, 403)}
+        )
+        response = self.post(test_client, session, instructions_locale="ja")
+        page = test_client.get(response.headers["Location"]).data.decode()
+        assert expected in page
+
+    def test_an_unrecognised_refusal_never_reaches_the_page_as_text(
+        self, config, store
+    ):
+        """The bot's error strings must not become this app's HTML."""
+        leak = "surprising-internal-detail"
+        test_client, _api, session = self.logged_in(
+            config, store, errors={"update_settings": BotAPIError(leak, 400)}
+        )
+        response = self.post(test_client, session, instructions_locale="ja")
+        assert "error=unknown" in response.headers["Location"]
+        page = test_client.get(response.headers["Location"]).data.decode()
+        assert leak not in page
+        assert "couldn&#39;t be saved" in page
+
+    def test_an_arbitrary_error_code_in_the_url_is_not_reflected(
+        self, config, store
+    ):
+        test_client, _api, _session = self.logged_in(config, store)
+        page = test_client.get(
+            f"/guild/{GUILD_IN}?error=%3Cimg+src%3Dx+onerror%3Dalert(1)%3E"
+        ).data.decode()
+        assert "onerror" not in page
+        assert "couldn&#39;t be saved" in page
+
+
+class TestTheFormMatchesWhatTheBotAccepts:
+    """Controls appear only where the bot said it would take the value."""
+
+    def test_a_premium_server_gets_all_three_controls(self, config, store):
+        test_client, _api = settings_client(
+            config, store, settings=make_settings(premium=True)
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert 'name="instructions_locale"' in page
+        assert 'name="panel_embed_color"' in page
+        assert 'name="panel_show_icon"' in page
+        assert "Save changes" in page
+
+    def test_a_free_server_gets_the_language_control_only(self, config, store):
+        """Branding is write-locked, so no control -- but the language is free
+        and must stay editable."""
+        test_client, _api = settings_client(config, store)
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert 'name="instructions_locale"' in page
+        assert 'type="color"' not in page
+        assert 'name="panel_show_icon"' not in page
+
+    def test_a_field_the_bot_has_not_opened_gets_no_control(self, config, store):
+        test_client, _api = settings_client(
+            config, store, settings=make_settings(premium=True, writable=set())
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "<form" not in page.split("Instructions panel")[-1]
+        assert "Save changes" not in page
+
+    def test_the_language_options_come_from_the_bot(self, config, store):
+        """Not from the dashboard's display-name table, which may be stale."""
+        test_client, _api = settings_client(
+            config,
+            store,
+            settings=make_settings(premium=True),
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        for code in LOCALES:
+            assert f'value="{code}"' in page
+        # Present in LOCALE_NAMES, absent from what the bot offered.
+        assert 'value="pa-IN"' not in page
+
+    def test_every_form_carries_a_csrf_token(self, config, store):
+        test_client, _api = settings_client(
+            config, store, settings=make_settings(premium=True)
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert page.count('name="csrf_token"') >= page.count("<form")
+
+
 # -------------------------------------------------------------------
 # Hardening
 # -------------------------------------------------------------------
@@ -884,8 +1106,10 @@ class TestHardening:
         for path in ("/", f"/guild/{GUILD_IN}"):
             page = test_client.get(path).data
             assert b"style=" not in page, f"inline style on {path}"
-        # The swatch still rendered; it just isn't CSS.
-        assert b'fill="#ff00ff"' in test_client.get(f"/guild/{GUILD_IN}").data
+        # A swatch still rendered; it just isn't CSS. The verified role's is the
+        # stable one to look at -- role_id has no save path in this phase, so it
+        # is always the read-only presentation.
+        assert b'fill="#5865f2"' in test_client.get(f"/guild/{GUILD_IN}").data
 
     def test_logout_requires_the_csrf_token(self, client, store):
         session = login_as(client, store)
@@ -992,16 +1216,18 @@ class TestSettingsViewModel:
         assert settings_view.panel_summary({"posted": False})["posted"] is False
 
 
-class TestReadOnlyPhase:
-    """Step 3 is login and a picker. Nothing here may change a server."""
+class TestWriteSurface:
+    """Step 5 opens exactly one save path. Widening it means editing this."""
 
-    def test_the_only_post_route_is_logout(self, app):
+    def test_the_post_routes_are_logout_and_the_panel_save(self, app):
         posts = {
             rule.rule
             for rule in app.url_map.iter_rules()
             if "POST" in (rule.methods or set())
         }
-        assert posts == {"/logout"}, f"an unexpected write route appeared: {posts}"
+        assert posts == {"/logout", "/guild/<int:guild_id>/panel"}, (
+            f"an unexpected write route appeared: {posts}"
+        )
 
     def test_the_dashboard_holds_no_database_credential(self):
         """A compromise of the public host must not reach the users table."""


### PR DESCRIPTION
Step 5 of #65 — **the first write path this project has ever had.** It opens the instructions panel group (language, colour, server icon) and nothing else.

That group went first because every value in it is a constrained type: one of a fixed set of language codes, a 24-bit int, a bool. The first write path is where the plumbing gets decided, and it is better decided without also solving free-text validation or role hierarchy. Nothing in the group can break verification if it goes wrong.

## The boundary is the bot's

`DASHBOARD_WRITABLE_FIELDS` in `bot.py` decides what may be written. The settings payload now reports, **per field**, whether the save path accepts it — so the dashboard renders a control only where the bot has already said it would take the value, instead of keeping a second copy of the list that can drift from the enforcing one.

The allowed languages travel over the wire for the same reason: a `<select>` built from the dashboard's own display-name table could offer a language the bot cannot render, and the admin would only find out when the panel came out in English.

## A read token cannot become a write token

The endpoint is `PATCH /api/v1/guilds/{id}/settings` — same path as the read, different method. Since `_operation_for` takes the method from the matched route and the method is inside the signed operation, a token minted for the `GET` is refused with `wrong_operation`. That's the property this endpoint most needs, and it's pinned.

`BotAPIDeps` gains exactly one writer, named. The tests that asserted there were none now assert there is one; widening either is a deliberate edit.

| guard | behaviour |
|---|---|
| read token replayed as write | `403 wrong_operation`, writer never called |
| token for another guild | `403 wrong_guild` |
| non-administrator | `403 not_administrator` |
| same token twice | `401 replayed`, one write |
| free server writing branding | `403 requires_premium`, nothing stored |
| one bad field in a batch | `400`, **none** of the batch applied |

## The audit trail moved here from step 6

Auth decisions were already logged, but logs rotate and aren't queryable per guild — and the first write is exactly when "who changed this" starts having an answer worth keeping. `dashboard_audit` records the actor **from the verified token claims, never from the request body**, plus the field and both values. Only real changes are recorded, so a form posting every field can't bury the one line that matters. Nothing in this codebase updates or deletes a row in that table.

## Two smaller decisions worth naming

- **A guild with no `servers` row cannot set a language.** `owner_id` is `NOT NULL` and the dashboard has no honest value for it — and inserting a row would mint a fresh `servers.id`, pushing the guild above the grandfather line as a side effect of a language change.
- **Branding is read-modify-written as a whole row**, and refuses rather than merging when the current value can't be read. Writing a merged row on top of an unreadable one silently resets whichever half wasn't submitted.

Refusals reach the page as codes mapped to copy chosen in the dashboard, never as the bot's own strings round-tripped through a URL.

## Tests

945, up from 878. Four of them drive the dashboard's **real** client against the bot's **real** handler and writer over HTTP — the seam that fakes on either side structurally cannot cover.