### PR TITLE
Open the last three settings for saving, finishing step 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,21 +328,36 @@ lists the servers they administer, and shows one server's settings. It holds no
 database credential and no bot token: everything it knows it asks the bot for
 over mTLS, and the bot decides what it is allowed to know.
 
-It can now save two groups — the **instructions panel** (language, colour,
-server icon) and **verification** (verified role, unverified role, auto-verify
-on join). That boundary is enforced in the bot by `DASHBOARD_WRITABLE_FIELDS`,
+It can now save **every setting the slash commands can**, one form per group.
+That boundary is still enforced in the bot by `DASHBOARD_WRITABLE_FIELDS`,
 not by which controls the website chose to draw, and the payload tells the
 dashboard which fields are open so the two cannot drift. The website renders a
 control only where the bot has said it would accept the value — and, for a
 picker, only when it actually has something to pick from, because an empty
 `<select>` invites a save that would clear the verified role.
 
-On roles the bot checks that the id names a real role in *that* guild — the
-guarantee Discord's role picker gives `/vrcverify_setup` for free, which a form
-submitting a raw id has to provide for itself. It does **not** refuse a role it
-cannot assign: `/vrcverify_setup` doesn't either, so refusing would make the
-website stricter than the slash command and would block an admin who means to
-set the role first and fix the hierarchy after. The page warns instead.
+Each value is checked the way its own slash command checks it, and the
+differences between them are deliberate:
+
+- **Roles** must name a real role in *that* guild — the guarantee Discord's
+  picker gives `/vrcverify_setup` for free, which a form submitting a raw id
+  has to provide for itself. A role the bot cannot *assign* is still accepted,
+  because `/vrcverify_setup` accepts it too; refusing would block an admin who
+  means to set the role first and fix the hierarchy after. The page warns.
+- **The log channel** must not be an announcement channel, because
+  `/vrcverify_logchannel` refuses those outright — other servers can follow
+  one, which would republish an age disclosure about a named member. Those
+  channels are left out of the picker entirely: here, omitting is matching the
+  bot rather than being stricter than it.
+- **The custom DM** goes through `sanitize_custom_message()` — the same
+  function the slash command uses, not a second implementation. It strips
+  zero-width characters, defuses `@everyone`, and allows links only to
+  discord.com and vrchat.com. The *sanitised* text is what gets stored.
+
+A picker is only rendered when it has something to pick from. When the roles or
+channels read fails, the field falls back to read-only — an empty `<select>`
+invites a save that would clear the verified role and stop verification for the
+whole server.
 
 The write path adds one route on each side, and both are pinned by tests:
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -770,8 +770,20 @@ DASHBOARD_WRITABLE_FIELDS = frozenset(
         "role_id",
         "unverified_role_id",
         "auto_verify_new_members",
+        "auto_nickname_change",
+        "custom_verification_requested_message",
+        "verification_log_channel_id",
     }
 )
+
+# The modal's own cap, so the website cannot store a message the slash command
+# could not have produced.
+CUSTOM_MESSAGE_MAX_LEN = 1000
+
+# What /vrcverify_setrequestmessage treats as "clear this". Reused rather than
+# reimplemented: if the dashboard stored a literal "none", it would be holding
+# a value the slash command has no way to set.
+CUSTOM_MESSAGE_CLEARING = frozenset({"clear", "reset", "none", "default"})
 
 
 # Raised by the writer below, mapped to a status by bot_api. It lives over
@@ -830,10 +842,45 @@ def _role_coercer(field_name: str, *, required: bool):
     return coerce
 
 
