### PR TITLE
Open the verification group for saving (re-land of #75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,19 +328,28 @@ lists the servers they administer, and shows one server's settings. It holds no
 database credential and no bot token: everything it knows it asks the bot for
 over mTLS, and the bot decides what it is allowed to know.
 
-It can now **save the instructions panel group** — language, colour, server
-icon — and nothing else. That boundary is enforced in the bot by
-`DASHBOARD_WRITABLE_FIELDS`, not by which controls the website chose to draw,
-and the payload tells the dashboard which fields are open so the two cannot
-drift. The website renders a control only where the bot has said it would
-accept the value.
+It can now save two groups — the **instructions panel** (language, colour,
+server icon) and **verification** (verified role, unverified role, auto-verify
+on join). That boundary is enforced in the bot by `DASHBOARD_WRITABLE_FIELDS`,
+not by which controls the website chose to draw, and the payload tells the
+dashboard which fields are open so the two cannot drift. The website renders a
+control only where the bot has said it would accept the value — and, for a
+picker, only when it actually has something to pick from, because an empty
+`<select>` invites a save that would clear the verified role.
+
+On roles the bot checks that the id names a real role in *that* guild — the
+guarantee Discord's role picker gives `/vrcverify_setup` for free, which a form
+submitting a raw id has to provide for itself. It does **not** refuse a role it
+cannot assign: `/vrcverify_setup` doesn't either, so refusing would make the
+website stricter than the slash command and would block an admin who means to
+set the role first and fix the hierarchy after. The page warns instead.
 
 The write path adds one route on each side, and both are pinned by tests:
 
 - `PATCH /api/v1/guilds/{id}/settings` on the bot, the only non-GET route.
   Because the signed operation includes the **method**, a token minted to read
   a guild's settings cannot be replayed to write them.
-- `POST /guild/<id>/panel` on the dashboard, behind a CSRF token and a
+- One `POST` per group on the dashboard, behind a CSRF token and a
   `SameSite=Lax` cookie — though the check that matters is the bot's, which
   re-runs Administrator, re-runs the plan gate, and validates every value
   against its own allowlist. Nothing the website sends is trusted by the thing

--- a/src/bot.py
+++ b/src/bot.py
@@ -763,7 +763,14 @@ SETTINGS_FIELDS_BY_NAME = {field.name: field for field in SETTINGS_FIELDS}
 # This list is the enforcement point, not the dashboard's form. The website is
 # untrusted: it renders whatever it likes, and the bot decides.
 DASHBOARD_WRITABLE_FIELDS = frozenset(
-    {"instructions_locale", "panel_embed_color", "panel_show_icon"}
+    {
+        "instructions_locale",
+        "panel_embed_color",
+        "panel_show_icon",
+        "role_id",
+        "unverified_role_id",
+        "auto_verify_new_members",
+    }
 )
 
 
@@ -797,11 +804,60 @@ def _coerce_show_icon(value):
     return value
 
 
+def _role_coercer(field_name: str, *, required: bool):
+    """A Discord snowflake, as the string the servers table stores.
+
+    Accepts an int as well as a digit string because JSON has a number type and
+    an id that arrived as one is not wrong -- only ambiguous, and normalising
+    here is cheaper than a mismatch nobody notices until a role stops matching.
+    """
+
+    def coerce(value):
+        if value is None or value == "":
+            if required:
+                # Mirrors /vrcverify_setup, whose verified_role argument is not
+                # optional. Verification cannot run without one.
+                raise SettingRejected(field_name, "role_required")
+            return None
+        if isinstance(value, bool):
+            raise SettingRejected(field_name, "not_a_role")
+        if isinstance(value, int):
+            value = str(value)
+        if not isinstance(value, str) or not value.isdigit():
+            raise SettingRejected(field_name, "not_a_role")
+        return value
+
+    return coerce
+
+
+def _coerce_auto_verify(value):
+    if not isinstance(value, bool):
+        raise SettingRejected("auto_verify_new_members", "not_a_boolean")
+    return value
+
+
 SETTING_COERCERS = {
     "instructions_locale": _coerce_locale,
     "panel_embed_color": _coerce_embed_color,
     "panel_show_icon": _coerce_show_icon,
+    "role_id": _role_coercer("role_id", required=True),
+    "unverified_role_id": _role_coercer("unverified_role_id", required=False),
+    "auto_verify_new_members": _coerce_auto_verify,
 }
+
+# Fields whose value has to name a real role in *this* guild.
+#
+# Only existence is enforced, not assignability. /vrcverify_setup performs no
+# hierarchy check at all -- Discord's role picker will accept a role above the
+# bot quite happily -- so refusing one here would make the website stricter
+# than the slash command, and would stop an admin who means to set the role
+# first and fix the hierarchy afterwards. The settings page warns about it
+# instead, which is the whole reason `assignable` is surfaced.
+#
+# Existence is different: it is the guarantee Discord's picker provides for
+# free and the dashboard has to provide for itself, because it submits a raw
+# id rather than a choice from a list the platform vouched for.
+ROLE_FIELDS = frozenset({"role_id", "unverified_role_id"})
 
 
 # The grandfather line is drawn on the servers table's autoincrementing primary
@@ -4864,6 +4920,30 @@ async def write_dashboard_settings(guild_id, actor_id, changes: dict):
         if state["locked"]:
             raise SettingRejected(name, "requires_premium", locked=True)
 
+    # --- Roles have to name something that exists in THIS guild ---
+    role_names = ROLE_FIELDS & set(coerced)
+    if role_names:
+        guild = bot.get_guild(int(guild_id))
+        if guild is None or guild.me is None:
+            # The guild was present when _authorize checked; if it is not
+            # visible now, this is the bot failing rather than the caller
+            # asking for something wrong.
+            return None
+        known = {str(role.id) for role in guild.roles if not role.is_default()}
+        for name in role_names:
+            wanted = coerced[name]
+            if wanted is not None and wanted not in known:
+                # Covers a deleted role, a role from another guild, and
+                # @everyone -- which is excluded from `known` because assigning
+                # it means nothing and read_dashboard_roles never offers it.
+                raise SettingRejected(name, "role_not_in_guild")
+
+    # --- A column an older deployment is missing cannot be written ---
+    if "auto_verify_new_members" in coerced and not server_has_column(
+        "auto_verify_new_members"
+    ):
+        raise SettingRejected("auto_verify_new_members", "column_missing")
+
     try:
         changed = []
 
@@ -4884,8 +4964,15 @@ async def write_dashboard_settings(guild_id, actor_id, changes: dict):
                 changed.append(("panel_show_icon", old_icon, new_icon))
             save_panel_branding(guild_id, new_color, bool(new_icon))
 
-        # --- The locale lives on the servers row ---
-        if "instructions_locale" in coerced:
+        # --- Everything else lives on the servers row ---
+        row_fields = {
+            "instructions_locale": "en-US",
+            "role_id": None,
+            "unverified_role_id": None,
+            "auto_verify_new_members": True,
+        }
+        wanted_on_row = {name: coerced[name] for name in row_fields if name in coerced}
+        if wanted_on_row:
             with session_scope() as session:
                 srv = (
                     session.query(Server)
@@ -4897,14 +4984,19 @@ async def write_dashboard_settings(guild_id, actor_id, changes: dict):
                     # for it -- the acting admin is not necessarily the owner.
                     # Inserting a row here would also mint a fresh servers.id,
                     # placing the guild above the grandfather line as a side
-                    # effect of changing its language.
-                    raise SettingRejected("instructions_locale", "server_not_set_up")
-                old_locale = srv.instructions_locale or "en-US"
-                if old_locale != coerced["instructions_locale"]:
-                    changed.append(
-                        ("instructions_locale", old_locale, coerced["instructions_locale"])
+                    # effect of changing a setting.
+                    raise SettingRejected(
+                        sorted(wanted_on_row)[0], "server_not_set_up"
                     )
-                    srv.instructions_locale = coerced["instructions_locale"]
+                for name, new in wanted_on_row.items():
+                    current = getattr(srv, name, None)
+                    if name == "instructions_locale":
+                        current = current or row_fields[name]
+                    elif name == "auto_verify_new_members":
+                        current = row_fields[name] if current is None else bool(current)
+                    if current != new:
+                        changed.append((name, current, new))
+                        setattr(srv, name, new)
 
         if changed:
             with session_scope() as session:

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -338,6 +338,33 @@ def _register_routes(app: Flask) -> None:
             csrf_token=session.csrf_token,
         )
 
+    @app.post("/guild/<int:guild_id>/verification")
+    def save_verification_settings(guild_id: int):
+        """The verification group: which roles, and auto-verify on join.
+
+        Same shape as the panel save below, and the same division of labour --
+        the bot confirms each role actually exists in the guild, which is the
+        guarantee Discord's role picker gives `/vrcverify_setup` for free and
+        this form cannot give itself.
+        """
+        session = _require_login()
+        if session is None:
+            return redirect(url_for("index"))
+        if not _csrf_ok(session):
+            abort(400)
+
+        changes = {}
+        if "role_id" in request.form:
+            changes["role_id"] = request.form.get("role_id")
+        if "unverified_role_id" in request.form:
+            # A select always submits, so an empty value here is a real choice
+            # -- "None". /vrcverify_setup clears it the same way, by leaving
+            # the argument off.
+            changes["unverified_role_id"] = request.form.get("unverified_role_id") or None
+        _read_checkbox(changes, "auto_verify_new_members")
+
+        return _save(guild_id, session, changes)
+
     @app.post("/guild/<int:guild_id>/panel")
     def save_panel_settings(guild_id: int):
         """Save the instructions panel group. The only write in the app.
@@ -359,9 +386,7 @@ def _register_routes(app: Flask) -> None:
         session = _require_login()
         if session is None:
             return redirect(url_for("index"))
-
-        submitted = request.form.get("csrf_token", "")
-        if not secrets.compare_digest(session.csrf_token, submitted):
+        if not _csrf_ok(session):
             abort(400)
 
         changes = {}
@@ -370,13 +395,8 @@ def _register_routes(app: Flask) -> None:
         if locale:
             changes["instructions_locale"] = locale
 
-        if request.form.get("panel_fields_present"):
-            # A checkbox that is off sends nothing at all, so the form declares
-            # that its branding controls were on the page. Without this, an
-            # unticked "show icon" would be indistinguishable from a free
-            # server whose controls were never rendered, and the save would
-            # quietly turn the icon off.
-            changes["panel_show_icon"] = bool(request.form.get("panel_show_icon"))
+        _read_checkbox(changes, "panel_show_icon")
+        if request.form.get("present_panel_embed_color"):
             if request.form.get("panel_color_default"):
                 changes["panel_embed_color"] = None
             else:
@@ -384,27 +404,7 @@ def _register_routes(app: Flask) -> None:
                     request.form.get("panel_embed_color")
                 )
 
-        if not changes:
-            return redirect(url_for("guild_settings", guild_id=guild_id))
-
-        try:
-            _bot_api().update_settings(int(session.discord_id), guild_id, changes)
-        except BotAPIError as error:
-            logger.warning("save refused for guild %s: %s", guild_id, error)
-            # A code, never the bot's text. What comes back is a fixed reason
-            # string today, but round-tripping it through a URL and into a page
-            # would make the bot's error strings part of this app's HTML, and
-            # the day one of them carries something a caller influenced is not
-            # the day to find that out.
-            return redirect(
-                url_for(
-                    "guild_settings",
-                    guild_id=guild_id,
-                    error=_save_error_code(error),
-                )
-            )
-
-        return redirect(url_for("guild_settings", guild_id=guild_id, saved=1))
+        return _save(guild_id, session, changes)
 
     @app.post("/logout")
     def logout():
@@ -451,6 +451,52 @@ SAVE_ERRORS = {
     ),
 }
 GENERIC_SAVE_ERROR = "That change couldn't be saved, so nothing was changed."
+
+
+def _read_checkbox(changes: dict, name: str) -> None:
+    """Record a checkbox only if its control was actually on the page.
+
+    An unticked box submits nothing, which is indistinguishable from a control
+    that was never rendered -- so the template emits a `present_<name>` marker
+    beside every checkbox. Without it, saving a free server's language would
+    look exactly like switching its branding off, and the bot would dutifully
+    be asked to do so.
+    """
+    if request.form.get(f"present_{name}"):
+        changes[name] = bool(request.form.get(name))
+
+
+def _csrf_ok(session) -> bool:
+    """The second line. `SameSite=Lax` on the cookie is the first."""
+    return secrets.compare_digest(
+        session.csrf_token, request.form.get("csrf_token", "")
+    )
+
+
+def _save(guild_id: int, session, changes: dict):
+    """Hand a group's changes to the bot and turn the answer into a redirect.
+
+    Shared by every group so there is exactly one place that talks to the write
+    endpoint, one place that decides what a refusal looks like, and one thing
+    to re-read if that ever needs to change.
+    """
+    if not changes:
+        return redirect(url_for("guild_settings", guild_id=guild_id))
+
+    try:
+        _bot_api().update_settings(int(session.discord_id), guild_id, changes)
+    except BotAPIError as error:
+        logger.warning("save refused for guild %s: %s", guild_id, error)
+        # A code, never the bot's text. What comes back is a fixed reason
+        # string today, but round-tripping it through a URL and into a page
+        # would make the bot's error strings part of this app's HTML, and the
+        # day one of them carries something a caller influenced is not the day
+        # to find that out.
+        return redirect(
+            url_for("guild_settings", guild_id=guild_id, error=_save_error_code(error))
+        )
+
+    return redirect(url_for("guild_settings", guild_id=guild_id, saved=1))
 
 
 def _save_error_code(error: BotAPIError) -> str:

--- a/src/dashboard/settings_view.py
+++ b/src/dashboard/settings_view.py
@@ -39,6 +39,9 @@ from typing import Optional
 # what "no colour" means is the bot's business, and it stores NULL either way.
 DEFAULT_PANEL_SWATCH = "#5865f2"
 
+# Field kinds rendered as a <select>, which is only usable with options.
+CHOICE_KINDS = frozenset({"role", "role_optional", "locale"})
+
 LOCALE_NAMES = {
     "en-US": "English",
     "es-ES": "Spanish",
@@ -97,12 +100,21 @@ class Field:
     def editable(self) -> bool:
         """Render a control, rather than just the value.
 
-        Both halves come from the bot: `writable` is which fields the save path
-        accepts in this phase, `locked` is whether the plan allows it. The
-        website never decides either, and it renders a control only when the
-        bot would actually accept the value it produces.
+        The first two halves come from the bot: `writable` is which fields the
+        save path accepts in this phase, `locked` is whether the plan allows
+        it. The website never decides either, and it renders a control only
+        when the bot would actually accept the value it produces.
+
+        The third is local, and it matters: a picker needs something to pick
+        from. When the roles or channels read failed we have no options, and an
+        empty <select> is worse than the read-only view -- it invites a save
+        that would clear the verified role and stop verification for everyone.
         """
-        return self.writable and not self.locked
+        if not self.writable or self.locked:
+            return False
+        if self.kind in CHOICE_KINDS and not self.choices:
+            return False
+        return True
 
     @property
     def badge(self) -> Optional[str]:
@@ -143,11 +155,18 @@ def _role_field(
     *,
     unassignable_hint: str,
     empty_warning: Optional[str] = None,
+    required: bool = False,
 ) -> Field:
     state = _state(settings, name)
     raw = state.get("value")
     warnings = []
     swatch = None
+    # Options for the picker. A role the bot cannot manage is still offered,
+    # because /vrcverify_setup offers it too -- the warning is the honest
+    # treatment, not removal from the list.
+    choices = [
+        (str(role.get("id")), _role_option_label(role)) for role in (roles or [])
+    ]
 
     if raw is None or str(raw) == "":
         display, empty = "Not set", True
@@ -182,13 +201,30 @@ def _role_field(
         name,
         label,
         description,
-        "role",
+        "role" if required else "role_optional",
         display,
         empty=empty,
         swatch=swatch,
         warnings=warnings,
+        choices=choices,
+        value="" if raw is None else str(raw),
         **_plan(state),
     )
+
+
+def _role_option_label(role: dict) -> str:
+    """The role's name, saying so when the bot could not manage it.
+
+    In the option text rather than a disabled option: the value is selectable
+    on purpose, and a picker that silently omitted the role an admin was
+    looking for would be the more confusing failure.
+    """
+    name = role.get("name") or f"Role {role.get('id')}"
+    if role.get("managed"):
+        return f"{name} (managed by an integration)"
+    if role.get("assignable") is False:
+        return f"{name} (above VRCVerify)"
+    return name
 
 
 def _lookup(entries: Optional[list], wanted) -> Optional[dict]:
@@ -252,6 +288,7 @@ def build_groups(
             "No verified role is set, so verification cannot complete. Members "
             "are told to contact an admin."
         ),
+        required=True,
     )
 
     unverified = _role_field(
@@ -295,6 +332,7 @@ def build_groups(
             "title": "Verification",
             "blurb": "The core of the bot. These are free for every server.",
             "fields": [verified, unverified, auto_verify],
+            "save_endpoint": "save_verification_settings",
         },
         {
             "title": "After verifying",

--- a/src/dashboard/settings_view.py
+++ b/src/dashboard/settings_view.py
@@ -161,11 +161,13 @@ def _role_field(
     raw = state.get("value")
     warnings = []
     swatch = None
-    # Options for the picker. A role the bot cannot manage is still offered,
-    # because /vrcverify_setup offers it too -- the warning is the honest
-    # treatment, not removal from the list.
+    # Options for the picker: the role's name, and nothing else. A role the bot
+    # cannot manage is still offered, because /vrcverify_setup offers it too --
+    # the warning below the field is the honest treatment, not an annotation
+    # inside the list or removal from it.
     choices = [
-        (str(role.get("id")), _role_option_label(role)) for role in (roles or [])
+        (str(role.get("id")), role.get("name") or f"Role {role.get('id')}")
+        for role in (roles or [])
     ]
 
     if raw is None or str(raw) == "":
@@ -210,21 +212,6 @@ def _role_field(
         value="" if raw is None else str(raw),
         **_plan(state),
     )
-
-
-def _role_option_label(role: dict) -> str:
-    """The role's name, saying so when the bot could not manage it.
-
-    In the option text rather than a disabled option: the value is selectable
-    on purpose, and a picker that silently omitted the role an admin was
-    looking for would be the more confusing failure.
-    """
-    name = role.get("name") or f"Role {role.get('id')}"
-    if role.get("managed"):
-        return f"{name} (managed by an integration)"
-    if role.get("assignable") is False:
-        return f"{name} (above VRCVerify)"
-    return name
 
 
 def _lookup(entries: Optional[list], wanted) -> Optional[dict]:

--- a/src/dashboard/templates/settings.html
+++ b/src/dashboard/templates/settings.html
@@ -1,6 +1,14 @@
 {% extends "base.html" %}
 {% block title %}{{ guild_name }} — VRCVerify{% endblock %}
 
+{# An unticked checkbox submits nothing at all, which is indistinguishable from
+   a control that was never on the page -- and the difference matters, because
+   a free server's form has no branding controls and must not be read as having
+   switched them all off. So every checkbox declares itself. #}
+{% macro present(field) -%}
+  <input type="hidden" name="present_{{ field.name }}" value="1">
+{%- endmacro %}
+
 {% block content %}
 <p class="crumb"><a href="{{ url_for('index') }}">&larr; All servers</a></p>
 
@@ -102,7 +110,17 @@
             </dt>
             <dd>
               {% if field.editable %}
-                {% if field.kind == 'locale' %}
+                {% if field.kind in ('role', 'role_optional') %}
+                  <select name="{{ field.name }}" id="f-{{ field.name }}">
+                    {% if field.kind == 'role_optional' %}
+                      <option value="" {% if field.empty %}selected{% endif %}>None</option>
+                    {% endif %}
+                    {% for role_id, label in field.choices %}
+                      <option value="{{ role_id }}"
+                        {%- if role_id == field.value %} selected{% endif %}>{{ label }}</option>
+                    {% endfor %}
+                  </select>
+                {% elif field.kind == 'locale' %}
                   <select name="{{ field.name }}" id="f-{{ field.name }}">
                     {% for code, label in field.choices %}
                       <option value="{{ code }}"
@@ -112,7 +130,7 @@
                 {% elif field.kind == 'color' %}
                   {# A colour input cannot be empty, so "no colour" is its own
                      checkbox rather than a sentinel value pretending to be one. #}
-                  <input type="hidden" name="panel_fields_present" value="1">
+                  {{ present(field) }}
                   <label class="check">
                     <input type="checkbox" name="panel_color_default"
                            {%- if field.empty %} checked{% endif %}>
@@ -121,6 +139,7 @@
                   <input type="color" name="{{ field.name }}"
                          value="{{ field.value }}" aria-label="Panel colour">
                 {% elif field.kind == 'bool' %}
+                  {{ present(field) }}
                   <label class="check">
                     <input type="checkbox" name="{{ field.name }}"
                            {%- if field.value %} checked{% endif %}>

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -1289,10 +1289,9 @@ class TestSettingsWriter:
     @pytest.mark.parametrize(
         "changes",
         [
-            {"role_id": "1"},                     # writable later, not now
-            {"auto_verify_new_members": False},
-            {"custom_verification_requested_message": "hi"},
+            {"custom_verification_requested_message": "hi"},  # opens later
             {"verification_log_channel_id": "5"},
+            {"auto_nickname_change": True},
         ],
     )
     def test_a_field_not_yet_open_is_refused(self, changes, subscribed):
@@ -1358,6 +1357,109 @@ class TestSettingsWriter:
         for empty in ({}, None, "fields"):
             with pytest.raises(bot.SettingRejected):
                 write(empty)
+
+    # ----- the verification group -----
+    def guild_with_roles(self, monkeypatch):
+        guild = FakeGuild(
+            roles=[
+                FakeRole(1, "@everyone", 0, default=True),
+                FakeRole(2, "Verified", 10),
+                FakeRole(3, "Unverified", 9),
+                FakeRole(4, "Admins", 99),          # above the bot
+                FakeRole(5, "Booster", 5, managed=True),
+            ]
+        )
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
+        return guild
+
+    def test_a_verified_role_is_stored_and_audited(self, monkeypatch, subscribed):
+        self.guild_with_roles(monkeypatch)
+        make_server(role_id="2")
+        write({"role_id": "3"})
+        assert audit_rows() == [("role_id", "2", "3", str(ADMIN_ID))]
+
+    def test_an_unverified_role_can_be_cleared(self, monkeypatch, subscribed):
+        """/vrcverify_setup clears it by omitting the argument, so this must too."""
+        self.guild_with_roles(monkeypatch)
+        make_server(role_id="2", unverified_role_id="3")
+        write({"unverified_role_id": None})
+        with bot.session_scope() as session:
+            srv = session.query(bot.Server).filter_by(server_id=str(GUILD_ID)).first()
+            assert srv.unverified_role_id is None
+
+    def test_the_verified_role_cannot_be_cleared(self, monkeypatch, subscribed):
+        """verified_role is a required argument on the slash command."""
+        self.guild_with_roles(monkeypatch)
+        make_server(role_id="2")
+        with pytest.raises(bot.SettingRejected) as caught:
+            write({"role_id": None})
+        assert caught.value.reason == "role_required"
+
+    @pytest.mark.parametrize("wanted", ["1", "9999", "not-a-number", True])
+    def test_a_role_that_is_not_a_real_role_here_is_refused(
+        self, monkeypatch, subscribed, wanted
+    ):
+        """`1` is @everyone, `9999` is another guild's or a deleted one.
+
+        Discord's role picker gives the slash command this guarantee for free.
+        The dashboard submits a raw id, so it has to provide it for itself.
+        """
+        self.guild_with_roles(monkeypatch)
+        make_server(role_id="2")
+        with pytest.raises(bot.SettingRejected):
+            write({"role_id": wanted})
+        assert audit_rows() == []
+
+    @pytest.mark.parametrize("wanted", ["4", "5"])
+    def test_an_unassignable_role_is_allowed_and_only_warned_about(
+        self, monkeypatch, subscribed, wanted
+    ):
+        """Above the bot, or managed by an integration.
+
+        /vrcverify_setup performs no hierarchy check at all, so refusing here
+        would make the website stricter than the slash command -- and would
+        block an admin who means to set the role first and fix the ordering
+        after. The settings page shows the warning instead.
+        """
+        self.guild_with_roles(monkeypatch)
+        make_server(role_id="2")
+        write({"role_id": wanted})
+        with bot.session_scope() as session:
+            srv = session.query(bot.Server).filter_by(server_id=str(GUILD_ID)).first()
+            assert srv.role_id == wanted
+
+    def test_an_id_that_arrived_as_a_number_is_stored_as_a_string(
+        self, monkeypatch, subscribed
+    ):
+        self.guild_with_roles(monkeypatch)
+        make_server(role_id="2")
+        write({"role_id": 3})
+        with bot.session_scope() as session:
+            srv = session.query(bot.Server).filter_by(server_id=str(GUILD_ID)).first()
+            assert srv.role_id == "3"
+
+    def test_auto_verify_is_written_for_a_free_server(self, free):
+        """Never gated, for anyone, ever."""
+        make_server(row_id=500, auto_verify_new_members=True)
+        write({"auto_verify_new_members": False})
+        assert audit_rows()[0][:3] == ("auto_verify_new_members", "True", "False")
+
+    def test_auto_verify_is_refused_when_the_column_is_missing(
+        self, monkeypatch, subscribed
+    ):
+        make_server()
+        monkeypatch.setattr(bot, "server_has_column", lambda name: False)
+        with pytest.raises(bot.SettingRejected) as caught:
+            write({"auto_verify_new_members": False})
+        assert caught.value.reason == "column_missing"
+
+    def test_a_guild_the_bot_cannot_see_does_not_write_a_role(
+        self, monkeypatch, subscribed
+    ):
+        make_server(role_id="2")
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: None)
+        assert write({"role_id": "3"}) is None
+        assert audit_rows() == []
 
     def test_the_writer_reports_the_stored_state_not_the_request(self, subscribed):
         """What the admin sees next is what is saved, not what they submitted."""
@@ -1438,7 +1540,8 @@ class TestBothHalvesTogether:
         )
         assert payload["choices"]["instructions_locale"]
         assert payload["fields"]["instructions_locale"]["writable"] is True
-        assert payload["fields"]["role_id"]["writable"] is False
+        # Still closed, so the page renders it without a control.
+        assert payload["fields"]["verification_log_channel_id"]["writable"] is False
 
     def test_a_refusal_arrives_as_its_reason(self, free):
         """The dashboard maps these to copy, so the string has to survive."""

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,4 +1,4 @@
-"""Unit tests for the web dashboard (issue #65, steps 3 and 4).
+"""Unit tests for the web dashboard (issue #65, steps 3 to 5).
 
 This is the internet-facing half of the system, so the tests are mostly about
 the ways a login can be subverted rather than the happy path:
@@ -106,7 +106,14 @@ DEFAULT_VALUES = {
 # What the bot currently lets the website write. Mirrors
 # bot.DASHBOARD_WRITABLE_FIELDS -- the payload carries it so the dashboard
 # never has to know.
-WRITABLE = {"instructions_locale", "panel_embed_color", "panel_show_icon"}
+WRITABLE = {
+    "instructions_locale",
+    "panel_embed_color",
+    "panel_show_icon",
+    "role_id",
+    "unverified_role_id",
+    "auto_verify_new_members",
+}
 
 LOCALES = ["en-US", "es-ES", "ja", "de"]
 
@@ -625,10 +632,19 @@ class TestSettingsPage:
         assert response.headers["Location"].endswith("/")
 
     def test_values_are_shown_with_names_not_ids(self, config, store):
-        test_client, _api = settings_client(config, store)
+        """A read-only field shows the role's name and never its id."""
+        test_client, _api = settings_client(
+            config, store, settings=make_settings(writable=set())
+        )
         page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
         assert "Verified" in page
         assert VERIFIED_ROLE not in page
+
+    def test_an_editable_role_is_labelled_by_name(self, config, store):
+        """Editable, the id has to be in the option value -- the label doesn't."""
+        test_client, _api = settings_client(config, store)
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert f'<option value="{VERIFIED_ROLE}" selected>Verified</option>' in page
 
     def test_every_read_is_scoped_to_the_session_owner_and_that_guild(
         self, config, store
@@ -841,6 +857,19 @@ class TestSecondaryReadsDegradeGracefully:
         assert f"Unknown role ({VERIFIED_ROLE})" in page
         assert "show an ID instead of a name" in page
 
+    def test_a_role_picker_with_nothing_to_pick_is_not_offered(self, config, store):
+        """An empty <select> invites a save that clears the verified role.
+
+        Better to fall back to the read-only view than to render a control
+        whose only options are "leave it" and "break verification".
+        """
+        test_client, _api = settings_client(
+            config, store, errors={"roles": BotAPIError("unavailable", 503)}
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert 'name="role_id"' not in page
+        assert 'name="unverified_role_id"' not in page
+
     def test_an_unresolved_id_is_not_reported_as_deleted(self, config, store):
         """"We could not check" and "it is gone" are different claims."""
         test_client, _api = settings_client(
@@ -880,8 +909,9 @@ class TestSavingThePanelGroup:
             test_client,
             session,
             instructions_locale="ja",
-            panel_fields_present="1",
+            present_panel_embed_color="1",
             panel_embed_color="#ff0000",
+            present_panel_show_icon="1",
             panel_show_icon="on",
         )
         assert response.status_code == 302
@@ -899,7 +929,7 @@ class TestSavingThePanelGroup:
         self.post(
             test_client,
             session,
-            panel_fields_present="1",
+            present_panel_embed_color="1",
             panel_embed_color="#0a0b0c",
         )
         assert api.saves[-1][2]["panel_embed_color"] == 0x0A0B0C
@@ -909,7 +939,7 @@ class TestSavingThePanelGroup:
         self.post(
             test_client,
             session,
-            panel_fields_present="1",
+            present_panel_embed_color="1",
             panel_color_default="on",
             panel_embed_color="#ff0000",
         )
@@ -921,7 +951,7 @@ class TestSavingThePanelGroup:
         """A checkbox that is off sends nothing, which is why the form declares
         that its branding controls were rendered at all."""
         test_client, api, session = self.logged_in(config, store)
-        self.post(test_client, session, panel_fields_present="1")
+        self.post(test_client, session, present_panel_show_icon="1")
         assert api.saves[-1][2]["panel_show_icon"] is False
 
     def test_branding_is_untouched_when_its_controls_were_not_rendered(
@@ -1010,6 +1040,83 @@ class TestSavingThePanelGroup:
         ).data.decode()
         assert "onerror" not in page
         assert "couldn&#39;t be saved" in page
+
+
+class TestSavingTheVerificationGroup:
+    def post(self, test_client, session, **form):
+        form.setdefault("csrf_token", session.csrf_token)
+        return test_client.post(f"/guild/{GUILD_IN}/verification", data=form)
+
+    def logged_in(self, config, store, **kwargs):
+        api = FakeBotAPI(**kwargs)
+        app = create_app(config, store=store, client=api)
+        app.config.update(TESTING=True)
+        test_client = app.test_client()
+        return test_client, api, login_as(test_client, store)
+
+    def test_roles_and_auto_verify_are_sent(self, config, store):
+        test_client, api, session = self.logged_in(config, store)
+        self.post(
+            test_client,
+            session,
+            role_id=VERIFIED_ROLE,
+            unverified_role_id=UNVERIFIED_ROLE,
+            present_auto_verify_new_members="1",
+            auto_verify_new_members="on",
+        )
+        assert api.saves[-1][2] == {
+            "role_id": VERIFIED_ROLE,
+            "unverified_role_id": UNVERIFIED_ROLE,
+            "auto_verify_new_members": True,
+        }
+
+    def test_an_empty_unverified_role_clears_it(self, config, store):
+        """A select always submits, so blank is a real choice, not an absence."""
+        test_client, api, session = self.logged_in(config, store)
+        self.post(test_client, session, role_id=VERIFIED_ROLE, unverified_role_id="")
+        assert api.saves[-1][2]["unverified_role_id"] is None
+
+    def test_auto_verify_off_is_sent_as_false(self, config, store):
+        test_client, api, session = self.logged_in(config, store)
+        self.post(
+            test_client,
+            session,
+            role_id=VERIFIED_ROLE,
+            present_auto_verify_new_members="1",
+        )
+        assert api.saves[-1][2]["auto_verify_new_members"] is False
+
+    def test_a_form_without_the_auto_verify_control_leaves_it_alone(
+        self, config, store
+    ):
+        """The marker is what tells "unticked" from "never rendered"."""
+        test_client, api, session = self.logged_in(config, store)
+        self.post(test_client, session, role_id=VERIFIED_ROLE)
+        assert "auto_verify_new_members" not in api.saves[-1][2]
+
+    def test_it_needs_the_csrf_token(self, config, store):
+        test_client, api, _session = self.logged_in(config, store)
+        response = test_client.post(
+            f"/guild/{GUILD_IN}/verification",
+            data={"csrf_token": "wrong", "role_id": VERIFIED_ROLE},
+        )
+        assert response.status_code == 400
+        assert api.saves == []
+
+    def test_a_signed_out_visitor_cannot_save(self, client, bot_api):
+        response = client.post(
+            f"/guild/{GUILD_IN}/verification", data={"role_id": VERIFIED_ROLE}
+        )
+        assert response.status_code == 302
+        assert not getattr(bot_api, "saves", [])
+
+    def test_a_refused_role_is_explained(self, config, store):
+        test_client, _api, session = self.logged_in(
+            config, store, errors={"update_settings": BotAPIError("role_not_in_guild", 400)}
+        )
+        response = self.post(test_client, session, role_id="123")
+        page = test_client.get(response.headers["Location"]).data.decode()
+        assert "no longer exists" in page or "couldn&#39;t be saved" in page
 
 
 class TestTheFormMatchesWhatTheBotAccepts:
@@ -1101,15 +1208,18 @@ class TestHardening:
         test_client, _api = settings_client(
             config,
             store,
-            settings=make_settings(premium=True, values={"panel_embed_color": 0xFF00FF}),
+            # Nothing writable, so every field takes the read-only path and the
+            # swatches are the presentation under test.
+            settings=make_settings(
+                premium=True, writable=set(), values={"panel_embed_color": 0xFF00FF}
+            ),
         )
         for path in ("/", f"/guild/{GUILD_IN}"):
             page = test_client.get(path).data
             assert b"style=" not in page, f"inline style on {path}"
-        # A swatch still rendered; it just isn't CSS. The verified role's is the
-        # stable one to look at -- role_id has no save path in this phase, so it
-        # is always the read-only presentation.
-        assert b'fill="#5865f2"' in test_client.get(f"/guild/{GUILD_IN}").data
+        page = test_client.get(f"/guild/{GUILD_IN}").data
+        assert b'fill="#ff00ff"' in page   # the panel colour
+        assert b'fill="#5865f2"' in page   # the verified role's colour
 
     def test_logout_requires_the_csrf_token(self, client, store):
         session = login_as(client, store)
@@ -1219,15 +1329,17 @@ class TestSettingsViewModel:
 class TestWriteSurface:
     """Step 5 opens exactly one save path. Widening it means editing this."""
 
-    def test_the_post_routes_are_logout_and_the_panel_save(self, app):
+    def test_the_post_routes_are_logout_and_the_two_group_saves(self, app):
         posts = {
             rule.rule
             for rule in app.url_map.iter_rules()
             if "POST" in (rule.methods or set())
         }
-        assert posts == {"/logout", "/guild/<int:guild_id>/panel"}, (
-            f"an unexpected write route appeared: {posts}"
-        )
+        assert posts == {
+            "/logout",
+            "/guild/<int:guild_id>/panel",
+            "/guild/<int:guild_id>/verification",
+        }, f"an unexpected write route appeared: {posts}"
 
     def test_the_dashboard_holds_no_database_credential(self):
         """A compromise of the public host must not reach the users table."""


### PR DESCRIPTION
**Re-land.** #75 was stacked on #74 and merged into `65-dashboard-saves` rather than `main` — that base branch had already been merged and was then deleted, so #75's content never reached `main`. Nothing was lost; this is the same two commits, based on `main` directly.

Verified before opening: `main` contains neither `ROLE_FIELDS` nor either commit.

---

The second group of step 5: verified role, unverified role, auto-verify on join.

## Roles are checked against the guild

Discord's role picker gives `/vrcverify_setup` a guarantee for free — every option it offers is a real role in that server. A form submitting a raw id has to provide that itself, so an id naming a deleted role, another guild's role, or `@everyone` is refused.

**Assignability is deliberately not enforced.** `/vrcverify_setup` performs no hierarchy check at all. Refusing here would make the website stricter than the slash command, and would block an admin who means to set the role first and fix the ordering after. The warning under the field says the rest.

| | verified role | unverified role |
|---|---|---|
| can be cleared | no — required argument on the slash command | yes — omitting the argument is how the command clears it |
| must exist in the guild | yes | yes |
| may be unassignable | yes, with a warning | yes, with a warning |

## An empty picker is never editable

When the roles read fails there is nothing to choose from, and the field was still marked writable — rendering a `<select>` whose only options are "leave it" and "blank". Saving that would clear the verified role and stop verification for the whole server. Choice-kind fields now fall back to the read-only view when they have no options; fields needing none, like the auto-verify checkbox, stay editable.

## Checkbox presence moved from per-form to per-field

The per-form marker from #74 was wrong for a free server: its panel form renders a language control but no branding controls, so submitting it looked exactly like switching the branding off.

## Role pickers show only the role name

No `(above VRCVerify)` or `(managed by an integration)` annotations — the picker reads as a plain list of the server's roles. The warning under the field carries the signal when such a role is actually selected.

## Tests

966, up from 945 on `main`.