-def _coerce_auto_verify(value):
-    if not isinstance(value, bool):
-        raise SettingRejected("auto_verify_new_members", "not_a_boolean")
-    return value
+def _bool_coercer(field_name: str):
+    def coerce(value):
+        if not isinstance(value, bool):
+            raise SettingRejected(field_name, "not_a_boolean")
+        return value
+
+    return coerce
+
+
+def _coerce_custom_message(value):
+    """The custom DM, through the same sanitiser the slash command uses.
+
+    Not a reimplementation: sanitize_custom_message strips zero-width
+    characters, defuses @everyone/@here, and allows links only to discord.com
+    and vrchat.com. This text is delivered to members by DM, so a second
+    implementation that drifted from the first would be a way to say things
+    through the bot that the bot's own command refuses to say.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise SettingRejected("custom_verification_requested_message", "not_text")
+
+    raw = value.strip()
+    if raw == "" or raw.lower() in CUSTOM_MESSAGE_CLEARING:
+        return None
+    if len(raw) > CUSTOM_MESSAGE_MAX_LEN:
+        raise SettingRejected(
+            "custom_verification_requested_message", "message_too_long"
+        )
+
+    cleaned, invalid = sanitize_custom_message(raw)
+    if invalid:
+        raise SettingRejected(
+            "custom_verification_requested_message", "message_links_not_allowed"
+        )
+    # The sanitised text, never the submitted text -- the @everyone defusal has
+    # to survive into the database, not just past the check.
+    return cleaned
 
 
 SETTING_COERCERS = {
@@ -842,7 +889,14 @@ SETTING_COERCERS = {
     "panel_show_icon": _coerce_show_icon,
     "role_id": _role_coercer("role_id", required=True),
     "unverified_role_id": _role_coercer("unverified_role_id", required=False),
-    "auto_verify_new_members": _coerce_auto_verify,
+    "auto_verify_new_members": _bool_coercer("auto_verify_new_members"),
+    "auto_nickname_change": _bool_coercer("auto_nickname_change"),
+    "custom_verification_requested_message": _coerce_custom_message,
+    # Same shape as a role id, and clearable the same way /vrcverify_logchannel
+    # clears it: by leaving the channel argument off.
+    "verification_log_channel_id": _role_coercer(
+        "verification_log_channel_id", required=False
+    ),
 }
 
 # Fields whose value has to name a real role in *this* guild.
@@ -858,6 +912,19 @@ SETTING_COERCERS = {
 # free and the dashboard has to provide for itself, because it submits a raw
 # id rather than a choice from a list the platform vouched for.
 ROLE_FIELDS = frozenset({"role_id", "unverified_role_id"})
+
+# The log channel, which unlike a role has rules beyond existing.
+#
+# /vrcverify_logchannel refuses an announcement channel outright: other servers
+# can *follow* one, and every entry in this log pairs a Discord user with their
+# 18+ status, so a followed channel would republish an age disclosure about a
+# named member into servers they have no relationship with.
+#
+# It also confirms by posting into the channel, which doubles as a permission
+# check. The dashboard refuses on `can_send` instead of posting: a settings
+# save should not put a message in a channel as a side effect, and the bot
+# already computes the same answer for the settings page.
+CHANNEL_FIELDS = frozenset({"verification_log_channel_id"})
 
 
 # The grandfather line is drawn on the servers table's autoincrementing primary
@@ -4938,6 +5005,25 @@ async def write_dashboard_settings(guild_id, actor_id, changes: dict):
                 # it means nothing and read_dashboard_roles never offers it.
                 raise SettingRejected(name, "role_not_in_guild")
 
+    # --- The log channel has to be somewhere the bot may actually log ---
+    for name in CHANNEL_FIELDS & set(coerced):
+        wanted = coerced[name]
+        if wanted is None:
+            continue
+        guild = bot.get_guild(int(guild_id))
+        if guild is None or guild.me is None:
+            return None
+        channel = next(
+            (c for c in guild.text_channels if str(c.id) == wanted), None
+        )
+        if channel is None:
+            raise SettingRejected(name, "channel_not_in_guild")
+        if channel.is_news():
+            raise SettingRejected(name, "channel_is_announcement")
+        perms = channel.permissions_for(guild.me)
+        if not (perms.view_channel and perms.send_messages):
+            raise SettingRejected(name, "channel_not_writable")
+
     # --- A column an older deployment is missing cannot be written ---
     if "auto_verify_new_members" in coerced and not server_has_column(
         "auto_verify_new_members"
@@ -4964,12 +5050,24 @@ async def write_dashboard_settings(guild_id, actor_id, changes: dict):
                 changed.append(("panel_show_icon", old_icon, new_icon))
             save_panel_branding(guild_id, new_color, bool(new_icon))
 
+        # --- The log channel has its own table, so its own write ---
+        if "verification_log_channel_id" in coerced:
+            new_channel = coerced["verification_log_channel_id"]
+            old_channel = load_log_channel_id(guild_id)
+            if (old_channel or None) != (new_channel or None):
+                changed.append(
+                    ("verification_log_channel_id", old_channel, new_channel)
+                )
+                set_log_channel(guild_id, new_channel)
+
         # --- Everything else lives on the servers row ---
         row_fields = {
             "instructions_locale": "en-US",
             "role_id": None,
             "unverified_role_id": None,
             "auto_verify_new_members": True,
+            "auto_nickname_change": False,
+            "custom_verification_requested_message": None,
         }
         wanted_on_row = {name: coerced[name] for name in row_fields if name in coerced}
         if wanted_on_row:

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -365,6 +365,51 @@ def _register_routes(app: Flask) -> None:
 
         return _save(guild_id, session, changes)
 
+    @app.post("/guild/<int:guild_id>/member")
+    def save_member_settings(guild_id: int):
+        """Nickname sync and the custom verification DM.
+
+        The message is submitted exactly as typed. Every rule about it -- the
+        length cap, the zero-width stripping, the @everyone defusal, the
+        discord.com/vrchat.com link allowlist -- belongs to the bot, which runs
+        the same sanitiser its own slash command does. Trimming or cleaning it
+        here would create a second opinion about what an admin is allowed to
+        say through the bot.
+        """
+        session = _require_login()
+        if session is None:
+            return redirect(url_for("index"))
+        if not _csrf_ok(session):
+            abort(400)
+
+        changes = {}
+        _read_checkbox(changes, "auto_nickname_change")
+        if "custom_verification_requested_message" in request.form:
+            changes["custom_verification_requested_message"] = request.form.get(
+                "custom_verification_requested_message"
+            )
+
+        return _save(guild_id, session, changes)
+
+    @app.post("/guild/<int:guild_id>/logging")
+    def save_logging_settings(guild_id: int):
+        """Where verification activity is logged, or nowhere."""
+        session = _require_login()
+        if session is None:
+            return redirect(url_for("index"))
+        if not _csrf_ok(session):
+            abort(400)
+
+        changes = {}
+        if "verification_log_channel_id" in request.form:
+            # A select always submits, so blank is the real choice "off" --
+            # which is how /vrcverify_logchannel turns it off too.
+            changes["verification_log_channel_id"] = (
+                request.form.get("verification_log_channel_id") or None
+            )
+
+        return _save(guild_id, session, changes)
+
     @app.post("/guild/<int:guild_id>/panel")
     def save_panel_settings(guild_id: int):
         """Save the instructions panel group. The only write in the app.
@@ -448,6 +493,37 @@ SAVE_ERRORS = {
     "unavailable": (
         "The bot couldn't complete the save, so nothing was changed. Try again "
         "shortly."
+    ),
+    "role_not_in_guild": (
+        "That role isn't in this server any more. Reload the page and pick "
+        "again."
+    ),
+    "role_required": "Pick a verified role -- verification can't run without one.",
+    # The offending links are deliberately not echoed back. The rule is short
+    # enough to state, the admin is looking at their own message, and the page
+    # stays free of text that came from a request.
+    "message_links_not_allowed": (
+        "Links in the custom message may only point to discord.com or "
+        "vrchat.com. Nothing was changed."
+    ),
+    "message_too_long": (
+        "That custom message is too long. The limit is 1000 characters."
+    ),
+    "channel_is_announcement": (
+        "Verification logs can't go in an announcement channel -- other servers "
+        "can follow one, which would republish your members' age status."
+    ),
+    "channel_not_in_guild": (
+        "That channel isn't in this server any more. Reload the page and pick "
+        "again."
+    ),
+    "channel_not_writable": (
+        "VRCVerify can't post in that channel, so it can't log there. Check the "
+        "channel's permissions and try again."
+    ),
+    "column_missing": (
+        "This bot's database is missing the column for that setting. Contact "
+        "the bot operator."
     ),
 }
 GENERIC_SAVE_ERROR = "That change couldn't be saved, so nothing was changed."

--- a/src/dashboard/settings_view.py
+++ b/src/dashboard/settings_view.py
@@ -39,8 +39,12 @@ from typing import Optional
 # what "no colour" means is the bot's business, and it stores NULL either way.
 DEFAULT_PANEL_SWATCH = "#5865f2"
 
+# The bot's own cap, mirrored so the textarea stops at the same place the save
+# does. The browser attribute is a courtesy; the bot enforces it.
+CUSTOM_MESSAGE_MAX_LEN = 1000
+
 # Field kinds rendered as a <select>, which is only usable with options.
-CHOICE_KINDS = frozenset({"role", "role_optional", "locale"})
+CHOICE_KINDS = frozenset({"role", "role_optional", "locale", "channel"})
 
 LOCALE_NAMES = {
     "en-US": "English",
@@ -78,6 +82,7 @@ class Field:
         writable: bool = False,
         choices: Optional[list] = None,
         value=None,
+        maxlength: Optional[int] = None,
     ):
         self.name = name
         self.label = label
@@ -95,6 +100,7 @@ class Field:
         # The raw value a form control needs, as distinct from `display`, which
         # is prose for a human.
         self.value = value
+        self.maxlength = maxlength
 
     @property
     def editable(self) -> bool:
@@ -325,6 +331,7 @@ def build_groups(
             "title": "After verifying",
             "blurb": "What happens once a member is confirmed.",
             "fields": [nickname, custom_dm],
+            "save_endpoint": "save_member_settings",
         },
         {
             "title": "Instructions panel",
@@ -341,6 +348,7 @@ def build_groups(
             "title": "Logging",
             "blurb": "A record of verification activity for your moderators.",
             "fields": [log_channel],
+            "save_endpoint": "save_logging_settings",
         },
     ]
 
@@ -355,10 +363,14 @@ def _custom_dm_field(settings: dict) -> Field:
     return Field(
         "custom_verification_requested_message",
         "Custom verification message",
-        "Replaces the default DM a member gets when they start verifying.",
+        "Replaces the default DM a member gets when they start verifying. "
+        "Links may only point to discord.com or vrchat.com. Leave it empty to "
+        "go back to the default.",
         "text",
         display,
         empty=empty,
+        value="" if raw is None else str(raw),
+        maxlength=CUSTOM_MESSAGE_MAX_LEN,
         **_plan(state),
     )
 
@@ -444,6 +456,16 @@ def _log_channel_field(settings: dict, channels: Optional[list]) -> Field:
             if channel.get("can_send") is False:
                 warnings.append("VRCVerify cannot post in this channel.")
 
+    # Announcement channels are left out of the picker rather than offered and
+    # refused. Unlike an unassignable role -- which /vrcverify_setup accepts and
+    # this page only warns about -- /vrcverify_logchannel refuses these
+    # outright, so omitting them is matching the bot, not being stricter.
+    choices = [
+        (str(channel.get("id")), f"#{channel.get('name') or channel.get('id')}")
+        for channel in (channels or [])
+        if not channel.get("is_news")
+    ]
+
     return Field(
         "verification_log_channel_id",
         "Verification log channel",
@@ -452,6 +474,8 @@ def _log_channel_field(settings: dict, channels: Optional[list]) -> Field:
         display,
         empty=empty,
         warnings=warnings,
+        choices=choices,
+        value="" if raw is None else str(raw),
         **_plan(state),
     )
 

--- a/src/dashboard/static/style.css
+++ b/src/dashboard/static/style.css
@@ -283,3 +283,15 @@ footer {
   color: var(--muted);
   font-size: 0.85rem;
 }
+
+textarea {
+  display: block;
+  width: 100%;
+  font: inherit;
+  color: var(--ink);
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0.45rem 0.55rem;
+  resize: vertical;
+}

--- a/src/dashboard/templates/settings.html
+++ b/src/dashboard/templates/settings.html
@@ -110,7 +110,19 @@
             </dt>
             <dd>
               {% if field.editable %}
-                {% if field.kind in ('role', 'role_optional') %}
+                {% if field.kind == 'text' %}
+                  <textarea name="{{ field.name }}" rows="4"
+                            maxlength="{{ field.maxlength }}"
+                            id="f-{{ field.name }}">{{ field.value }}</textarea>
+                {% elif field.kind == 'channel' %}
+                  <select name="{{ field.name }}" id="f-{{ field.name }}">
+                    <option value="" {% if field.empty %}selected{% endif %}>Off</option>
+                    {% for channel_id, label in field.choices %}
+                      <option value="{{ channel_id }}"
+                        {%- if channel_id == field.value %} selected{% endif %}>{{ label }}</option>
+                    {% endfor %}
+                  </select>
+                {% elif field.kind in ('role', 'role_optional') %}
                   <select name="{{ field.name }}" id="f-{{ field.name }}">
                     {% if field.kind == 'role_optional' %}
                       <option value="" {% if field.empty %}selected{% endif %}>None</option>

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -1286,20 +1286,16 @@ class TestSettingsWriter:
         assert caught.value.locked is False
         assert audit_rows() == []
 
-    @pytest.mark.parametrize(
-        "changes",
-        [
-            {"custom_verification_requested_message": "hi"},  # opens later
-            {"verification_log_channel_id": "5"},
-            {"auto_nickname_change": True},
-        ],
-    )
-    def test_a_field_not_yet_open_is_refused(self, changes, subscribed):
-        make_server()
-        with pytest.raises(bot.SettingRejected) as caught:
-            write(changes)
-        assert caught.value.reason == "not_writable_yet"
-        assert audit_rows() == []
+    def test_every_declared_setting_is_now_writable(self):
+        """Step 5 is finished: the whole allowlist is open.
+
+        Kept as an equality rather than deleted, so adding a SettingsField
+        forces a decision about whether the website may set it. Failing here
+        means someone has to choose, which is the point.
+        """
+        assert bot.DASHBOARD_WRITABLE_FIELDS == {
+            field.name for field in bot.SETTINGS_FIELDS
+        }
 
     def test_an_unknown_field_is_refused(self, subscribed):
         make_server()
@@ -1461,6 +1457,132 @@ class TestSettingsWriter:
         assert write({"role_id": "3"}) is None
         assert audit_rows() == []
 
+    # ----- the custom DM -----
+    def test_a_custom_message_is_stored_sanitised(self, subscribed):
+        """The stored text, not the submitted text.
+
+        The @everyone defusal has to survive into the database -- passing the
+        check and then saving the original would be worse than no check.
+        """
+        make_server()
+        write({"custom_verification_requested_message": "Welcome @everyone!"})
+        with bot.session_scope() as session:
+            srv = session.query(bot.Server).filter_by(server_id=str(GUILD_ID)).first()
+            assert "@everyone" not in srv.custom_verification_requested_message
+            assert "@ everyone" in srv.custom_verification_requested_message
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Join us at https://evil.example.com",
+            "See http://discord.com.attacker.test/x",
+        ],
+    )
+    def test_a_message_linking_off_the_allowlist_is_refused(self, text, subscribed):
+        make_server()
+        with pytest.raises(bot.SettingRejected) as caught:
+            write({"custom_verification_requested_message": text})
+        assert caught.value.reason == "message_links_not_allowed"
+        assert audit_rows() == []
+
+    def test_an_allowed_link_is_accepted(self, subscribed):
+        make_server()
+        write(
+            {"custom_verification_requested_message": "Guide: https://vrchat.com/home"}
+        )
+        assert audit_rows()[0][0] == "custom_verification_requested_message"
+
+    def test_a_message_over_the_modal_cap_is_refused(self, subscribed):
+        make_server()
+        with pytest.raises(bot.SettingRejected) as caught:
+            write(
+                {
+                    "custom_verification_requested_message": "x"
+                    * (bot.CUSTOM_MESSAGE_MAX_LEN + 1)
+                }
+            )
+        assert caught.value.reason == "message_too_long"
+
+    @pytest.mark.parametrize("text", ["", "   ", "clear", "None", "DEFAULT"])
+    def test_the_words_the_slash_command_clears_on_also_clear_here(
+        self, text, subscribed
+    ):
+        """Otherwise the website could store a value the command cannot set."""
+        make_server(custom_verification_requested_message="old")
+        write({"custom_verification_requested_message": text})
+        with bot.session_scope() as session:
+            srv = session.query(bot.Server).filter_by(server_id=str(GUILD_ID)).first()
+            assert srv.custom_verification_requested_message is None
+
+    # ----- the log channel -----
+    def guild_with_channels(self, monkeypatch, sendable=True):
+        guild = FakeGuild(
+            channels=[
+                FakeChannel(70, "verify-log", position=0, sendable=sendable),
+                FakeChannel(71, "announcements", position=1, news=True),
+            ]
+        )
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
+        return guild
+
+    def test_a_log_channel_is_stored_and_audited(self, monkeypatch, subscribed):
+        self.guild_with_channels(monkeypatch)
+        make_server()
+        write({"verification_log_channel_id": "70"})
+        assert bot.load_log_channel_id(GUILD_ID) == "70"
+        assert audit_rows()[0][:3] == ("verification_log_channel_id", None, "70")
+
+    def test_a_log_channel_can_be_cleared(self, monkeypatch, subscribed):
+        self.guild_with_channels(monkeypatch)
+        make_server()
+        bot.set_log_channel(GUILD_ID, "70")
+        write({"verification_log_channel_id": None})
+        assert bot.load_log_channel_id(GUILD_ID) is None
+
+    def test_an_announcement_channel_is_refused(self, monkeypatch, subscribed):
+        """Other servers can follow one, republishing an age disclosure."""
+        self.guild_with_channels(monkeypatch)
+        make_server()
+        with pytest.raises(bot.SettingRejected) as caught:
+            write({"verification_log_channel_id": "71"})
+        assert caught.value.reason == "channel_is_announcement"
+        assert bot.load_log_channel_id(GUILD_ID) is None
+
+    def test_a_channel_from_another_guild_is_refused(self, monkeypatch, subscribed):
+        self.guild_with_channels(monkeypatch)
+        make_server()
+        with pytest.raises(bot.SettingRejected) as caught:
+            write({"verification_log_channel_id": "9999"})
+        assert caught.value.reason == "channel_not_in_guild"
+
+    def test_a_channel_the_bot_cannot_post_in_is_refused(self, monkeypatch, subscribed):
+        """/vrcverify_logchannel finds this out by posting; we ask instead."""
+        self.guild_with_channels(monkeypatch, sendable=False)
+        make_server()
+        with pytest.raises(bot.SettingRejected) as caught:
+            write({"verification_log_channel_id": "70"})
+        assert caught.value.reason == "channel_not_writable"
+
+    def test_a_free_server_cannot_set_a_log_channel(self, monkeypatch, free):
+        self.guild_with_channels(monkeypatch)
+        make_server(row_id=500)
+        with pytest.raises(bot.SettingRejected) as caught:
+            write({"verification_log_channel_id": "70"})
+        assert caught.value.reason == "requires_premium"
+        assert bot.load_log_channel_id(GUILD_ID) is None
+
+    # ----- nickname sync -----
+    def test_nickname_sync_is_premium_only(self, free):
+        make_server(row_id=500)
+        with pytest.raises(bot.SettingRejected) as caught:
+            write({"auto_nickname_change": True})
+        assert caught.value.locked is True
+
+    def test_nickname_sync_is_stored_for_a_premium_server(self, subscribed):
+        make_server()
+        write({"auto_nickname_change": True})
+        assert audit_rows()[0][:3] == ("auto_nickname_change", "False", "True")
+
     def test_the_writer_reports_the_stored_state_not_the_request(self, subscribed):
         """What the admin sees next is what is saved, not what they submitted."""
         make_server()
@@ -1539,9 +1661,9 @@ class TestBothHalvesTogether:
             lambda client: client.settings(ADMIN_ID, GUILD_ID)
         )
         assert payload["choices"]["instructions_locale"]
-        assert payload["fields"]["instructions_locale"]["writable"] is True
-        # Still closed, so the page renders it without a control.
-        assert payload["fields"]["verification_log_channel_id"]["writable"] is False
+        assert all(
+            field["writable"] is True for field in payload["fields"].values()
+        )
 
     def test_a_refusal_arrives_as_its_reason(self, free):
         """The dashboard maps these to copy, so the string has to survive."""

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -106,14 +106,7 @@ DEFAULT_VALUES = {
 # What the bot currently lets the website write. Mirrors
 # bot.DASHBOARD_WRITABLE_FIELDS -- the payload carries it so the dashboard
 # never has to know.
-WRITABLE = {
-    "instructions_locale",
-    "panel_embed_color",
-    "panel_show_icon",
-    "role_id",
-    "unverified_role_id",
-    "auto_verify_new_members",
-}
+WRITABLE = set(FREE_PLAN)  # step 5 is complete: every declared setting is open
 
 LOCALES = ["en-US", "es-ES", "ja", "de"]
 
@@ -1116,7 +1109,131 @@ class TestSavingTheVerificationGroup:
         )
         response = self.post(test_client, session, role_id="123")
         page = test_client.get(response.headers["Location"]).data.decode()
-        assert "no longer exists" in page or "couldn&#39;t be saved" in page
+        assert "isn&#39;t in this server any more" in page
+
+
+class TestSavingTheRemainingGroups:
+    def logged_in(self, config, store, **kwargs):
+        api = FakeBotAPI(**kwargs)
+        app = create_app(config, store=store, client=api)
+        app.config.update(TESTING=True)
+        test_client = app.test_client()
+        return test_client, api, login_as(test_client, store)
+
+    def post(self, test_client, session, group, **form):
+        form.setdefault("csrf_token", session.csrf_token)
+        return test_client.post(f"/guild/{GUILD_IN}/{group}", data=form)
+
+    # ----- after verifying -----
+    def test_the_custom_message_is_sent_exactly_as_typed(self, config, store):
+        """Sanitising here would be a second opinion about what is allowed."""
+        test_client, api, session = self.logged_in(config, store)
+        raw = "  Welcome @everyone!  \nhttps://vrchat.com/home  "
+        self.post(
+            test_client,
+            session,
+            "member",
+            custom_verification_requested_message=raw,
+        )
+        assert api.saves[-1][2]["custom_verification_requested_message"] == raw
+
+    def test_an_empty_message_is_sent_through_to_be_cleared(self, config, store):
+        test_client, api, session = self.logged_in(config, store)
+        self.post(
+            test_client, session, "member", custom_verification_requested_message=""
+        )
+        assert api.saves[-1][2]["custom_verification_requested_message"] == ""
+
+    def test_nickname_sync_uses_the_presence_marker(self, config, store):
+        test_client, api, session = self.logged_in(config, store)
+        self.post(
+            test_client,
+            session,
+            "member",
+            present_auto_nickname_change="1",
+        )
+        assert api.saves[-1][2]["auto_nickname_change"] is False
+
+    def test_a_form_without_the_nickname_control_leaves_it_alone(self, config, store):
+        test_client, api, session = self.logged_in(config, store)
+        self.post(
+            test_client, session, "member", custom_verification_requested_message="hi"
+        )
+        assert "auto_nickname_change" not in api.saves[-1][2]
+
+    @pytest.mark.parametrize(
+        "reason, expected",
+        [
+            ("message_links_not_allowed", "discord.com or vrchat.com"),
+            ("message_too_long", "1000 characters"),
+        ],
+    )
+    def test_a_message_refusal_is_explained(self, config, store, reason, expected):
+        test_client, _api, session = self.logged_in(
+            config, store, errors={"update_settings": BotAPIError(reason, 400)}
+        )
+        response = self.post(
+            test_client, session, "member", custom_verification_requested_message="x"
+        )
+        page = test_client.get(response.headers["Location"]).data.decode()
+        assert expected in page
+
+    def test_the_offending_links_are_never_echoed_back(self, config, store):
+        test_client, _api, session = self.logged_in(
+            config,
+            store,
+            errors={"update_settings": BotAPIError("message_links_not_allowed", 400)},
+        )
+        response = self.post(
+            test_client,
+            session,
+            "member",
+            custom_verification_requested_message="go to https://evil.example.com",
+        )
+        page = test_client.get(response.headers["Location"]).data.decode()
+        assert "evil.example.com" not in page
+
+    # ----- logging -----
+    def test_a_log_channel_is_sent(self, config, store):
+        test_client, api, session = self.logged_in(config, store)
+        self.post(
+            test_client, session, "logging", verification_log_channel_id=LOG_CHANNEL
+        )
+        assert api.saves[-1][2] == {"verification_log_channel_id": LOG_CHANNEL}
+
+    def test_an_empty_channel_selection_turns_logging_off(self, config, store):
+        test_client, api, session = self.logged_in(config, store)
+        self.post(test_client, session, "logging", verification_log_channel_id="")
+        assert api.saves[-1][2]["verification_log_channel_id"] is None
+
+    def test_the_announcement_refusal_explains_why(self, config, store):
+        test_client, _api, session = self.logged_in(
+            config,
+            store,
+            errors={"update_settings": BotAPIError("channel_is_announcement", 400)},
+        )
+        response = self.post(
+            test_client, session, "logging", verification_log_channel_id=NEWS_CHANNEL
+        )
+        page = test_client.get(response.headers["Location"]).data.decode()
+        assert "republish your members" in page
+
+    # ----- guards, on both -----
+    @pytest.mark.parametrize("group", ["member", "logging"])
+    def test_they_need_the_csrf_token(self, config, store, group):
+        test_client, api, _session = self.logged_in(config, store)
+        response = test_client.post(
+            f"/guild/{GUILD_IN}/{group}",
+            data={"csrf_token": "wrong", "verification_log_channel_id": LOG_CHANNEL},
+        )
+        assert response.status_code == 400
+        assert api.saves == []
+
+    @pytest.mark.parametrize("group", ["member", "logging"])
+    def test_a_signed_out_visitor_cannot_save(self, client, bot_api, group):
+        response = client.post(f"/guild/{GUILD_IN}/{group}", data={})
+        assert response.status_code == 302
+        assert not getattr(bot_api, "saves", [])
 
 
 class TestTheFormMatchesWhatTheBotAccepts:
@@ -1161,6 +1278,37 @@ class TestTheFormMatchesWhatTheBotAccepts:
             assert f'value="{code}"' in page
         # Present in LOCALE_NAMES, absent from what the bot offered.
         assert 'value="pa-IN"' not in page
+
+    def test_announcement_channels_are_not_offered_at_all(self, config, store):
+        """Unlike an unassignable role, the bot refuses these outright.
+
+        So leaving them out of the picker is matching the bot rather than being
+        stricter than it -- the opposite call from the role list, for the
+        opposite reason.
+        """
+        test_client, _api = settings_client(
+            config, store, settings=make_settings(premium=True)
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert f'value="{LOG_CHANNEL}"' in page
+        assert f'value="{NEWS_CHANNEL}"' not in page
+
+    def test_a_channel_picker_with_nothing_to_pick_is_not_offered(self, config, store):
+        test_client, _api = settings_client(
+            config,
+            store,
+            settings=make_settings(premium=True),
+            errors={"channels": BotAPIError("unavailable", 503)},
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert 'name="verification_log_channel_id"' not in page
+
+    def test_the_custom_message_textarea_carries_the_bot_s_cap(self, config, store):
+        test_client, _api = settings_client(
+            config, store, settings=make_settings(premium=True)
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert 'maxlength="1000"' in page
 
     def test_every_form_carries_a_csrf_token(self, config, store):
         test_client, _api = settings_client(
@@ -1329,7 +1477,7 @@ class TestSettingsViewModel:
 class TestWriteSurface:
     """Step 5 opens exactly one save path. Widening it means editing this."""
 
-    def test_the_post_routes_are_logout_and_the_two_group_saves(self, app):
+    def test_the_post_routes_are_logout_and_one_save_per_group(self, app):
         posts = {
             rule.rule
             for rule in app.url_map.iter_rules()
@@ -1337,9 +1485,19 @@ class TestWriteSurface:
         }
         assert posts == {
             "/logout",
-            "/guild/<int:guild_id>/panel",
             "/guild/<int:guild_id>/verification",
+            "/guild/<int:guild_id>/member",
+            "/guild/<int:guild_id>/panel",
+            "/guild/<int:guild_id>/logging",
         }, f"an unexpected write route appeared: {posts}"
+
+    def test_every_group_that_saves_names_a_route_that_exists(self, app, config):
+        """A typo in `save_endpoint` would be a 500 on page load, not a test."""
+        groups = settings_view.build_groups(make_settings(premium=True), DEFAULT_ROLES, DEFAULT_CHANNELS)
+        endpoints = {rule.endpoint for rule in app.url_map.iter_rules()}
+        for group in groups:
+            if group.get("save_endpoint"):
+                assert group["save_endpoint"] in endpoints
 
     def test_the_dashboard_holds_no_database_credential(self):
         """A compromise of the public host must not reach the users table."""


### PR DESCRIPTION
Nickname sync, the custom verification DM, and the log channel. **Every setting the slash commands can change, the website can now change.**

Branched from `main` after #76 — no stacking this time.

## The custom DM reuses the bot's sanitiser

`sanitize_custom_message()` is the bot's own function, not a second implementation. It strips zero-width characters, defuses `@everyone`/`@here`, and allows links only to discord.com and vrchat.com.

This text is delivered to members by DM, so a reimplementation that drifted would be a way to say things through the bot that the bot's own command refuses to say. The **sanitised** text is what gets stored — passing the check and then saving the original would be worse than no check.

The 1000-character cap and the words that clear it (`clear`/`reset`/`none`/`default`) are the modal's, for the same reason: a website storing a literal `"none"` would hold a value the slash command cannot set.

## Two opposite calls, for the same reason

| | in the picker? | why |
|---|---|---|
| a role the bot can't assign | **offered**, with a warning | `/vrcverify_setup` accepts it, so refusing would be stricter than the bot |
| an announcement channel | **omitted** | `/vrcverify_logchannel` refuses it outright, so omitting is matching the bot |

Both follow the same rule — mirror the slash command — and land in opposite places.

`/vrcverify_logchannel` confirms by posting into the channel, which doubles as a permission check. The dashboard refuses on `can_send` instead: a settings save shouldn't put a message in a channel as a side effect, and the bot already computes that answer for the settings page.

## Refusals name the rule, never the input

A message rejected for its links is explained as "links may only point to discord.com or vrchat.com" rather than by listing them back. The admin is looking at their own message, and the page stays free of text that arrived in a request. There's a test asserting the offending URL never reaches the HTML.

## The phase pin changed shape

`DASHBOARD_WRITABLE_FIELDS` is now asserted **equal** to `{f.name for f in SETTINGS_FIELDS}` rather than listed against what's still closed. Adding a setting to the bot fails that test until someone decides whether the website may set it.

## Tests

1000, up from 966.