### PR TITLE
Post the panel, read the history, and stop Discord silently discarding both

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -193,6 +193,15 @@ LOG_LEVEL=INFO
 # BOT_API_RATE_LIMIT=60
 # BOT_API_RATE_WINDOW=60
 # BOT_API_GLOBAL_RATE_LIMIT=600
+#
+# Budgets for the two routes that CHANGE something, charged on top of the two
+# above and deliberately far smaller. A GET is answered from the gateway cache
+# and costs Discord nothing; saving a setting or posting a panel turns into
+# real Discord REST calls against the same account-wide budget verification
+# runs on. Ten a minute is already more than a human configuring a server
+# needs, so raise these only if real admins are actually hitting them.
+# BOT_API_WRITE_RATE_LIMIT=10
+# BOT_API_GLOBAL_WRITE_RATE_LIMIT=60
 
 # --- docker-compose.deploy.yml only (not read by bot.py directly) ---
 # Pinned image tag to deploy; docker-compose.deploy.yml refuses to run

--- a/README.md
+++ b/README.md
@@ -288,7 +288,8 @@ socket and the bot behaves exactly as it did before this existed.
 
 When it *is* enabled, it runs inside the bot process (sharing the gateway
 cache, so it can answer questions about roles, channels and permissions without
-a second copy of anything) and serves read-only settings data to the dashboard.
+a second copy of anything), answers the dashboard's questions about a guild's
+settings, and accepts the two changes it is allowed to make to them.
 Three independent checks guard every request:
 
 1. **mTLS** against a private CA — see `scripts/gen_bot_api_certs.sh`. The
@@ -317,9 +318,17 @@ Deployment rules, all enforced or explained in `.env.example`:
 - A misconfiguration stops the API, never the bot. Verification keeps working
   through an expired dashboard certificate; the log says so at `ERROR`.
 
-This phase is **read-only by construction**: the API is handed a set of reader
-callables and nothing else, so it cannot express a write at all.
-`tests/test_bot_api.py` pins both that and the absence of any non-GET route.
+The API's authority is **a set of named capabilities, not a database handle**:
+`BotAPIDeps` holds eleven callables, nine of which only read or check, and
+exactly two that change anything — `write_settings` and `post_panel`. There is
+no generic column setter, so widening what the website
+can do to a server means adding a named capability here — a reviewable diff,
+not a query string nobody noticed. `tests/test_bot_api.py` pins the exact
+membership of that set and that no third mutating route exists.
+
+(Through step 4 this was read-only by construction, with no writers at all.
+Step 5 added the two above deliberately; the control was never "no writers
+ever", it was "a writer cannot appear by accident".)
 
 ### The dashboard itself
 
@@ -369,14 +378,26 @@ twice by accident the main hazard, so the bot decides what a request means:
 - the panel is recorded elsewhere → **move**: post the new one, re-point the
   ids, and tell the admin where the old one still is. Deleting it would be this
   code destroying a message nobody pointed at.
+- the panel is there but Discord **won't let the bot edit it** → **replace**:
+  post a new one, then delete the old. A panel posted as a slash-command reply
+  belongs to a webhook, and Discord answers 200 to an embed edit on one of
+  those and keeps the old embed — so its text can never be corrected, and
+  refreshing it again is a silent no-op. This is the one case that deletes, and
+  it is the opposite of the move above for a reason: a move leaves the old
+  panel alone in a different channel, where it is still the only panel there,
+  while this one would sit directly above its replacement with live buttons and
+  text nothing can fix. The delete is bounded to the message id the bot itself
+  recorded, and only runs once the replacement is up and saved.
 - the recorded location **cannot be read** → post nothing. That is the case
   where "no panel exists" and "the database blinked" look identical.
 
-The write path adds one route on each side, and both are pinned by tests:
+The write path adds two routes on the bot, and both are pinned by tests —
+`TestWriteSurfaceIsExactlyTwoThings` asserts there are no others:
 
-- `PATCH /api/v1/guilds/{id}/settings` on the bot, the only non-GET route.
-  Because the signed operation includes the **method**, a token minted to read
-  a guild's settings cannot be replayed to write them.
+- `PATCH /api/v1/guilds/{id}/settings` and `POST /api/v1/guilds/{id}/panel`,
+  the only non-GET routes. Because the signed operation includes the
+  **method and path**, a token minted to read a guild's settings cannot be
+  replayed to write them, or to post its panel.
 - One `POST` per group on the dashboard, behind a CSRF token and a
   `SameSite=Lax` cookie — though the check that matters is the bot's, which
   re-runs Administrator, re-runs the plan gate, and validates every value

--- a/README.md
+++ b/README.md
@@ -377,6 +377,13 @@ deletes a row in that table: an audit trail exists to disagree with someone's
 account of events, which it cannot do if the code that made the change can
 rewrite the record of it.
 
+The settings page shows that history back — ids resolved to names, an actor
+who has since left the server shown by id rather than dropped. It covers
+changes made **from the website only**; slash commands are not recorded, and
+the page says so rather than implying the list is everything that ever
+happened. An unreadable trail renders as "couldn't load", never as "no changes
+have been made" — those are different facts and only one of them is reassuring.
+
 Two rules the settings page exists to honour:
 
 - **It mirrors the bot field for field, including the inconsistencies.** Some

--- a/README.md
+++ b/README.md
@@ -359,6 +359,19 @@ channels read fails, the field falls back to read-only — an empty `<select>`
 invites a save that would clear the verified role and stop verification for the
 whole server.
 
+It can also **post the instructions panel** into a channel — the one thing the
+dashboard makes the bot *do* in a server rather than store. That makes doing it
+twice by accident the main hazard, so the bot decides what a request means:
+
+- the panel is already in the chosen channel → **refresh** it, the same
+  one-call edit the fleet sweep uses. A double-click costs an edit, not a
+  second panel with live buttons that nothing tracks.
+- the panel is recorded elsewhere → **move**: post the new one, re-point the
+  ids, and tell the admin where the old one still is. Deleting it would be this
+  code destroying a message nobody pointed at.
+- the recorded location **cannot be read** → post nothing. That is the case
+  where "no panel exists" and "the database blinked" look identical.
+
 The write path adds one route on each side, and both are pinned by tests:
 
 - `PATCH /api/v1/guilds/{id}/settings` on the bot, the only non-GET route.

--- a/src/api_tokens.py
+++ b/src/api_tokens.py
@@ -43,6 +43,8 @@ OP_GUILD_AUDIT = "GET /api/v1/guilds/{guild_id}/audit"
 # The method is part of the operation, so a token minted to read a guild's
 # settings cannot be replayed to write them.
 OP_UPDATE_SETTINGS = "PATCH /api/v1/guilds/{guild_id}/settings"
+# An action, not a setting: it makes the bot post in a server.
+OP_POST_PANEL = "POST /api/v1/guilds/{guild_id}/panel"
 
 # Tokens are minted per request and used immediately. Thirty seconds is
 # generous for a call across a tunnel and short enough that a captured token is

--- a/src/api_tokens.py
+++ b/src/api_tokens.py
@@ -39,6 +39,7 @@ OP_GUILD_SETTINGS = "GET /api/v1/guilds/{guild_id}/settings"
 OP_GUILD_ROLES = "GET /api/v1/guilds/{guild_id}/roles"
 OP_GUILD_CHANNELS = "GET /api/v1/guilds/{guild_id}/channels"
 OP_GUILD_PANEL = "GET /api/v1/guilds/{guild_id}/panel"
+OP_GUILD_AUDIT = "GET /api/v1/guilds/{guild_id}/audit"
 # The method is part of the operation, so a token minted to read a guild's
 # settings cannot be replayed to write them.
 OP_UPDATE_SETTINGS = "PATCH /api/v1/guilds/{guild_id}/settings"

--- a/src/bot.py
+++ b/src/bot.py
@@ -4923,6 +4923,12 @@ async def read_dashboard_channels(guild_id) -> Optional[list]:
     for the verification log: other servers can *follow* it, which would
     republish an age disclosure about a named member into servers they have no
     relationship with.
+
+    `can_send` and `can_embed` are separate because the two things this bot
+    posts need different permissions. The verification log is plain text, so
+    Send Messages is the whole requirement. The instructions panel is an embed,
+    and a channel granting one permission but not the other looks perfectly
+    writable right up until the panel is refused.
     """
     try:
         guild = bot.get_guild(int(guild_id))
@@ -4934,9 +4940,11 @@ async def read_dashboard_channels(guild_id) -> Optional[list]:
         for channel in guild.text_channels:
             if me is None:
                 can_send = None
+                can_embed = None
             else:
                 perms = channel.permissions_for(me)
                 can_send = bool(perms.view_channel and perms.send_messages)
+                can_embed = bool(can_send and perms.embed_links)
             channels.append(
                 {
                     "id": str(channel.id),
@@ -4945,6 +4953,7 @@ async def read_dashboard_channels(guild_id) -> Optional[list]:
                     "position": channel.position,
                     "is_news": bool(channel.is_news()),
                     "can_send": can_send,
+                    "can_embed": can_embed,
                 }
             )
         channels.sort(key=lambda entry: entry["position"])
@@ -4971,6 +4980,10 @@ async def read_dashboard_panel(guild_id) -> Optional[dict]:
     requirement — editing the bot's own message needs no Send Messages, and
     button clicks are interactions rather than messages. A panel sitting in a
     locked channel is the normal case, not a broken one.
+
+    It includes Embed Links, because the panel IS an embed. A channel with Send
+    Messages and no Embed Links reads as writable everywhere else and then
+    refuses the panel, which is a confusing way to find that out.
     """
     try:
         entry = load_instruction_panel(guild_id)
@@ -4988,7 +5001,9 @@ async def read_dashboard_panel(guild_id) -> Optional[dict]:
         postable = None
         if guild is not None and guild.me is not None and channel is not None:
             perms = channel.permissions_for(guild.me)
-            postable = bool(perms.view_channel and perms.send_messages)
+            postable = bool(
+                perms.view_channel and perms.send_messages and perms.embed_links
+            )
 
         return {
             "posted": True,

--- a/src/bot.py
+++ b/src/bot.py
@@ -785,6 +785,10 @@ CUSTOM_MESSAGE_MAX_LEN = 1000
 # a value the slash command has no way to set.
 CUSTOM_MESSAGE_CLEARING = frozenset({"clear", "reset", "none", "default"})
 
+# How much history one call may ask for. The page shows a recent slice, not an
+# export -- an admin wanting the whole thing has the database.
+MAX_AUDIT_ROWS = 50
+
 
 # Raised by the writer below, mapped to a status by bot_api. It lives over
 # there because it is the contract between the two halves, not a detail of
@@ -4922,6 +4926,56 @@ async def read_dashboard_panel(guild_id) -> Optional[dict]:
         return None
 
 
+async def read_dashboard_audit(guild_id, limit: int = 25) -> Optional[list]:
+    """This guild's recent settings changes, newest first.
+
+    Only ever this guild's, and only the fields SETTINGS_FIELDS names -- an
+    admin can see who changed their own server's configuration, which is what
+    an audit trail is for, and nothing about any other server.
+
+    Actor names are resolved from the gateway cache when the member is still
+    around, and left as an id when they are not. No REST call: an admin who
+    left is exactly the entry worth keeping, and paying a fetch per row to
+    prettify history would make this the most expensive read on the page.
+    """
+    try:
+        guild = bot.get_guild(int(guild_id))
+        with session_scope() as session:
+            rows = (
+                session.query(DashboardAudit)
+                .filter_by(server_id=panel_view_key(guild_id))
+                .order_by(DashboardAudit.id.desc())
+                .limit(max(1, min(int(limit), MAX_AUDIT_ROWS)))
+                .all()
+            )
+            entries = []
+            for row in rows:
+                member = None
+                if guild is not None:
+                    try:
+                        member = guild.get_member(int(row.actor_id))
+                    except (TypeError, ValueError):
+                        member = None
+                entries.append(
+                    {
+                        "actor_id": row.actor_id,
+                        "actor_name": getattr(member, "display_name", None),
+                        "field": row.field,
+                        "old_value": row.old_value,
+                        "new_value": row.new_value,
+                        "changed_at": (
+                            row.changed_at.isoformat() if row.changed_at else None
+                        ),
+                    }
+                )
+            return entries
+    except Exception:
+        logger.warning(
+            "Could not read the audit trail for guild %s.", guild_id, exc_info=True
+        )
+        return None
+
+
 def _record_dashboard_audit(session, guild_id, actor_id, changed: list) -> None:
     """Append one row per field that actually moved.
 
@@ -5133,6 +5187,7 @@ def build_bot_api_deps() -> bot_api.BotAPIDeps:
         read_roles=read_dashboard_roles,
         read_channels=read_dashboard_channels,
         read_panel=read_dashboard_panel,
+        read_audit=read_dashboard_audit,
         write_settings=write_dashboard_settings,
     )
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -415,6 +415,16 @@ class DashboardAudit(Base):
     member data, no VRChat identity, nothing about who is verified — this table
     is about administrators changing configuration, and it should stay boring
     enough that its own disclosure would not matter much.
+
+    **What this trail does not cover.** The actor comes from verified token
+    claims, which makes it trustworthy exactly as far as the signing key is. The
+    dashboard host holds that key, and the design elsewhere says to assume that
+    host is eventually compromised — so an attacker at VPS level can mint a
+    token naming any actor, including a guild's owner, and every row they cause
+    will name that person. This table detects a stolen *session*; against a
+    compromised dashboard it does not merely fail to detect, it actively
+    misattributes. Reading a row as proof a particular human did something is
+    only sound while the key is sound.
     """
 
     __tablename__ = "dashboard_audit"
@@ -3208,7 +3218,9 @@ async def vrcverify_instructions(interaction: discord.Interaction):
             # ids on the floor: the panel went up but nothing tracked it, so the
             # startup refresh never saw it and /vrcverify_status would call it
             # missing. Create the row like the settings view does instead.
-            server = Server(server_id=guild_id, owner_id=str(interaction.user.id))
+            server = Server(
+                server_id=guild_id, owner_id=panel_row_owner_id(interaction.guild, interaction.user.id)
+            )
             session.add(server)
         server.instructions_channel_id = channel_id
         server.instructions_message_id = str(message.id)
@@ -4158,6 +4170,23 @@ class RequestPacer:
         delay = slot - now
         if delay > 0:
             await asyncio.sleep(delay)
+
+
+def panel_row_owner_id(guild, actor_id) -> str:
+    """`owner_id` for a servers row created by posting a panel.
+
+    The guild's real owner when the bot can see one, not whoever clicked. That
+    column feeds resolve_config_admin, which decides who gets configuration DMs
+    — so filling it with the acting admin quietly appoints them, and on the
+    dashboard that admin need not be the owner at all. Both panel paths use
+    this, so the two cannot drift.
+
+    Falls back to the actor only when the guild is not in cache, which is the
+    same guess the code made unconditionally before, and still better than a
+    NOT NULL violation that would lose the panel's ids.
+    """
+    owner_id = getattr(guild, "owner_id", None) if guild is not None else None
+    return str(owner_id or actor_id)
 
 
 def panel_view_key(server_id) -> str:
@@ -5237,9 +5266,18 @@ async def _post_dashboard_panel(guild_id, actor_id, channel_id):
                 .first()
             )
             if server is None:
-                # Same reasoning as /vrcverify_instructions: the panel is up, so
-                # something has to track it or the startup refresh never sees it.
-                server = Server(server_id=str(guild_id), owner_id=str(actor_id))
+                # Same reasoning as /vrcverify_instructions, and deliberately
+                # the opposite of write_dashboard_settings, which refuses with
+                # server_not_set_up rather than insert. The difference is not an
+                # oversight: a settings save has nothing to record if it
+                # refuses, while by this point a message is already live in
+                # someone's server and something has to track it or the startup
+                # refresh never sees it again. Mirroring the slash command is
+                # also the rule -- /vrcverify_instructions inserts here too.
+                server = Server(
+                    server_id=str(guild_id),
+                    owner_id=panel_row_owner_id(guild, actor_id),
+                )
                 session.add(server)
             server.instructions_channel_id = str(channel.id)
             server.instructions_message_id = str(message.id)

--- a/src/bot.py
+++ b/src/bot.py
@@ -3165,13 +3165,37 @@ async def vrcverify_instructions(interaction: discord.Interaction):
     embed = build_instructions_embed(instr_locale, panel_color, panel_icon)
 
     view = VRCVerifyInstructionView(locale=instr_locale)
-    # Send the initial response and then fetch the message
-    await interaction.response.send_message(embed=embed, view=view)
-    message = await interaction.original_response()
+    # An ordinary channel message, NOT this command's reply. A reply is owned by
+    # a webhook, and Discord answers 200 to an embed edit on a webhook-owned
+    # message and then keeps the old embed -- only the components change. Panels
+    # posted as the reply could therefore never be restyled or translated again:
+    # a language change came out as new button labels above the old text. The
+    # refresh path is the whole point of tracking the panel, so the panel has to
+    # be something the bot can actually edit.
+    await interaction.response.defer(ephemeral=True)
+    channel = interaction.channel
+    try:
+        message = await channel.send(embed=embed, view=view)
+    except discord.Forbidden:
+        await interaction.followup.send(
+            "I can't post in this channel. Give VRCVerify **Send Messages** and "
+            "**Embed Links** here, then run this again.",
+            ephemeral=True,
+        )
+        return
+    except Exception:
+        logger.exception(
+            "Failed to post the instructions panel for guild %s", interaction.guild.id
+        )
+        await interaction.followup.send(
+            "Something went wrong posting the panel. Please try again shortly.",
+            ephemeral=True,
+        )
+        return
 
     # Save the channel and message IDs to your database for reinitialization.
     guild_id = str(interaction.guild.id)
-    channel_id = str(interaction.channel.id)
+    channel_id = str(channel.id)
     with session_scope() as session:
         server = session.query(Server).filter_by(server_id=guild_id).first()
         if not server:
@@ -4990,6 +5014,37 @@ def _stored_panel_location(guild_id):
         }
 
 
+async def _panel_is_webhook_owned(channel, message_id) -> Optional[bool]:
+    """Whether this panel is a message the bot cannot fully edit.
+
+    A panel posted as a slash-command reply belongs to a webhook. Discord takes
+    an embed edit on one of those, answers 200, and keeps the old embed -- only
+    the components change. So such a panel can never be restyled or translated,
+    however many times it is refreshed, and the only repair is a replacement.
+
+    None means the question could not be answered, which must never be read as
+    "no": replacing a panel on a failed lookup is how a server ends up with two.
+    A message that is simply gone answers False, because the ordinary refresh
+    path already knows how to notice that and post afresh.
+    """
+    try:
+        message = await channel.fetch_message(int(message_id))
+    except discord.NotFound:
+        return False
+    except (TypeError, ValueError):
+        return False
+    except Exception:
+        logger.warning(
+            "Could not read panel message %s in guild's channel %s while "
+            "checking whether it can be edited.",
+            message_id,
+            getattr(channel, "id", None),
+            exc_info=True,
+        )
+        return None
+    return message.webhook_id is not None
+
+
 async def post_dashboard_panel(guild_id, actor_id, channel_id):
     """Put this guild's instructions panel where the admin asked for it.
 
@@ -5030,25 +5085,37 @@ async def post_dashboard_panel(guild_id, actor_id, channel_id):
         )
         return None
 
-    # --- Already there: refresh in place ---
+    # --- Already there: refresh in place, or replace it if editing cannot work ---
     # No permission precheck on this branch. Editing the bot's own message does
     # not need Send Messages, so a panel parked in a locked channel refreshes
     # fine -- the fleet sweep does exactly this on every restart without asking.
     # probe_instruction_panel's Forbidden branch is the honest answer, the same
     # reasoning its own docstring gives for /vrcverify_status.
+    replacing = None
     if existing and str(existing.get("channel_id")) == str(channel.id):
-        outcome = await probe_instruction_panel(existing, rebuild_embed=True)
-        if outcome == "ok":
-            _audit_panel(guild_id, actor_id, "refreshed", channel.id)
-            return {"action": "refreshed", "channel_id": str(channel.id)}
-        if outcome in {"gone", "missing_ids", "malformed"}:
-            # The record points at a message that is not there any more, so
-            # this is a first post rather than a duplicate.
-            existing = None
-        elif outcome == "forbidden":
-            raise SettingRejected("panel_channel", "channel_not_writable")
-        else:
+        stuck = await _panel_is_webhook_owned(channel, existing.get("message_id"))
+        if stuck is None:
             return None
+        if stuck:
+            # No edit will ever change this panel's text, so refreshing it would
+            # be the silent no-op that hid this for so long. Post a replacement
+            # and delete the original below. Cleared so the post path reads this
+            # as a fresh post rather than a move to a different channel.
+            replacing = existing
+            existing = None
+        else:
+            outcome = await probe_instruction_panel(existing, rebuild_embed=True)
+            if outcome == "ok":
+                _audit_panel(guild_id, actor_id, "refreshed", channel.id)
+                return {"action": "refreshed", "channel_id": str(channel.id)}
+            if outcome in {"gone", "missing_ids", "malformed"}:
+                # The record points at a message that is not there any more, so
+                # this is a first post rather than a duplicate.
+                existing = None
+            elif outcome == "forbidden":
+                raise SettingRejected("panel_channel", "channel_not_writable")
+            else:
+                return None
 
     # --- Post a new one ---
     # Now it really is a send, so the send permissions are now the right test.
@@ -5094,9 +5161,30 @@ async def post_dashboard_panel(guild_id, actor_id, channel_id):
 
     record_panel_view_version(guild_id)
     complete_guild_onboarding(guild_id)
-    _audit_panel(guild_id, actor_id, "moved" if previous else "posted", channel.id)
+
+    # The replaced panel is deleted rather than left up, unlike the one a move
+    # leaves behind. A move puts the new panel somewhere else, so the old one is
+    # still the only panel in its own channel and removing it is the admin's
+    # call; this one sits directly above its replacement in the same channel,
+    # with live buttons and text nothing can ever correct.
+    if replacing:
+        try:
+            await channel.get_partial_message(
+                int(replacing["message_id"])
+            ).delete()
+        except Exception:
+            logger.warning(
+                "Replaced the panel for guild %s but could not delete the old "
+                "message %s.",
+                guild_id,
+                replacing.get("message_id"),
+                exc_info=True,
+            )
+
+    action = "replaced" if replacing else ("moved" if previous else "posted")
+    _audit_panel(guild_id, actor_id, action, channel.id)
     return {
-        "action": "moved" if previous else "posted",
+        "action": action,
         "channel_id": str(channel.id),
         "previous_channel_id": previous,
     }

--- a/src/bot.py
+++ b/src/bot.py
@@ -4893,6 +4893,12 @@ async def read_dashboard_panel(guild_id) -> Optional[dict]:
     returns None both for "never posted" and for "the database could not be
     read", so `posted: false` is not proof no panel exists — whatever offers to
     repost a panel in step 6 has to confirm before it posts a duplicate.
+
+    `channel_postable` answers one narrow question: could a NEW message go here.
+    It is not "can this panel be kept alive", which is a different and weaker
+    requirement — editing the bot's own message needs no Send Messages, and
+    button clicks are interactions rather than messages. A panel sitting in a
+    locked channel is the normal case, not a broken one.
     """
     try:
         entry = load_instruction_panel(guild_id)
@@ -4907,10 +4913,10 @@ async def read_dashboard_panel(guild_id) -> Optional[dict]:
             except (TypeError, ValueError):
                 channel = None
 
-        reachable = None
+        postable = None
         if guild is not None and guild.me is not None and channel is not None:
             perms = channel.permissions_for(guild.me)
-            reachable = bool(perms.view_channel and perms.send_messages)
+            postable = bool(perms.view_channel and perms.send_messages)
 
         return {
             "posted": True,
@@ -4918,7 +4924,7 @@ async def read_dashboard_panel(guild_id) -> Optional[dict]:
             "message_id": str(entry["message_id"]),
             "channel_name": getattr(channel, "name", None),
             "channel_exists": channel is not None,
-            "channel_reachable": reachable,
+            "channel_postable": postable,
             "locale": entry.get("locale", "en-US"),
         }
     except Exception:
@@ -4980,9 +4986,6 @@ async def post_dashboard_panel(guild_id, actor_id, channel_id):
     )
     if channel is None:
         raise SettingRejected("panel_channel", "channel_not_in_guild")
-    perms = channel.permissions_for(guild.me)
-    if not (perms.view_channel and perms.send_messages and perms.embed_links):
-        raise SettingRejected("panel_channel", "channel_not_writable")
 
     try:
         existing = _stored_panel_location(guild_id)
@@ -4995,6 +4998,11 @@ async def post_dashboard_panel(guild_id, actor_id, channel_id):
         return None
 
     # --- Already there: refresh in place ---
+    # No permission precheck on this branch. Editing the bot's own message does
+    # not need Send Messages, so a panel parked in a locked channel refreshes
+    # fine -- the fleet sweep does exactly this on every restart without asking.
+    # probe_instruction_panel's Forbidden branch is the honest answer, the same
+    # reasoning its own docstring gives for /vrcverify_status.
     if existing and str(existing.get("channel_id")) == str(channel.id):
         outcome = await probe_instruction_panel(existing, rebuild_embed=True)
         if outcome == "ok":
@@ -5010,6 +5018,11 @@ async def post_dashboard_panel(guild_id, actor_id, channel_id):
             return None
 
     # --- Post a new one ---
+    # Now it really is a send, so the send permissions are now the right test.
+    perms = channel.permissions_for(guild.me)
+    if not (perms.view_channel and perms.send_messages and perms.embed_links):
+        raise SettingRejected("panel_channel", "channel_not_writable")
+
     style = await resolve_panel_style(guild_id, guild)
     color, icon = style if style else (DEFAULT_PANEL_COLOR, None)
     locale = get_server_locale_code(guild_id, guild)

--- a/src/bot.py
+++ b/src/bot.py
@@ -785,6 +785,11 @@ PANEL_VISIBLE_FIELDS = frozenset(
     {"instructions_locale", "panel_embed_color", "panel_show_icon"}
 )
 
+# Outcomes of the post-save restyle that mean "stored, but the live panel does
+# not show it". The save is still a success; the admin just needs telling, or
+# they are looking at a panel that silently disagrees with their settings.
+PANEL_STALE_OUTCOMES = frozenset({"frozen", "style_unreadable", "forbidden", "error"})
+
 # The modal's own cap, so the website cannot store a message the slash command
 # could not have produced.
 CUSTOM_MESSAGE_MAX_LEN = 1000
@@ -4406,7 +4411,9 @@ def build_instructions_embed(
     return embed
 
 
-async def probe_instruction_panel(entry, rebuild_embed: bool) -> str:
+async def probe_instruction_panel(
+    entry, rebuild_embed: bool, already_checked: bool = False
+) -> str:
     """Re-attach a fresh view (and optionally a rebuilt embed) to one saved panel.
 
     Uses a partial message so this costs exactly one API call and needs nothing
@@ -4440,11 +4447,23 @@ async def probe_instruction_panel(entry, rebuild_embed: bool) -> str:
             # Discord answers 200 to an embed edit on one while keeping the old
             # embed. The view would still apply, so editing anyway is precisely
             # the half-update that hid this bug -- new button labels above text
-            # nothing can change. Costs one fetch, and only on the paths that
-            # rebuild the embed; the fleet sweep never gets here. A read that
-            # fails answers None and falls through to the edit, because a fetch
-            # hiccup must not start refusing ordinary refreshes.
-            if await _panel_is_webhook_owned(messageable, message_id):
+            # nothing can change.
+            #
+            # It costs one fetch, on the paths that rebuild the embed. That is
+            # the startup sweep's exemption (it passes rebuild_embed=False) but
+            # NOT the manual whole-fleet refresh, which passes True and so pays
+            # it per panel -- worth knowing before raising
+            # INSTRUCTIONS_REFRESH_RATE, since the pacer reserves one slot per
+            # panel and each now issues two calls.
+            #
+            # `already_checked` is how the dashboard's panel button avoids
+            # asking twice; it has just asked in order to decide between
+            # refreshing and replacing. A read that fails answers None and falls
+            # through to the edit, because a fetch hiccup must not start
+            # refusing ordinary refreshes.
+            if not already_checked and await _panel_is_webhook_owned(
+                messageable, message_id
+            ):
                 logger.warning(
                     "⚠️ The instructions panel for guild %s cannot be edited by "
                     "Discord (it was posted as a command reply). It has to be "
@@ -5075,8 +5094,37 @@ async def _panel_is_webhook_owned(channel, message_id) -> Optional[bool]:
     return message.webhook_id is not None
 
 
+# One lock per guild that has ever used the panel button. The duplicate guard
+# below reads the recorded location and then suspends three times before it
+# writes a new one, so two overlapping requests -- a double click is enough --
+# would both see "no panel here" and both post one. The whole promise of this
+# function is that clicking twice cannot do that.
+_panel_post_locks: dict[str, asyncio.Lock] = {}
+
+
+def _panel_post_lock(guild_id) -> asyncio.Lock:
+    key = panel_view_key(guild_id)
+    lock = _panel_post_locks.get(key)
+    if lock is None:
+        # setdefault, not assignment: two coroutines reaching here in the same
+        # tick must end up holding the same lock, or it guards nothing.
+        lock = _panel_post_locks.setdefault(key, asyncio.Lock())
+    return lock
+
+
 async def post_dashboard_panel(guild_id, actor_id, channel_id):
     """Put this guild's instructions panel where the admin asked for it.
+
+    Serialised per guild -- see `_panel_post_lock`. Everything below reads a
+    recorded location and acts on it across several awaits, which is only safe
+    if one request per guild is doing it at a time.
+    """
+    async with _panel_post_lock(guild_id):
+        return await _post_dashboard_panel(guild_id, actor_id, channel_id)
+
+
+async def _post_dashboard_panel(guild_id, actor_id, channel_id):
+    """The body of the above, holding the guild's panel lock.
 
     The only thing the dashboard can make the bot *do* in a server, as opposed
     to store, so it is deliberately hard to do twice by accident:
@@ -5134,7 +5182,11 @@ async def post_dashboard_panel(guild_id, actor_id, channel_id):
             replacing = existing
             existing = None
         else:
-            outcome = await probe_instruction_panel(existing, rebuild_embed=True)
+            # already_checked: `stuck` is False, so probe must not re-fetch the
+            # message just to reach the same answer.
+            outcome = await probe_instruction_panel(
+                existing, rebuild_embed=True, already_checked=True
+            )
             if outcome == "ok":
                 _audit_panel(guild_id, actor_id, "refreshed", channel.id)
                 return {"action": "refreshed", "channel_id": str(channel.id)}
@@ -5155,7 +5207,13 @@ async def post_dashboard_panel(guild_id, actor_id, channel_id):
 
     style = await resolve_panel_style(guild_id, guild)
     color, icon = style if style else (DEFAULT_PANEL_COLOR, None)
-    locale = get_server_locale_code(guild_id, guild)
+    # panel_view_key, like every other lookup in this function. This is the one
+    # helper here that queries server_id un-normalised, and the deployed column
+    # disagrees with its declared type -- see panel_view_key's docstring. A
+    # mismatch there is swallowed, so the panel would silently go up in the
+    # guild's Discord language and be rewritten to the configured one on the
+    # next refresh.
+    locale = get_server_locale_code(panel_view_key(guild_id), guild)
     embed = build_instructions_embed(locale, color, icon)
 
     try:
@@ -5168,7 +5226,9 @@ async def post_dashboard_panel(guild_id, actor_id, channel_id):
         logger.exception("Failed to post the instructions panel for %s", guild_id)
         return None
 
-    previous = str(existing["channel_id"]) if existing else None
+    # A row with a message id but no channel id would otherwise report the
+    # string "None" as the previous channel, and call this a move.
+    previous = str(existing["channel_id"]) if existing and existing.get("channel_id") else None
     try:
         with session_scope() as session:
             server = (
@@ -5184,9 +5244,22 @@ async def post_dashboard_panel(guild_id, actor_id, channel_id):
             server.instructions_channel_id = str(channel.id)
             server.instructions_message_id = str(message.id)
     except Exception:
-        # The message is already posted; failing to record it would leave an
-        # untracked panel, which is worse than saying the save half-failed.
         logger.exception("Posted a panel for %s but could not record it", guild_id)
+        # Take it back down. An unrecorded panel has live verification buttons
+        # and nothing that can ever refresh, restyle or find it again, and the
+        # admin is about to see a failure and click again -- which would add
+        # another. Deleting the bot's own just-sent message is the one cleanup
+        # here that cannot destroy anything an admin put there.
+        try:
+            await message.delete()
+        except Exception:
+            logger.warning(
+                "Could not remove the unrecorded panel %s in guild %s; it is "
+                "live and untracked and has to be deleted by hand.",
+                message.id,
+                guild_id,
+                exc_info=True,
+            )
         return None
 
     record_panel_view_version(guild_id)
@@ -5484,10 +5557,18 @@ async def write_dashboard_settings(guild_id, actor_id, changes: dict):
     # rebuilds the view but not the embed. Only after the write, and never in a
     # way that can fail the save: restyle_instruction_panel swallows its own
     # errors and answers "no_panel" for the guilds that have none.
+    panel_outcome = None
     if any(name in PANEL_VISIBLE_FIELDS for name, _old, _new in changed):
-        await restyle_instruction_panel(guild_id)
+        panel_outcome = await restyle_instruction_panel(guild_id)
 
-    return await read_dashboard_settings(guild_id)
+    settings = await read_dashboard_settings(guild_id)
+    # The save succeeded either way -- this is about whether the admin gets to
+    # know the panel did not follow it. "frozen" is the case that cost a long
+    # debugging session in production: the setting stored, the page showed the
+    # new value, and the panel stayed as it was with nothing saying so.
+    if settings is not None and panel_outcome in PANEL_STALE_OUTCOMES:
+        settings["panel_stale"] = panel_outcome
+    return settings
 
 
 def build_bot_api_deps() -> bot_api.BotAPIDeps:

--- a/src/bot.py
+++ b/src/bot.py
@@ -776,6 +776,15 @@ DASHBOARD_WRITABLE_FIELDS = frozenset(
     }
 )
 
+# Settings an already-posted panel RENDERS, as opposed to ones that only affect
+# what happens after somebody clicks it. Changing one of these leaves the live
+# message stale, because the fleet sweep refreshes the view but passes
+# rebuild_embed=False -- so a save that touches any of them has to re-edit the
+# panel itself or the change is invisible until an operator forces a refresh.
+PANEL_VISIBLE_FIELDS = frozenset(
+    {"instructions_locale", "panel_embed_color", "panel_show_icon"}
+)
+
 # The modal's own cap, so the website cannot store a message the slash command
 # could not have produced.
 CUSTOM_MESSAGE_MAX_LEN = 1000
@@ -2165,6 +2174,12 @@ class PagedSettingsView(View):
                     session.add(srv)
                 if nick_allowed:
                     srv.auto_nickname_change = bool(self.auto_nick)
+                # The panel renders in this language, so a change here needs the
+                # same re-edit a colour change gets. The language is free, which
+                # is why this is not folded into branding_allowed below.
+                locale_changed = (
+                    srv.instructions_locale or "en-US"
+                ) != str(self.instr_locale)
                 srv.instructions_locale = str(self.instr_locale)
                 if self.auto_verify_available:
                     setattr(srv, "auto_verify_new_members", bool(self.auto_verify))
@@ -2198,7 +2213,7 @@ class PagedSettingsView(View):
             # through a 429, which can push the reply past the three seconds
             # Discord allows. The admin would then be told the interaction
             # failed even though the save and the restyle both worked.
-            if branding_allowed:
+            if branding_allowed or locale_changed:
                 await restyle_instruction_panel(interaction.guild.id)
 
         back_btn.callback = on_back
@@ -5167,6 +5182,9 @@ async def write_dashboard_settings(guild_id, actor_id, changes: dict):
     Everything is validated before anything is applied. A batch with one bad
     field changes nothing at all, rather than saving the first two and failing
     on the third.
+
+    A save that changes something the panel displays also re-edits the panel,
+    for the reason PANEL_VISIBLE_FIELDS gives: nothing else would.
     """
     if not isinstance(changes, dict) or not changes:
         raise SettingRejected("", "no_changes")
@@ -5324,6 +5342,14 @@ async def write_dashboard_settings(guild_id, actor_id, changes: dict):
             "Could not save dashboard settings for guild %s.", guild_id, exc_info=True
         )
         return None
+
+    # The save is committed, so a panel still showing the old language or colour
+    # is now merely stale -- and would stay that way, since the fleet sweep
+    # rebuilds the view but not the embed. Only after the write, and never in a
+    # way that can fail the save: restyle_instruction_panel swallows its own
+    # errors and answers "no_panel" for the guilds that have none.
+    if any(name in PANEL_VISIBLE_FIELDS for name, _old, _new in changed):
+        await restyle_instruction_panel(guild_id)
 
     return await read_dashboard_settings(guild_id)
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -4424,13 +4424,22 @@ async def probe_instruction_panel(entry, rebuild_embed: bool) -> str:
                 # handling above owns deciding what to do about the id itself.
                 guild = None
             style = await resolve_panel_style(entry["server_id"], guild)
-            # None means the branding table could not be read. Leave the embed
-            # off the payload so the panel keeps whatever it already has — the
-            # view still gets refreshed, which is what this pass is for.
-            if style is not None:
-                payload["embed"] = build_instructions_embed(
-                    entry["locale"], *style
+            # None means the branding table could not be read, so the embed
+            # cannot be rebuilt without restyling a paying server over a
+            # database hiccup. Editing anyway used to send the view on its own,
+            # which produced the worst of the three outcomes: buttons in the new
+            # language above an embed still in the old one, logged as a success.
+            # Leave the whole panel alone instead. It stays internally
+            # consistent, and the caller is told this is a retry rather than a
+            # refusal.
+            if style is None:
+                logger.warning(
+                    "⚠️ Could not resolve the panel style for guild %s; leaving "
+                    "the panel untouched rather than half-updating it.",
+                    entry["server_id"],
                 )
+                return "style_unreadable"
+            payload["embed"] = build_instructions_embed(entry["locale"], *style)
         await message.edit(**payload)
         if entry.get("view_version") != INSTRUCTIONS_VIEW_VERSION:
             record_panel_view_version(entry["server_id"])

--- a/src/bot.py
+++ b/src/bot.py
@@ -4926,6 +4926,151 @@ async def read_dashboard_panel(guild_id) -> Optional[dict]:
         return None
 
 
+def _stored_panel_location(guild_id):
+    """This guild's recorded panel ids, distinguishing "none" from "unknown".
+
+    load_instruction_panel returns None for both, which is fine for a refresh
+    sweep and dangerous here: "no panel recorded" is the one condition under
+    which posting a new one is safe, and a database hiccup must not be allowed
+    to look like it. Raises rather than returning a sentinel, so a caller
+    cannot forget to check.
+    """
+    with session_scope() as session:
+        server = (
+            session.query(Server)
+            .filter_by(server_id=panel_view_key(guild_id))
+            .first()
+        )
+        if server is None or not server.instructions_message_id:
+            return None
+        return {
+            "server_id": server.server_id,
+            "channel_id": server.instructions_channel_id,
+            "message_id": server.instructions_message_id,
+            "locale": server.instructions_locale or "en-US",
+        }
+
+
+async def post_dashboard_panel(guild_id, actor_id, channel_id):
+    """Put this guild's instructions panel where the admin asked for it.
+
+    The only thing the dashboard can make the bot *do* in a server, as opposed
+    to store, so it is deliberately hard to do twice by accident:
+
+    * A panel already in the requested channel is REFRESHED -- the same
+      one-call edit the fleet sweep uses -- rather than posted again. A double
+      click therefore costs an edit, not a second panel with live buttons that
+      nothing tracks.
+    * A panel recorded elsewhere is a MOVE. The new one is posted and the ids
+      re-pointed, and the caller is told where the old one still is so an admin
+      can remove it. Deleting it here would be this code destroying a message
+      nobody pointed at.
+    * If the recorded location cannot be read at all, nothing is posted. That
+      is the case where "no panel exists" and "the database blinked" look
+      identical, and guessing wrong leaves a duplicate.
+
+    Returns a dict describing what happened, or None when it could not be done.
+    """
+    guild = bot.get_guild(int(guild_id))
+    if guild is None or guild.me is None:
+        return None
+
+    channel = next(
+        (c for c in guild.text_channels if str(c.id) == str(channel_id)), None
+    )
+    if channel is None:
+        raise SettingRejected("panel_channel", "channel_not_in_guild")
+    perms = channel.permissions_for(guild.me)
+    if not (perms.view_channel and perms.send_messages and perms.embed_links):
+        raise SettingRejected("panel_channel", "channel_not_writable")
+
+    try:
+        existing = _stored_panel_location(guild_id)
+    except Exception:
+        logger.warning(
+            "Could not read the panel location for guild %s; not posting.",
+            guild_id,
+            exc_info=True,
+        )
+        return None
+
+    # --- Already there: refresh in place ---
+    if existing and str(existing.get("channel_id")) == str(channel.id):
+        outcome = await probe_instruction_panel(existing, rebuild_embed=True)
+        if outcome == "ok":
+            _audit_panel(guild_id, actor_id, "refreshed", channel.id)
+            return {"action": "refreshed", "channel_id": str(channel.id)}
+        if outcome in {"gone", "missing_ids", "malformed"}:
+            # The record points at a message that is not there any more, so
+            # this is a first post rather than a duplicate.
+            existing = None
+        elif outcome == "forbidden":
+            raise SettingRejected("panel_channel", "channel_not_writable")
+        else:
+            return None
+
+    # --- Post a new one ---
+    style = await resolve_panel_style(guild_id, guild)
+    color, icon = style if style else (DEFAULT_PANEL_COLOR, None)
+    locale = get_server_locale_code(guild_id, guild)
+    embed = build_instructions_embed(locale, color, icon)
+
+    try:
+        message = await channel.send(
+            embed=embed, view=VRCVerifyInstructionView(locale=locale)
+        )
+    except discord.Forbidden:
+        raise SettingRejected("panel_channel", "channel_not_writable")
+    except Exception:
+        logger.exception("Failed to post the instructions panel for %s", guild_id)
+        return None
+
+    previous = str(existing["channel_id"]) if existing else None
+    try:
+        with session_scope() as session:
+            server = (
+                session.query(Server)
+                .filter_by(server_id=panel_view_key(guild_id))
+                .first()
+            )
+            if server is None:
+                # Same reasoning as /vrcverify_instructions: the panel is up, so
+                # something has to track it or the startup refresh never sees it.
+                server = Server(server_id=str(guild_id), owner_id=str(actor_id))
+                session.add(server)
+            server.instructions_channel_id = str(channel.id)
+            server.instructions_message_id = str(message.id)
+    except Exception:
+        # The message is already posted; failing to record it would leave an
+        # untracked panel, which is worse than saying the save half-failed.
+        logger.exception("Posted a panel for %s but could not record it", guild_id)
+        return None
+
+    record_panel_view_version(guild_id)
+    complete_guild_onboarding(guild_id)
+    _audit_panel(guild_id, actor_id, "moved" if previous else "posted", channel.id)
+    return {
+        "action": "moved" if previous else "posted",
+        "channel_id": str(channel.id),
+        "previous_channel_id": previous,
+    }
+
+
+def _audit_panel(guild_id, actor_id, action: str, channel_id) -> None:
+    try:
+        with session_scope() as session:
+            _record_dashboard_audit(
+                session,
+                guild_id,
+                actor_id,
+                [("instructions_panel", action, str(channel_id))],
+            )
+    except Exception:
+        logger.warning(
+            "Could not record the panel action for guild %s.", guild_id, exc_info=True
+        )
+
+
 async def read_dashboard_audit(guild_id, limit: int = 25) -> Optional[list]:
     """This guild's recent settings changes, newest first.
 
@@ -5189,6 +5334,7 @@ def build_bot_api_deps() -> bot_api.BotAPIDeps:
         read_panel=read_dashboard_panel,
         read_audit=read_dashboard_audit,
         write_settings=write_dashboard_settings,
+        post_panel=post_dashboard_panel,
     )
 
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -4443,7 +4443,16 @@ async def probe_instruction_panel(entry, rebuild_embed: bool) -> str:
         await message.edit(**payload)
         if entry.get("view_version") != INSTRUCTIONS_VIEW_VERSION:
             record_panel_view_version(entry["server_id"])
-        logger.debug(f"Refreshed instructions message for guild {entry['server_id']}")
+        # Says what went, not just that something did. A panel coming out in two
+        # languages was invisible in the logs for exactly as long as this line
+        # read "Refreshed" whether or not the embed was part of the edit.
+        logger.debug(
+            "Refreshed instructions message %s for guild %s (locale=%s, sent=%s)",
+            message_id,
+            entry["server_id"],
+            entry["locale"],
+            "+".join(sorted(payload)),
+        )
         return "ok"
     except discord.NotFound:
         # Either the channel or the message is gone; both cases make the saved

--- a/src/bot.py
+++ b/src/bot.py
@@ -4425,9 +4425,8 @@ async def probe_instruction_panel(entry, rebuild_embed: bool) -> str:
         return "missing_ids"
 
     try:
-        message = bot.get_partial_messageable(int(channel_id)).get_partial_message(
-            int(message_id)
-        )
+        messageable = bot.get_partial_messageable(int(channel_id))
+        message = messageable.get_partial_message(int(message_id))
     except (TypeError, ValueError):
         logger.warning(f"⚠️ Malformed channel/message id for guild {entry['server_id']}; skipping.")
         return "malformed"
@@ -4437,6 +4436,22 @@ async def probe_instruction_panel(entry, rebuild_embed: bool) -> str:
         # abort the whole fleet pass, it only costs this one guild.
         payload = {"view": VRCVerifyInstructionView(locale=entry["locale"])}
         if rebuild_embed:
+            # A panel posted as a slash-command reply belongs to a webhook, and
+            # Discord answers 200 to an embed edit on one while keeping the old
+            # embed. The view would still apply, so editing anyway is precisely
+            # the half-update that hid this bug -- new button labels above text
+            # nothing can change. Costs one fetch, and only on the paths that
+            # rebuild the embed; the fleet sweep never gets here. A read that
+            # fails answers None and falls through to the edit, because a fetch
+            # hiccup must not start refusing ordinary refreshes.
+            if await _panel_is_webhook_owned(messageable, message_id):
+                logger.warning(
+                    "⚠️ The instructions panel for guild %s cannot be edited by "
+                    "Discord (it was posted as a command reply). It has to be "
+                    "replaced -- use the dashboard's panel button.",
+                    entry["server_id"],
+                )
+                return "frozen"
             # Resolving the style is what reverts a lapsed server to the default
             # look, so it happens here rather than being cached with the panel.
             # Guilds with no branding row skip the entitlement read entirely.

--- a/src/bot_api.py
+++ b/src/bot_api.py
@@ -166,6 +166,10 @@ class BotAPIDeps:
     # the re-read settings, returns None because it could not complete, or
     # raises the bot's SettingRejected for anything the caller got wrong.
     write_settings: Callable[[int, int, dict], Awaitable[Optional[dict]]]
+    # The one action. Everything else here stores a value; this makes the bot
+    # post a message in somebody's server, so it is named separately rather
+    # than folded into write_settings.
+    post_panel: Callable[[int, int, str], Awaitable[Optional[dict]]]
 
 
 # -------------------------------------------------------------------
@@ -665,8 +669,51 @@ async def handle_update_settings(request: web.Request) -> web.Response:
     return _json(payload)
 
 
+async def handle_post_panel(request: web.Request) -> web.Response:
+    """Post or refresh a guild's instructions panel.
+
+    The only endpoint whose effect is visible to people who are not the caller:
+    everything else changes a row, this puts a message in a server. It gets the
+    same three gates and one more consideration -- what happens when it is
+    called twice. That is answered inside the bot, which refreshes an existing
+    panel rather than posting a second one, so a double-click costs an edit.
+    """
+    try:
+        claims = await _authorize(request, guild_scoped=True)
+    except _Denied as denied:
+        return denied.response
+
+    deps: BotAPIDeps = request.app[DEPS_KEY]
+    guild_id = int(request.match_info["guild_id"])
+
+    try:
+        body = await request.json()
+    except (ValueError, UnicodeDecodeError):
+        return _deny(request, 400, "bad_json", actor=claims.actor_id)
+    if not isinstance(body, dict):
+        return _deny(request, 400, "bad_json", actor=claims.actor_id)
+
+    channel_id = body.get("channel_id")
+    if not isinstance(channel_id, (str, int)) or not str(channel_id).isdigit():
+        return _deny(request, 400, "bad_channel_id", actor=claims.actor_id)
+
+    try:
+        result = await deps.post_panel(guild_id, claims.actor_id, str(channel_id))
+    except SettingRejected as rejected:
+        return _deny(
+            request,
+            403 if rejected.locked else 400,
+            rejected.reason,
+            actor=claims.actor_id,
+        )
+
+    if result is None:
+        return _deny(request, 503, "unavailable", actor=claims.actor_id)
+    return _json(result)
+
+
 def create_app(config: BotAPIConfig, deps: BotAPIDeps) -> web.Application:
-    """Wire the routes. One PATCH, everything else a GET."""
+    """Wire the routes. One PATCH, one POST, everything else a GET."""
     app = web.Application(client_max_size=MAX_REQUEST_BYTES)
     app[CONFIG_KEY] = config
     app[DEPS_KEY] = deps
@@ -688,6 +735,7 @@ def create_app(config: BotAPIConfig, deps: BotAPIDeps) -> web.Application:
     app.router.add_patch(
         "/api/v1/guilds/{guild_id}/settings", handle_update_settings
     )
+    app.router.add_post("/api/v1/guilds/{guild_id}/panel", handle_post_panel)
 
     app.on_response_prepare.append(_harden_response)
     return app

--- a/src/bot_api.py
+++ b/src/bot_api.py
@@ -6,11 +6,12 @@ SQLAlchemy. Everything it is allowed to touch arrives as a callable on
 
 That is not tidiness, it is the "least privilege on the API surface" control
 issue #65 asks for. There is no generic "write these columns" entry point here:
-`BotAPIDeps` carries exactly one writer, `write_settings`, and this module does
-not know which fields exist, which are premium, or what values are legal. It
-validates the envelope and hands the body to the bot, which decides. Adding a
-second writer means editing that dataclass and the test that pins it — a
-visible, reviewable diff rather than a new query string someone slipped past.
+`BotAPIDeps` carries exactly two mutating capabilities, `write_settings` and
+`post_panel`, and this module does not know which fields exist, which are
+premium, or what values are legal. It validates the envelope and hands the body
+to the bot, which decides. Adding a third means editing that dataclass and the
+test that pins it — a visible, reviewable diff rather than a new query string
+someone slipped past.
 
 Three things guard every request, in this order:
 
@@ -76,6 +77,22 @@ DEFAULT_RATE_WINDOW = 60
 # event loop even while staying inside its own per-actor budget.
 DEFAULT_GLOBAL_RATE_LIMIT = 600
 
+# Mutating requests get their own, much smaller budget on top of the two above.
+# The budgets before this were sized when every route was a GET answered from
+# the gateway cache, costing Discord nothing. That is no longer what a request
+# costs: posting a panel is up to three Discord REST calls (fetch, send, delete)
+# and saving a language or colour is up to two (fetch, edit). At the general
+# limits alone the API would authorise enough of those to make a dent in the
+# bot's account-wide REST budget -- which verification shares, and verification
+# is the product.
+#
+# Ten a minute is far more than a human configuring a server will ever need
+# (saving all four groups and posting a panel is five), so this bites long
+# before honest use does. Both are env-tunable because the right number depends
+# on how many admins are actually using the dashboard.
+DEFAULT_WRITE_RATE_LIMIT = 10
+DEFAULT_GLOBAL_WRITE_RATE_LIMIT = 60
+
 # Nothing here accepts a body yet; this only has to be big enough for headers.
 MAX_REQUEST_BYTES = 16 * 1024
 
@@ -121,6 +138,8 @@ DEPS_KEY: "web.AppKey" = web.AppKey("deps")
 REPLAY_KEY: "web.AppKey" = web.AppKey("replay")
 RATE_KEY: "web.AppKey" = web.AppKey("rate_limiter")
 GLOBAL_RATE_KEY: "web.AppKey" = web.AppKey("global_rate_limiter")
+WRITE_RATE_KEY: "web.AppKey" = web.AppKey("write_rate_limiter")
+GLOBAL_WRITE_RATE_KEY: "web.AppKey" = web.AppKey("global_write_rate_limiter")
 
 
 # -------------------------------------------------------------------
@@ -130,14 +149,16 @@ GLOBAL_RATE_KEY: "web.AppKey" = web.AppKey("global_rate_limiter")
 class BotAPIDeps:
     """The complete list of things the API can do to the bot.
 
-    All readers but one. `tests/test_bot_api.py` pins the exact field set, so a
-    second writer cannot be added by accident — adding one means editing that
-    test on purpose, which is a reviewable diff rather than a quiet widening.
+    Nine of the eleven only read or check. `tests/test_bot_api.py` pins the
+    exact field set, so a third mutating capability cannot be added by accident
+    — adding one means editing that test on purpose, which is a reviewable diff
+    rather than a quiet widening.
 
-    `write_settings` is the whole write surface. It is a single named callable
-    that validates against its own allowlist inside the bot, not a generic
-    column setter, so the worst a compromised dashboard can do is submit valid
-    values for the handful of fields the bot has decided are writable.
+    `write_settings` and `post_panel` are the whole mutating surface. Both are
+    named callables that validate against their own allowlist inside the bot,
+    not generic setters, so the worst a compromised dashboard can do is submit
+    valid values for the handful of fields the bot has decided are writable, and
+    ask for the one message it is allowed to post.
 
     Readers take and return plain data — ids, dicts, lists — never discord.py
     objects. Shaping a Guild into JSON is the bot's job, not this module's,
@@ -202,6 +223,8 @@ class BotAPIConfig:
     rate_limit: int = DEFAULT_RATE_LIMIT
     rate_window: int = DEFAULT_RATE_WINDOW
     global_rate_limit: int = DEFAULT_GLOBAL_RATE_LIMIT
+    write_rate_limit: int = DEFAULT_WRITE_RATE_LIMIT
+    global_write_rate_limit: int = DEFAULT_GLOBAL_WRITE_RATE_LIMIT
 
     @staticmethod
     def enabled() -> bool:
@@ -251,6 +274,12 @@ class BotAPIConfig:
             rate_window=_int_env("BOT_API_RATE_WINDOW", DEFAULT_RATE_WINDOW),
             global_rate_limit=_int_env(
                 "BOT_API_GLOBAL_RATE_LIMIT", DEFAULT_GLOBAL_RATE_LIMIT
+            ),
+            write_rate_limit=_int_env(
+                "BOT_API_WRITE_RATE_LIMIT", DEFAULT_WRITE_RATE_LIMIT
+            ),
+            global_write_rate_limit=_int_env(
+                "BOT_API_GLOBAL_WRITE_RATE_LIMIT", DEFAULT_GLOBAL_WRITE_RATE_LIMIT
             ),
         )
 
@@ -494,6 +523,19 @@ async def _authorize(request: web.Request, *, guild_scoped: bool) -> TokenClaims
     if not limiter.allow(str(claims.actor_id)) or not global_limiter.allow("*"):
         raise _Denied(_deny(request, 429, "rate_limited", actor=claims.actor_id))
 
+    # Mutating requests pay a second, much smaller budget on top. A GET is
+    # answered from the gateway cache and costs Discord nothing; a PATCH or a
+    # POST here turns into real REST calls against the same account-wide budget
+    # verification runs on. Charged after the general one so a caller cannot
+    # spend write slots by hammering reads.
+    if request.method != "GET":
+        write_limiter: RateLimiter = request.app[WRITE_RATE_KEY]
+        global_write_limiter: RateLimiter = request.app[GLOBAL_WRITE_RATE_KEY]
+        if not write_limiter.allow(str(claims.actor_id)) or not global_write_limiter.allow("*"):
+            raise _Denied(
+                _deny(request, 429, "rate_limited", actor=claims.actor_id)
+            )
+
     # --- The bot's own answer ---
     if not deps.is_ready():
         raise _Denied(_deny(request, 503, "not_ready", actor=claims.actor_id))
@@ -720,6 +762,10 @@ def create_app(config: BotAPIConfig, deps: BotAPIDeps) -> web.Application:
     app[REPLAY_KEY] = ReplayGuard()
     app[RATE_KEY] = RateLimiter(config.rate_limit, config.rate_window)
     app[GLOBAL_RATE_KEY] = RateLimiter(config.global_rate_limit, config.rate_window)
+    app[WRITE_RATE_KEY] = RateLimiter(config.write_rate_limit, config.rate_window)
+    app[GLOBAL_WRITE_RATE_KEY] = RateLimiter(
+        config.global_write_rate_limit, config.rate_window
+    )
 
     app.router.add_get("/healthz", handle_health)
     app.router.add_get("/api/v1/guilds", handle_list_guilds)

--- a/src/bot_api.py
+++ b/src/bot_api.py
@@ -5,11 +5,12 @@ SQLAlchemy. Everything it is allowed to touch arrives as a callable on
 `BotAPIDeps`, which the bot builds and hands over at startup.
 
 That is not tidiness, it is the "least privilege on the API surface" control
-issue #65 asks for. There is no generic "write these columns" entry point here
-because there is no writer in `BotAPIDeps` at all — in this phase the API is
-structurally incapable of changing a row. Adding a write path later means
-adding a named writer to that dataclass, which is a visible, reviewable diff
-rather than a new query string someone slipped past.
+issue #65 asks for. There is no generic "write these columns" entry point here:
+`BotAPIDeps` carries exactly one writer, `write_settings`, and this module does
+not know which fields exist, which are premium, or what values are legal. It
+validates the envelope and hands the body to the bot, which decides. Adding a
+second writer means editing that dataclass and the test that pins it — a
+visible, reviewable diff rather than a new query string someone slipped past.
 
 Three things guard every request, in this order:
 
@@ -160,6 +161,7 @@ class BotAPIDeps:
     read_roles: Callable[[int], Awaitable[Optional[list]]]
     read_channels: Callable[[int], Awaitable[Optional[list]]]
     read_panel: Callable[[int], Awaitable[Optional[dict]]]
+    read_audit: Callable[[int], Awaitable[Optional[list]]]
     # The only writer. Takes (guild_id, actor_id, changes) and either returns
     # the re-read settings, returns None because it could not complete, or
     # raises the bot's SettingRejected for anything the caller got wrong.
@@ -682,6 +684,7 @@ def create_app(config: BotAPIConfig, deps: BotAPIDeps) -> web.Application:
         "/api/v1/guilds/{guild_id}/channels", _guild_reader("read_channels")
     )
     app.router.add_get("/api/v1/guilds/{guild_id}/panel", _guild_reader("read_panel"))
+    app.router.add_get("/api/v1/guilds/{guild_id}/audit", _guild_reader("read_audit"))
     app.router.add_patch(
         "/api/v1/guilds/{guild_id}/settings", handle_update_settings
     )

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -55,7 +55,13 @@ from dashboard.sessions import SessionStore
 
 logger = logging.getLogger(__name__)
 
-SESSION_COOKIE = "vrcverify_session"
+# The `__Host-` prefix is enforced by the browser: it only accepts the cookie if
+# it is Secure, has no Domain, and is Path=/. That makes it impossible for a
+# sibling subdomain to shadow this cookie with a Domain-scoped one of the same
+# name -- which matters more now that a session can write settings, since being
+# tossed into someone else's session means editing their server believing it is
+# yours.
+SESSION_COOKIE = "__Host-vrcverify_session"
 
 # Everything is same-origin and self-hosted, so the policy can be close to
 # nothing. The one external origin is Discord's icon CDN: guild icons are
@@ -264,7 +270,7 @@ def _register_routes(app: Flask) -> None:
 
         # The check that makes CSRF against the login flow impossible: the
         # state came from us, in this browser, for this attempt.
-        if not secrets.compare_digest(pending.oauth_state, state):
+        if not _same_secret(pending.oauth_state, state):
             logger.warning("OAuth state mismatch; refusing the callback.")
             store.destroy(pending.sid)
             return render_template("error.html", message="That login could not be verified. Please try again."), 400
@@ -339,6 +345,7 @@ def _register_routes(app: Flask) -> None:
             auto_verify_column_present=settings.get("auto_verify_column_present", True),
             saved=request.args.get("saved") == "1",
             panel_result=PANEL_RESULTS.get(request.args.get("panel")),
+            panel_stale=bool(request.args.get("panel_stale")),
             save_error=(
                 _save_error_message(request.args.get("error"))
                 or _panel_error_message(request.args.get("panel_error"))
@@ -408,11 +415,16 @@ def _register_routes(app: Flask) -> None:
                 )
             )
 
+        # Clamped to a known key before it travels, like the two error codes
+        # are. This is the bot's own string, but it is the one place a bot value
+        # reached a URL unchecked, and the invariant this module claims is that
+        # nothing from over the wire is echoed back without being looked up.
+        action = result.get("action")
         return redirect(
             url_for(
                 "guild_settings",
                 guild_id=guild_id,
-                panel=result.get("action", "posted"),
+                panel=action if action in PANEL_RESULTS else "posted",
             )
         )
 
@@ -506,8 +518,7 @@ def _register_routes(app: Flask) -> None:
     def logout():
         session = _require_login()
         if session is not None:
-            submitted = request.form.get("csrf_token", "")
-            if not secrets.compare_digest(session.csrf_token, submitted):
+            if not _csrf_ok(session):
                 abort(400)
             _store().destroy(session.sid)
         response = redirect(url_for("index"))
@@ -584,9 +595,11 @@ GENERIC_SAVE_ERROR = "That change couldn't be saved, so nothing was changed."
 # nothing true about a panel, and a panel needs Embed Links as well as Send
 # Messages -- which the log channel does not, so SAVE_ERRORS cannot just say so.
 PANEL_ERRORS = {
+    # Plain text: this is rendered into a web page, not sent to Discord, so
+    # markdown asterisks would show up literally.
     "channel_not_writable": (
-        "VRCVerify can't post the panel in that channel. It needs both **Send "
-        "Messages** and **Embed Links** there -- Embed Links is the one that's "
+        "VRCVerify can't post the panel in that channel. It needs both Send "
+        "Messages and Embed Links there -- Embed Links is the one that's "
         "usually missing, because the panel is an embed."
     ),
     "channel_not_in_guild": (
@@ -634,11 +647,23 @@ def _read_checkbox(changes: dict, name: str) -> None:
         changes[name] = bool(request.form.get(name))
 
 
+def _same_secret(expected: str, submitted: str) -> bool:
+    """Constant-time compare that survives whatever the request carried.
+
+    `secrets.compare_digest` raises TypeError on a str containing non-ASCII, so
+    comparing a submitted value directly turns "wrong token" into an unhandled
+    500 -- including on `/callback`, which a stranger can reach. Comparing the
+    utf-8 bytes keeps the timing property and makes every wrong value simply
+    wrong.
+    """
+    return secrets.compare_digest(
+        str(expected or "").encode("utf-8"), str(submitted or "").encode("utf-8")
+    )
+
+
 def _csrf_ok(session) -> bool:
     """The second line. `SameSite=Lax` on the cookie is the first."""
-    return secrets.compare_digest(
-        session.csrf_token, request.form.get("csrf_token", "")
-    )
+    return _same_secret(session.csrf_token, request.form.get("csrf_token", ""))
 
 
 def _save(guild_id: int, session, changes: dict):
@@ -652,7 +677,17 @@ def _save(guild_id: int, session, changes: dict):
         return redirect(url_for("guild_settings", guild_id=guild_id))
 
     try:
-        _bot_api().update_settings(int(session.discord_id), guild_id, changes)
+        saved = _bot_api().update_settings(int(session.discord_id), guild_id, changes)
+        # The save worked; the panel may not have followed it. Carried as its
+        # own flag rather than an error, because "stored but the panel still
+        # shows the old thing" is a true success plus a caveat, and reporting it
+        # as a failure would send an admin round the loop that produced it.
+        if isinstance(saved, dict) and saved.get("panel_stale"):
+            return redirect(
+                url_for(
+                    "guild_settings", guild_id=guild_id, saved=1, panel_stale=1
+                )
+            )
     except BotAPIError as error:
         logger.warning("save refused for guild %s: %s", guild_id, error)
         # A code, never the bot's text. What comes back is a fixed reason

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -322,6 +322,9 @@ def _register_routes(app: Flask) -> None:
         panel = _optional_read(
             lambda: _bot_api().panel(actor, guild_id), "panel", guild_id
         )
+        audit = _optional_read(
+            lambda: _bot_api().audit(actor, guild_id), "audit", guild_id
+        )
 
         guild = _session_guild(session, guild_id)
         return render_template(
@@ -330,6 +333,7 @@ def _register_routes(app: Flask) -> None:
             guild_icon=oauth.icon_url(guild) if guild else None,
             guild_id=str(guild_id),
             groups=settings_view.build_groups(settings, roles, channels, panel),
+            audit=settings_view.build_audit(audit, roles, channels),
             premium=settings.get("premium") or {},
             names_resolved=roles is not None and channels is not None,
             auto_verify_column_present=settings.get("auto_verify_column_present", True),

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -585,6 +585,15 @@ PANEL_RESULTS = {
         "Panel posted in the new channel. The old one is still up in its "
         "previous channel -- delete it in Discord when you're ready."
     ),
+    # Panels posted by /vrcverify_instructions before it stopped replying with
+    # them belong to a webhook, and Discord quietly ignores embed edits on those
+    # -- so the language and colour could never be applied to one. The only
+    # repair is a new message, which is why this reads as an explanation rather
+    # than as a plain success.
+    "replaced": (
+        "That panel was posted in a way Discord won't let the bot edit, so it "
+        "was replaced with a fresh one. Your settings apply to it now."
+    ),
 }
 
 

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -339,7 +339,10 @@ def _register_routes(app: Flask) -> None:
             auto_verify_column_present=settings.get("auto_verify_column_present", True),
             saved=request.args.get("saved") == "1",
             panel_result=PANEL_RESULTS.get(request.args.get("panel")),
-            save_error=_save_error_message(request.args.get("error")),
+            save_error=(
+                _save_error_message(request.args.get("error"))
+                or _panel_error_message(request.args.get("panel_error"))
+            ),
             csrf_token=session.csrf_token,
         )
 
@@ -399,7 +402,9 @@ def _register_routes(app: Flask) -> None:
             logger.warning("panel post refused for guild %s: %s", guild_id, error)
             return redirect(
                 url_for(
-                    "guild_settings", guild_id=guild_id, error=_save_error_code(error)
+                    "guild_settings",
+                    guild_id=guild_id,
+                    panel_error=_panel_error_code(error),
                 )
             )
 
@@ -574,6 +579,25 @@ SAVE_ERRORS = {
 }
 GENERIC_SAVE_ERROR = "That change couldn't be saved, so nothing was changed."
 
+# The panel button shares reason codes with the settings saves, but not their
+# wording. "so it can't log there" is the log channel's sentence and says
+# nothing true about a panel, and a panel needs Embed Links as well as Send
+# Messages -- which the log channel does not, so SAVE_ERRORS cannot just say so.
+PANEL_ERRORS = {
+    "channel_not_writable": (
+        "VRCVerify can't post the panel in that channel. It needs both **Send "
+        "Messages** and **Embed Links** there -- Embed Links is the one that's "
+        "usually missing, because the panel is an embed."
+    ),
+    "channel_not_in_guild": (
+        "That channel isn't in this server any more. Reload the page and pick "
+        "again."
+    ),
+}
+GENERIC_PANEL_ERROR = (
+    "The panel couldn't be posted just now. Try again shortly."
+)
+
 # Same treatment as the refusals: a code chosen by the bot, copy chosen here.
 PANEL_RESULTS = {
     "posted": "Panel posted.",
@@ -653,6 +677,17 @@ def _save_error_message(code: Optional[str]) -> Optional[str]:
     if not code:
         return None
     return SAVE_ERRORS.get(code, GENERIC_SAVE_ERROR)
+
+
+def _panel_error_code(error: BotAPIError) -> str:
+    reason = str(error)
+    return reason if reason in PANEL_ERRORS else "unknown"
+
+
+def _panel_error_message(code: Optional[str]) -> Optional[str]:
+    if not code:
+        return None
+    return PANEL_ERRORS.get(code, GENERIC_PANEL_ERROR)
 
 
 def _colour_to_int(raw: Optional[str]) -> Optional[int]:

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -325,6 +325,8 @@ def _register_routes(app: Flask) -> None:
         channels = _optional_read(
             lambda: _bot_api().channels(actor, guild_id), "channels", guild_id
         )
+        # Read once and cleared, so a reload does not repeat it.
+        notice = _store().take_notice(session.sid)
         panel = _optional_read(
             lambda: _bot_api().panel(actor, guild_id), "panel", guild_id
         )
@@ -343,12 +345,12 @@ def _register_routes(app: Flask) -> None:
             premium=settings.get("premium") or {},
             names_resolved=roles is not None and channels is not None,
             auto_verify_column_present=settings.get("auto_verify_column_present", True),
-            saved=request.args.get("saved") == "1",
-            panel_result=PANEL_RESULTS.get(request.args.get("panel")),
-            panel_stale=bool(request.args.get("panel_stale")),
+            saved=notice == "saved",
+            panel_result=PANEL_RESULTS.get(_notice_arg(notice, "panel")),
+            panel_stale=notice == "stale",
             save_error=(
-                _save_error_message(request.args.get("error"))
-                or _panel_error_message(request.args.get("panel_error"))
+                _save_error_message(_notice_arg(notice, "error"))
+                or _panel_error_message(_notice_arg(notice, "panel_error"))
             ),
             csrf_token=session.csrf_token,
         )
@@ -407,26 +409,19 @@ def _register_routes(app: Flask) -> None:
             )
         except BotAPIError as error:
             logger.warning("panel post refused for guild %s: %s", guild_id, error)
-            return redirect(
-                url_for(
-                    "guild_settings",
-                    guild_id=guild_id,
-                    panel_error=_panel_error_code(error),
-                )
-            )
+            _store().set_notice(session.sid, f"panel_error:{_panel_error_code(error)}")
+            return redirect(url_for("guild_settings", guild_id=guild_id))
 
         # Clamped to a known key before it travels, like the two error codes
         # are. This is the bot's own string, but it is the one place a bot value
         # reached a URL unchecked, and the invariant this module claims is that
         # nothing from over the wire is echoed back without being looked up.
         action = result.get("action")
-        return redirect(
-            url_for(
-                "guild_settings",
-                guild_id=guild_id,
-                panel=action if action in PANEL_RESULTS else "posted",
-            )
+        _store().set_notice(
+            session.sid,
+            f"panel:{action if action in PANEL_RESULTS else 'posted'}",
         )
+        return redirect(url_for("guild_settings", guild_id=guild_id))
 
     @app.post("/guild/<int:guild_id>/member")
     def save_member_settings(guild_id: int):
@@ -683,11 +678,8 @@ def _save(guild_id: int, session, changes: dict):
         # shows the old thing" is a true success plus a caveat, and reporting it
         # as a failure would send an admin round the loop that produced it.
         if isinstance(saved, dict) and saved.get("panel_stale"):
-            return redirect(
-                url_for(
-                    "guild_settings", guild_id=guild_id, saved=1, panel_stale=1
-                )
-            )
+            _store().set_notice(session.sid, "stale")
+            return redirect(url_for("guild_settings", guild_id=guild_id))
     except BotAPIError as error:
         logger.warning("save refused for guild %s: %s", guild_id, error)
         # A code, never the bot's text. What comes back is a fixed reason
@@ -695,11 +687,19 @@ def _save(guild_id: int, session, changes: dict):
         # would make the bot's error strings part of this app's HTML, and the
         # day one of them carries something a caller influenced is not the day
         # to find that out.
-        return redirect(
-            url_for("guild_settings", guild_id=guild_id, error=_save_error_code(error))
-        )
+        _store().set_notice(session.sid, f"error:{_save_error_code(error)}")
+        return redirect(url_for("guild_settings", guild_id=guild_id))
 
-    return redirect(url_for("guild_settings", guild_id=guild_id, saved=1))
+    _store().set_notice(session.sid, "saved")
+    return redirect(url_for("guild_settings", guild_id=guild_id))
+
+
+def _notice_arg(notice: Optional[str], kind: str) -> Optional[str]:
+    """`panel:moved` -> `moved`, but only when asked for the right kind."""
+    if not notice or ":" not in notice:
+        return None
+    prefix, _, value = notice.partition(":")
+    return value if prefix == kind else None
 
 
 def _save_error_code(error: BotAPIError) -> str:

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -338,6 +338,7 @@ def _register_routes(app: Flask) -> None:
             names_resolved=roles is not None and channels is not None,
             auto_verify_column_present=settings.get("auto_verify_column_present", True),
             saved=request.args.get("saved") == "1",
+            panel_result=PANEL_RESULTS.get(request.args.get("panel")),
             save_error=_save_error_message(request.args.get("error")),
             csrf_token=session.csrf_token,
         )
@@ -368,6 +369,47 @@ def _register_routes(app: Flask) -> None:
         _read_checkbox(changes, "auto_verify_new_members")
 
         return _save(guild_id, session, changes)
+
+    @app.post("/guild/<int:guild_id>/panel/post")
+    def post_panel(guild_id: int):
+        """Put the instructions panel in a channel.
+
+        The one control here that makes the bot act in a server rather than
+        store a value. What "put it there" means -- a fresh post, a refresh of
+        the one already there, or a move -- is decided by the bot, because it
+        is the only side that can see where the panel actually is. This route's
+        job is to carry the admin's choice of channel and report back what
+        happened.
+        """
+        session = _require_login()
+        if session is None:
+            return redirect(url_for("index"))
+        if not _csrf_ok(session):
+            abort(400)
+
+        channel_id = (request.form.get("panel_channel_id") or "").strip()
+        if not channel_id:
+            return redirect(url_for("guild_settings", guild_id=guild_id))
+
+        try:
+            result = _bot_api().post_panel(
+                int(session.discord_id), guild_id, channel_id
+            )
+        except BotAPIError as error:
+            logger.warning("panel post refused for guild %s: %s", guild_id, error)
+            return redirect(
+                url_for(
+                    "guild_settings", guild_id=guild_id, error=_save_error_code(error)
+                )
+            )
+
+        return redirect(
+            url_for(
+                "guild_settings",
+                guild_id=guild_id,
+                panel=result.get("action", "posted"),
+            )
+        )
 
     @app.post("/guild/<int:guild_id>/member")
     def save_member_settings(guild_id: int):
@@ -531,6 +573,19 @@ SAVE_ERRORS = {
     ),
 }
 GENERIC_SAVE_ERROR = "That change couldn't be saved, so nothing was changed."
+
+# Same treatment as the refusals: a code chosen by the bot, copy chosen here.
+PANEL_RESULTS = {
+    "posted": "Panel posted.",
+    "refreshed": (
+        "That channel already had the panel, so it was refreshed rather than "
+        "posted again."
+    ),
+    "moved": (
+        "Panel posted in the new channel. The old one is still up in its "
+        "previous channel -- delete it in Discord when you're ready."
+    ),
+}
 
 
 def _read_checkbox(changes: dict, name: str) -> None:

--- a/src/dashboard/botapi.py
+++ b/src/dashboard/botapi.py
@@ -29,6 +29,7 @@ from api_tokens import (
     OP_GUILD_PANEL,
     OP_GUILD_ROLES,
     OP_GUILD_SETTINGS,
+    OP_GUILD_AUDIT,
     OP_LIST_GUILDS,
     OP_UPDATE_SETTINGS,
     mint_token,
@@ -204,6 +205,11 @@ class BotAPIClient:
             reason,
         )
         raise BotAPIError(reason or "bot API refused the save", response.status_code)
+
+    def audit(self, actor_id: int, guild_id) -> list:
+        return self._get(
+            f"/api/v1/guilds/{int(guild_id)}/audit", OP_GUILD_AUDIT, actor_id, guild_id
+        )
 
     def panel(self, actor_id: int, guild_id) -> dict:
         return self._get(

--- a/src/dashboard/botapi.py
+++ b/src/dashboard/botapi.py
@@ -30,6 +30,7 @@ from api_tokens import (
     OP_GUILD_ROLES,
     OP_GUILD_SETTINGS,
     OP_GUILD_AUDIT,
+    OP_POST_PANEL,
     OP_LIST_GUILDS,
     OP_UPDATE_SETTINGS,
     mint_token,
@@ -205,6 +206,45 @@ class BotAPIClient:
             reason,
         )
         raise BotAPIError(reason or "bot API refused the save", response.status_code)
+
+    def post_panel(self, actor_id: int, guild_id, channel_id) -> dict:
+        """Ask the bot to put the instructions panel in this channel.
+
+        Whether that means posting a new one or refreshing the existing one is
+        the bot's call, not ours -- it is the only side that can see where the
+        panel actually is.
+        """
+        token = mint_token(
+            self.signing_key,
+            actor_id=int(actor_id),
+            operation=OP_POST_PANEL,
+            guild_id=int(guild_id),
+        )
+        try:
+            response = self._session.post(
+                f"{self.base_url}/api/v1/guilds/{int(guild_id)}/panel",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"channel_id": str(channel_id)},
+                timeout=self.timeout,
+            )
+        except requests.exceptions.SSLError as error:
+            raise BotAPIError(f"TLS failure talking to the bot API: {error}") from error
+        except requests.RequestException as error:
+            raise BotAPIError(f"could not reach the bot API: {error}") from error
+
+        if response.status_code == 200:
+            return response.json()
+
+        reason = ""
+        try:
+            reason = response.json().get("error", "")
+        except ValueError:
+            pass
+        logger.warning(
+            "bot API refused a panel post for actor=%s guild=%s: %s %s",
+            actor_id, guild_id, response.status_code, reason,
+        )
+        raise BotAPIError(reason or "bot API refused the panel post", response.status_code)
 
     def audit(self, actor_id: int, guild_id) -> list:
         return self._get(

--- a/src/dashboard/sessions.py
+++ b/src/dashboard/sessions.py
@@ -43,7 +43,11 @@ CREATE TABLE IF NOT EXISTS sessions (
     guilds_json    TEXT,
     guilds_at      INTEGER,
     created_at     INTEGER NOT NULL,
-    expires_at     INTEGER NOT NULL
+    expires_at     INTEGER NOT NULL,
+    -- A one-shot notice for the next render: "saved", "panel:moved",
+    -- "error:requires_premium". Server-side so the page cannot be made to
+    -- claim something happened by anyone who can craft a link.
+    notice         TEXT
 );
 CREATE INDEX IF NOT EXISTS sessions_expires_at ON sessions (expires_at);
 """
@@ -86,7 +90,42 @@ class SessionStore:
         conn = sqlite3.connect(self.path, timeout=10)
         conn.row_factory = sqlite3.Row
         conn.executescript(_SCHEMA)
+        # `notice` arrived after the first sessions.sqlite files existed, and a
+        # session store is not worth a migration framework: an existing file
+        # would otherwise keep working right up until the first save, then fail
+        # on an unknown column.
+        columns = {row["name"] for row in conn.execute("PRAGMA table_info(sessions)")}
+        if "notice" not in columns:
+            conn.execute("ALTER TABLE sessions ADD COLUMN notice TEXT")
+            conn.commit()
         return conn
+
+    # ----- one-shot notices -----
+    def set_notice(self, sid: Optional[str], notice: Optional[str]) -> None:
+        """Park a notice for the next page this session renders.
+
+        Notices used to travel as query parameters, which meant anyone who could
+        get an admin to open a link could show them "Saved." for a save that
+        never happened -- most usefully to stop them noticing something was
+        broken. Here it is written by the request that actually did the thing.
+        """
+        if not sid:
+            return
+        with self._connect() as conn:
+            conn.execute("UPDATE sessions SET notice = ? WHERE sid = ?", (notice, sid))
+
+    def take_notice(self, sid: Optional[str]) -> Optional[str]:
+        """Read the pending notice and clear it, so a reload does not repeat it."""
+        if not sid:
+            return None
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT notice FROM sessions WHERE sid = ?", (sid,)
+            ).fetchone()
+            if row is None or row["notice"] is None:
+                return None
+            conn.execute("UPDATE sessions SET notice = NULL WHERE sid = ?", (sid,))
+            return row["notice"]
 
     # ----- lifecycle -----
     def begin_login(self, oauth_state: str, now: Optional[float] = None) -> Session:

--- a/src/dashboard/settings_view.py
+++ b/src/dashboard/settings_view.py
@@ -480,6 +480,71 @@ def _log_channel_field(settings: dict, channels: Optional[list]) -> Field:
     )
 
 
+# Labels for the audit list. Deliberately the same words the settings above
+# use, so a line of history is recognisably about a control on this page.
+AUDIT_LABELS = {
+    "role_id": "Verified role",
+    "unverified_role_id": "Unverified role",
+    "auto_verify_new_members": "Auto-verify on join",
+    "auto_nickname_change": "Nickname sync",
+    "custom_verification_requested_message": "Custom verification message",
+    "instructions_locale": "Language",
+    "panel_embed_color": "Panel colour",
+    "panel_show_icon": "Server icon on the panel",
+    "verification_log_channel_id": "Verification log channel",
+}
+
+# Long enough to recognise a message, short enough that one entry cannot push
+# the rest of the history off the screen.
+AUDIT_VALUE_MAX = 80
+
+
+def build_audit(
+    entries: Optional[list],
+    roles: Optional[list],
+    channels: Optional[list],
+) -> Optional[list]:
+    """The change history, with ids resolved and values fit to read.
+
+    None means the bot could not answer, which the page says out loud -- an
+    empty history and an unavailable one are different facts, and a trail that
+    quietly renders as "nothing happened" is worse than one that admits it does
+    not know.
+    """
+    if entries is None:
+        return None
+    return [
+        {
+            "label": AUDIT_LABELS.get(entry.get("field"), entry.get("field")),
+            "actor": entry.get("actor_name") or f"ID {entry.get('actor_id')}",
+            "old": _audit_value(entry.get("field"), entry.get("old_value"), roles, channels),
+            "new": _audit_value(entry.get("field"), entry.get("new_value"), roles, channels),
+            "when": entry.get("changed_at"),
+        }
+        for entry in entries
+    ]
+
+
+def _audit_value(field, raw, roles, channels) -> str:
+    """One stored value, as something an admin can read."""
+    if raw is None or raw == "":
+        return "not set"
+    if field in {"role_id", "unverified_role_id"}:
+        role = _lookup(roles, raw)
+        return role.get("name") if role else f"a role that no longer exists ({raw})"
+    if field == "verification_log_channel_id":
+        channel = _lookup(channels, raw)
+        return f"#{channel['name']}" if channel else f"a channel that no longer exists ({raw})"
+    if field == "panel_embed_color":
+        return _hex(raw) or str(raw)
+    if field == "instructions_locale":
+        return locale_label(str(raw))
+    if raw in {"True", "False"}:
+        return "on" if raw == "True" else "off"
+    text = str(raw)
+    return text if len(text) <= AUDIT_VALUE_MAX else text[: AUDIT_VALUE_MAX - 1] + "…"
+
+
 def panel_summary(panel: Optional[dict]) -> dict:
     """The instructions panel's whereabouts, as a template-ready dict.
 

--- a/src/dashboard/settings_view.py
+++ b/src/dashboard/settings_view.py
@@ -338,6 +338,17 @@ def build_groups(
             "blurb": "The message members use to start verification.",
             "fields": [locale, color, icon],
             "panel": panel_summary(panel),
+            # Where the panel may be posted. Announcement channels are NOT
+            # filtered out, unlike the log channel's picker: the panel is public
+            # instructions, and /vrcverify_instructions can be run in one, so
+            # excluding them would be stricter than the bot. Channels the bot
+            # cannot post in are excluded, because that is not a choice.
+            "panel_channels": [
+                (str(channel.get("id")), f"#{channel.get('name') or channel.get('id')}")
+                for channel in (channels or [])
+                if channel.get("can_send") is not False
+            ],
+            "panel_channel_id": (panel or {}).get("channel_id") or "",
             # The only group with a save path so far. The template renders a
             # form when a group names an endpoint AND the bot said at least one
             # of its fields is writable, so opening the next group is a change

--- a/src/dashboard/settings_view.py
+++ b/src/dashboard/settings_view.py
@@ -501,6 +501,20 @@ AUDIT_LABELS = {
     "panel_embed_color": "Panel colour",
     "panel_show_icon": "Server icon on the panel",
     "verification_log_channel_id": "Verification log channel",
+    # Not a setting but an action, and the only row here whose pair is not
+    # (old value, new value) -- the bot stores (what it did, where). Without
+    # this entry the branch's own headline feature rendered its history as the
+    # raw column name and a bare channel id.
+    "instructions_panel": "Instructions panel",
+}
+
+# What the bot writes into old_value for an instructions_panel row, as a phrase
+# rather than a state it moved out of.
+PANEL_ACTIONS = {
+    "posted": "posted in",
+    "moved": "moved to",
+    "refreshed": "refreshed in",
+    "replaced": "replaced in",
 }
 
 # Long enough to recognise a message, short enough that one entry cannot push
@@ -522,28 +536,63 @@ def build_audit(
     """
     if entries is None:
         return None
-    return [
-        {
-            "label": AUDIT_LABELS.get(entry.get("field"), entry.get("field")),
-            "actor": entry.get("actor_name") or f"ID {entry.get('actor_id')}",
-            "old": _audit_value(entry.get("field"), entry.get("old_value"), roles, channels),
-            "new": _audit_value(entry.get("field"), entry.get("new_value"), roles, channels),
-            "when": entry.get("changed_at"),
-        }
-        for entry in entries
-    ]
+    rows = []
+    for entry in entries:
+        field = entry.get("field")
+        # An instructions_panel row is (what happened, where) rather than
+        # (before, after), so its halves resolve differently -- the second one
+        # is a channel id, not another action.
+        new_field = "instructions_panel_channel" if field == "instructions_panel" else field
+        rows.append(
+            {
+                "label": AUDIT_LABELS.get(field, field),
+                "actor": entry.get("actor_name") or f"ID {entry.get('actor_id')}",
+                "old": _audit_value(field, entry.get("old_value"), roles, channels),
+                "new": _audit_value(new_field, entry.get("new_value"), roles, channels),
+                "when": entry.get("changed_at"),
+                # Formatted here, not in the template. The template used to slice
+                # this string, which is the one place bot data was subscripted
+                # rather than printed -- a non-string would have 500'd the page.
+                "when_text": _audit_when(entry.get("changed_at")),
+            }
+        )
+    return rows
+
+
+def _audit_when(raw) -> str:
+    """`2026-08-11T07:11:36...` as `2026-08-11 07:11 UTC`, defensively."""
+    if not isinstance(raw, str) or len(raw) < 16:
+        return ""
+    return raw[:16].replace("T", " ") + " UTC"
 
 
 def _audit_value(field, raw, roles, channels) -> str:
-    """One stored value, as something an admin can read."""
+    """One stored value, as something an admin can read.
+
+    `roles`/`channels` are None when that read failed, which is "we could not
+    check" and NOT "it is gone" -- the same distinction _role_field draws above,
+    and the one this function used to lose. Telling an admin their verified role
+    was deleted when it was not is exactly the kind of false statement the rest
+    of this module is written to avoid.
+    """
     if raw is None or raw == "":
         return "not set"
+    if field == "instructions_panel":
+        return PANEL_ACTIONS.get(str(raw), str(raw))
     if field in {"role_id", "unverified_role_id"}:
+        if roles is None:
+            return f"role {raw}"
         role = _lookup(roles, raw)
-        return role.get("name") if role else f"a role that no longer exists ({raw})"
-    if field == "verification_log_channel_id":
+        if role is None:
+            return f"a role that no longer exists ({raw})"
+        return role.get("name") or f"Role {raw}"
+    if field in {"verification_log_channel_id", "instructions_panel_channel"}:
+        if channels is None:
+            return f"channel {raw}"
         channel = _lookup(channels, raw)
-        return f"#{channel['name']}" if channel else f"a channel that no longer exists ({raw})"
+        if channel is None:
+            return f"a channel that no longer exists ({raw})"
+        return f"#{channel.get('name') or raw}"
     if field == "panel_embed_color":
         return _hex(raw) or str(raw)
     if field == "instructions_locale":

--- a/src/dashboard/settings_view.py
+++ b/src/dashboard/settings_view.py
@@ -566,7 +566,12 @@ def _panel_channels(channels: Optional[list], panel: Optional[dict]) -> list:
     return [
         (str(channel.get("id")), f"#{channel.get('name') or channel.get('id')}")
         for channel in (channels or [])
-        if channel.get("can_send") is not False or str(channel.get("id")) == here
+        # can_embed, not can_send: the panel is an embed, and a channel with
+        # Send Messages but no Embed Links accepts the log and refuses this.
+        # A bot that predates the flag reports it as None, which is "unknown"
+        # rather than "no" -- offering it and letting the bot refuse is better
+        # than hiding every channel from an older deployment.
+        if channel.get("can_embed") is not False or str(channel.get("id")) == here
     ]
 
 
@@ -593,10 +598,12 @@ def panel_summary(panel: Optional[dict]) -> dict:
         # Deliberately narrow. The panel itself is fine: buttons are
         # interactions, and refreshing it edits a message VRCVerify already
         # owns, neither of which needs Send Messages. Only replacing it does.
+        # Both permissions are named because the panel is an embed, so Embed
+        # Links alone being off produces this with no other symptom.
         warnings.append(
-            "VRCVerify cannot send new messages in that channel. The panel "
-            "still works and can still be refreshed; it just cannot be "
-            "replaced with a new one there."
+            "VRCVerify can't post a new message in that channel — it needs "
+            "both Send Messages and Embed Links there. The panel still works "
+            "and can still be refreshed; it just can't be replaced."
         )
 
     name = panel.get("channel_name")

--- a/src/dashboard/settings_view.py
+++ b/src/dashboard/settings_view.py
@@ -342,12 +342,10 @@ def build_groups(
             # filtered out, unlike the log channel's picker: the panel is public
             # instructions, and /vrcverify_instructions can be run in one, so
             # excluding them would be stricter than the bot. Channels the bot
-            # cannot post in are excluded, because that is not a choice.
-            "panel_channels": [
-                (str(channel.get("id")), f"#{channel.get('name') or channel.get('id')}")
-                for channel in (channels or [])
-                if channel.get("can_send") is not False
-            ],
+            # cannot post in are excluded, because that is not a choice --
+            # except the one the panel is already in, where the button refreshes
+            # rather than posts and so needs no Send Messages at all.
+            "panel_channels": _panel_channels(channels, panel),
             "panel_channel_id": (panel or {}).get("channel_id") or "",
             # The only group with a save path so far. The template renders a
             # form when a group names an endpoint AND the bot said at least one
@@ -556,6 +554,22 @@ def _audit_value(field, raw, roles, channels) -> str:
     return text if len(text) <= AUDIT_VALUE_MAX else text[: AUDIT_VALUE_MAX - 1] + "…"
 
 
+def _panel_channels(channels: Optional[list], panel: Optional[dict]) -> list:
+    """Channels the panel button may target.
+
+    Somewhere the bot cannot send is not a real choice, so it is left out --
+    unless the panel already lives there, because then the button refreshes an
+    existing message instead of sending a new one. Dropping that option would
+    make this page refuse a thing the bot does unprompted on every restart.
+    """
+    here = str((panel or {}).get("channel_id") or "") if (panel or {}).get("posted") else ""
+    return [
+        (str(channel.get("id")), f"#{channel.get('name') or channel.get('id')}")
+        for channel in (channels or [])
+        if channel.get("can_send") is not False or str(channel.get("id")) == here
+    ]
+
+
 def panel_summary(panel: Optional[dict]) -> dict:
     """The instructions panel's whereabouts, as a template-ready dict.
 
@@ -575,10 +589,14 @@ def panel_summary(panel: Optional[dict]) -> dict:
             "The channel this panel was posted in no longer exists, so members "
             "have no way to start verifying."
         )
-    elif panel.get("channel_reachable") is False:
+    elif panel.get("channel_postable") is False:
+        # Deliberately narrow. The panel itself is fine: buttons are
+        # interactions, and refreshing it edits a message VRCVerify already
+        # owns, neither of which needs Send Messages. Only replacing it does.
         warnings.append(
-            "VRCVerify can no longer post in that channel, so it cannot refresh "
-            "this panel."
+            "VRCVerify cannot send new messages in that channel. The panel "
+            "still works and can still be refreshed; it just cannot be "
+            "replaced with a new one there."
         )
 
     name = panel.get("channel_name")

--- a/src/dashboard/static/style.css
+++ b/src/dashboard/static/style.css
@@ -295,3 +295,16 @@ textarea {
   padding: 0.45rem 0.55rem;
   resize: vertical;
 }
+
+/* --- change history --- */
+.audit { list-style: none; margin: 0; padding: 0; }
+
+.audit li {
+  padding: 0.55rem 0;
+  border-top: 1px solid var(--line);
+  font-size: 0.9rem;
+  overflow-wrap: anywhere;
+}
+
+.audit-what { font-weight: 600; margin-right: 0.4rem; }
+.audit-who { display: block; font-size: 0.825rem; }

--- a/src/dashboard/static/style.css
+++ b/src/dashboard/static/style.css
@@ -308,3 +308,16 @@ textarea {
 
 .audit-what { font-weight: 600; margin-right: 0.4rem; }
 .audit-who { display: block; font-size: 0.825rem; }
+
+.panel-post {
+  margin-top: 1.1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--line);
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.panel-post label { font-size: 0.95rem; }
+.panel-post .desc { flex-basis: 100%; margin: 0; }

--- a/src/dashboard/templates/settings.html
+++ b/src/dashboard/templates/settings.html
@@ -39,6 +39,15 @@
   {% if saved %}
     <p class="notice ok">Saved.</p>
   {% endif %}
+  {# Saved, but the live panel did not take it. Almost always a panel posted by
+     an older /vrcverify_instructions, which Discord will not let the bot edit
+     -- so the only repair is the replace the panel button below performs. #}
+  {% if panel_stale %}
+    <p class="notice">
+      Your settings were saved, but the instructions panel still shows the old
+      ones. Use <strong>Repost or move panel</strong> below to replace it.
+    </p>
+  {% endif %}
   {% if panel_result %}
     <p class="notice ok">{{ panel_result }}</p>
   {% endif %}
@@ -260,8 +269,8 @@
           <li>
             <span class="audit-what">{{ entry.label }}</span>
             <span class="muted">{{ entry.old }} &rarr; {{ entry.new }}</span>
-            <span class="muted audit-who">{{ entry.actor }}{% if entry.when %} &middot;
-              <time datetime="{{ entry.when }}">{{ entry.when[:16] | replace("T", " ") }} UTC</time>
+            <span class="muted audit-who">{{ entry.actor }}{% if entry.when_text %} &middot;
+              <time datetime="{{ entry.when }}">{{ entry.when_text }}</time>
             {% endif %}</span>
           </li>
         {% endfor %}

--- a/src/dashboard/templates/settings.html
+++ b/src/dashboard/templates/settings.html
@@ -224,12 +224,18 @@
           <button type="submit" class="button">
             {%- if group.panel.posted %}Repost or move panel{% else %}Post panel{% endif -%}
           </button>
+          {# This is a separate form from the settings above -- it has to be,
+             it posts elsewhere -- so a language picked but not saved is not
+             part of it. Saying so beats letting an admin click here and
+             wonder why nothing changed. #}
           <span class="muted desc">
             {% if group.panel.posted %}
               Choosing the channel it's already in refreshes it rather than
-              posting a second one.
+              posting a second one. This button only moves the panel; saving
+              the settings above is what changes what it says.
             {% else %}
-              Members use this message to start verifying.
+              Members use this message to start verifying. It is posted with
+              the settings saved above.
             {% endif %}
           </span>
         </form>

--- a/src/dashboard/templates/settings.html
+++ b/src/dashboard/templates/settings.html
@@ -207,5 +207,30 @@
     </section>
   {% endfor %}
 
+  <section class="group">
+    <h2>Recent changes</h2>
+    <p class="muted blurb">
+      Settings changed from this website. Changes made with slash commands in
+      Discord aren't listed here.
+    </p>
+
+    {% if audit is none %}
+      <p class="muted">Couldn't load the history just now. Try again shortly.</p>
+    {% elif not audit %}
+      <p class="muted">No changes have been made from the website yet.</p>
+    {% else %}
+      <ul class="audit">
+        {% for entry in audit %}
+          <li>
+            <span class="audit-what">{{ entry.label }}</span>
+            <span class="muted">{{ entry.old }} &rarr; {{ entry.new }}</span>
+            <span class="muted audit-who">{{ entry.actor }}{% if entry.when %} &middot;
+              <time datetime="{{ entry.when }}">{{ entry.when[:16] | replace("T", " ") }} UTC</time>
+            {% endif %}</span>
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </section>
 </section>
 {% endblock %}

--- a/src/dashboard/templates/settings.html
+++ b/src/dashboard/templates/settings.html
@@ -39,6 +39,9 @@
   {% if saved %}
     <p class="notice ok">Saved.</p>
   {% endif %}
+  {% if panel_result %}
+    <p class="notice ok">{{ panel_result }}</p>
+  {% endif %}
   {% if save_error %}
     <p class="notice">{{ save_error }}</p>
   {% endif %}
@@ -202,6 +205,33 @@
 
       {% if group.save_endpoint and editable %}
         <p class="actions"><button type="submit" class="button">Save changes</button></p>
+        </form>
+      {% endif %}
+
+      {# Its own form, after the settings one closes: this posts to a different
+         endpoint, and a form inside a form is not a thing. #}
+      {% if group.panel_channels %}
+        <form method="post" action="{{ url_for('post_panel', guild_id=guild_id) }}"
+              class="panel-post">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+          <label for="panel_channel_id">Post the panel in</label>
+          <select name="panel_channel_id" id="panel_channel_id">
+            {% for channel_id, label in group.panel_channels %}
+              <option value="{{ channel_id }}"
+                {%- if channel_id == group.panel_channel_id %} selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+          </select>
+          <button type="submit" class="button">
+            {%- if group.panel.posted %}Repost or move panel{% else %}Post panel{% endif -%}
+          </button>
+          <span class="muted desc">
+            {% if group.panel.posted %}
+              Choosing the channel it's already in refreshes it rather than
+              posting a second one.
+            {% else %}
+              Members use this message to start verifying.
+            {% endif %}
+          </span>
         </form>
       {% endif %}
     </section>

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -49,14 +49,15 @@ def run(coro):
 # -------------------------------------------------------------------
 # Fakes
 # -------------------------------------------------------------------
-def make_deps(written=None, **overrides) -> bot_api.BotAPIDeps:
+def make_deps(written=None, posted=None, **overrides) -> bot_api.BotAPIDeps:
     """A permissive set of capabilities, so each test breaks exactly one thing.
 
-    `written` collects what reached the writer, so a test can assert the
-    handler passed the body through unchanged -- and, more usefully, that a
-    refused request never reached it at all.
+    `written` and `posted` collect what reached the two mutating capabilities,
+    so a test can assert the handler passed the body through unchanged -- and,
+    more usefully, that a refused request never reached them at all.
     """
     written = [] if written is None else written
+    posted = [] if posted is None else posted
 
     async def is_admin(guild_id, user_id):
         return int(user_id) == ADMIN_ID
@@ -81,6 +82,10 @@ def make_deps(written=None, **overrides) -> bot_api.BotAPIDeps:
     async def read_audit(guild_id):
         return []
 
+    async def post_panel(guild_id, actor_id, channel_id):
+        posted.append((int(guild_id), int(actor_id), str(channel_id)))
+        return {"action": "posted", "channel_id": str(channel_id)}
+
     async def write_settings(guild_id, actor_id, changes):
         written.append((int(guild_id), int(actor_id), dict(changes)))
         return {"guild_id": str(guild_id), "fields": {}, "written": dict(changes)}
@@ -96,6 +101,7 @@ def make_deps(written=None, **overrides) -> bot_api.BotAPIDeps:
         read_panel=read_panel,
         read_audit=read_audit,
         write_settings=write_settings,
+        post_panel=post_panel,
     )
     defaults.update(overrides)
     return bot_api.BotAPIDeps(**defaults)
@@ -962,26 +968,27 @@ class TestTheWritePath:
         assert actor == ADMIN_ID
 
 
-class TestWriteSurfaceIsExactlyOneThing:
-    """Step 5 opens a write path. These pin how far it opens, and no further.
+class TestWriteSurfaceIsExactlyTwoThings:
+    """These pin how far the API can change things, and no further.
 
     Editing any of them is how you widen what the website can do to a server,
     which is the point: it cannot happen as a side effect of adding a route or
     a dependency.
     """
 
-    def test_the_only_write_route_is_the_settings_patch(self):
+    def test_the_only_mutating_routes_are_the_settings_patch_and_the_panel_post(self):
         app = bot_api.create_app(make_config(), make_deps())
         writes = {
             (route.method, route.resource.canonical)
             for route in app.router.routes()
             if route.method not in {"GET", "HEAD"}
         }
-        assert writes == {("PATCH", "/api/v1/guilds/{guild_id}/settings")}, (
-            f"an unexpected write route appeared: {writes}"
-        )
+        assert writes == {
+            ("PATCH", "/api/v1/guilds/{guild_id}/settings"),
+            ("POST", "/api/v1/guilds/{guild_id}/panel"),
+        }, f"an unexpected write route appeared: {writes}"
 
-    def test_the_api_holds_exactly_one_writer(self):
+    def test_the_api_holds_one_writer_and_one_action(self):
         assert bot_api.deps_field_names() == frozenset(
             {
                 "is_ready",
@@ -994,12 +1001,13 @@ class TestWriteSurfaceIsExactlyOneThing:
                 "read_panel",
                 "read_audit",
                 "write_settings",
+                "post_panel",
             }
         )
 
     def test_every_capability_is_named_for_what_it_does(self):
         for field in dataclass_fields(bot_api.BotAPIDeps):
-            assert field.name.startswith(("read_", "is_", "guild_", "write_"))
+            assert field.name.startswith(("read_", "is_", "guild_", "write_", "post_"))
 
     def test_the_module_decides_nothing_about_which_fields_are_writable(self):
         """The allowlist lives in the bot, not in the internet-facing path.
@@ -1593,6 +1601,136 @@ class TestSettingsWriter:
         make_server()
         result = write({"instructions_locale": "ja"})
         assert result == run(bot.read_dashboard_settings(GUILD_ID))
+
+
+class TestPanelAction:
+    """Posting a panel is the one thing that shows up in somebody's server."""
+
+    def setup_guild(self, monkeypatch, sendable=True, sent=None):
+        sent = [] if sent is None else sent
+
+        class Sendable(FakeChannel):
+            async def send(self, **kwargs):
+                sent.append((self.id, kwargs))
+                return SimpleNamespace(id=555000 + self.id)
+
+            def permissions_for(self, _member):
+                return SimpleNamespace(
+                    view_channel=True, send_messages=sendable, embed_links=sendable
+                )
+
+        guild = FakeGuild(
+            channels=[Sendable(70, "verify"), Sendable(71, "general", position=1)]
+        )
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
+        monkeypatch.setattr(
+            bot, "build_instructions_embed", lambda *a, **k: SimpleNamespace()
+        )
+        monkeypatch.setattr(
+            bot, "VRCVerifyInstructionView", lambda **k: SimpleNamespace()
+        )
+        return sent
+
+    def post(self, channel_id="70"):
+        return run(bot.post_dashboard_panel(GUILD_ID, ADMIN_ID, channel_id))
+
+    def test_a_first_post_records_where_it_went(self, monkeypatch, subscribed):
+        sent = self.setup_guild(monkeypatch)
+        make_server()
+        result = self.post()
+        assert result["action"] == "posted"
+        assert len(sent) == 1
+        with bot.session_scope() as session:
+            srv = session.query(bot.Server).filter_by(server_id=str(GUILD_ID)).first()
+            assert srv.instructions_channel_id == "70"
+            assert srv.instructions_message_id == "555070"
+
+    def test_posting_into_the_same_channel_refreshes_instead(
+        self, monkeypatch, subscribed
+    ):
+        """The double-click case. One edit, not a second live panel."""
+        sent = self.setup_guild(monkeypatch)
+        make_server(instructions_channel_id="70", instructions_message_id="900")
+        probed = []
+
+        async def fake_probe(entry, rebuild_embed):
+            probed.append(entry)
+            return "ok"
+
+        monkeypatch.setattr(bot, "probe_instruction_panel", fake_probe)
+
+        assert self.post()["action"] == "refreshed"
+        assert sent == []          # nothing new was posted
+        assert len(probed) == 1
+
+    def test_a_different_channel_is_a_move_and_says_where_the_old_one_is(
+        self, monkeypatch, subscribed
+    ):
+        sent = self.setup_guild(monkeypatch)
+        make_server(instructions_channel_id="70", instructions_message_id="900")
+        result = self.post("71")
+        assert result["action"] == "moved"
+        assert result["previous_channel_id"] == "70"
+        assert len(sent) == 1
+
+    def test_a_record_pointing_at_a_deleted_message_posts_afresh(
+        self, monkeypatch, subscribed
+    ):
+        sent = self.setup_guild(monkeypatch)
+        make_server(instructions_channel_id="70", instructions_message_id="900")
+
+        async def gone(entry, rebuild_embed):
+            return "gone"
+
+        monkeypatch.setattr(bot, "probe_instruction_panel", gone)
+        assert self.post()["action"] == "posted"
+        assert len(sent) == 1
+
+    def test_nothing_is_posted_when_the_record_cannot_be_read(
+        self, monkeypatch, subscribed
+    ):
+        """"No panel" and "the database blinked" look identical here.
+
+        Guessing wrong leaves a duplicate in somebody's server, so it refuses.
+        """
+        sent = self.setup_guild(monkeypatch)
+        make_server()
+
+        def boom(_guild_id):
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(bot, "_stored_panel_location", boom)
+        assert self.post() is None
+        assert sent == []
+
+    def test_a_channel_outside_the_guild_is_refused(self, monkeypatch, subscribed):
+        sent = self.setup_guild(monkeypatch)
+        make_server()
+        with pytest.raises(bot.SettingRejected) as caught:
+            self.post("9999")
+        assert caught.value.reason == "channel_not_in_guild"
+        assert sent == []
+
+    def test_a_channel_the_bot_cannot_post_in_is_refused(
+        self, monkeypatch, subscribed
+    ):
+        sent = self.setup_guild(monkeypatch, sendable=False)
+        make_server()
+        with pytest.raises(bot.SettingRejected) as caught:
+            self.post()
+        assert caught.value.reason == "channel_not_writable"
+        assert sent == []
+
+    def test_the_action_is_audited(self, monkeypatch, subscribed):
+        self.setup_guild(monkeypatch)
+        make_server()
+        self.post()
+        assert audit_rows()[0][:3] == ("instructions_panel", "posted", "70")
+
+    def test_a_guild_the_bot_cannot_see_posts_nothing(self, monkeypatch, subscribed):
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: None)
+        make_server()
+        assert self.post() is None
 
 
 class TestAuditReader:

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -528,6 +528,39 @@ class TestRequests:
         results = serve(scenario, config=make_config(rate_limit=2))
         assert [status for status, _ in results] == [200, 200, 429]
 
+    def test_writes_have_their_own_smaller_budget(self):
+        """A GET costs Discord nothing; a save costs it real REST calls.
+
+        The general budget was sized when every route was a cached read, so
+        writes are metered again on top of it rather than sharing that number.
+        """
+
+        async def scenario(client):
+            results = []
+            for _ in range(3):
+                results.append(
+                    await patch(client, SETTINGS_PATH, token_for(WRITE_OP),
+                                json={"fields": {"instructions_locale": "de"}})
+                )
+            return results
+
+        results = serve(scenario, config=make_config(write_rate_limit=2))
+        assert [status for status, _ in results] == [200, 200, 429]
+
+    def test_reads_do_not_spend_the_write_budget(self):
+        """Otherwise hammering the picker would lock an admin out of saving."""
+
+        async def scenario(client):
+            for _ in range(5):
+                await get(client, SETTINGS_PATH, token_for(SETTINGS_OP))
+            return await patch(
+                client, SETTINGS_PATH, token_for(WRITE_OP),
+                json={"fields": {"instructions_locale": "de"}},
+            )
+
+        status, _body = serve(scenario, config=make_config(write_rate_limit=2))
+        assert status == 200
+
     def test_health_is_metered_too(self):
         """The one tokenless endpoint still can't be an unmetered handler."""
 
@@ -2130,6 +2163,24 @@ class TestPanelAction:
 
         monkeypatch.setattr(bot, "restyle_instruction_panel", fine)
         assert "panel_stale" not in write({"instructions_locale": "de"})
+
+    def test_a_row_created_by_posting_names_the_real_owner(
+        self, monkeypatch, subscribed
+    ):
+        """owner_id feeds resolve_config_admin, which decides who gets DMs.
+
+        Filling it with whoever clicked quietly appoints that admin -- and on
+        the dashboard they need not be the owner at all.
+        """
+        self.setup_guild(monkeypatch)
+        with bot.session_scope() as session:
+            session.query(bot.Server).delete()
+
+        assert self.post()["action"] == "posted"
+        with bot.session_scope() as session:
+            srv = session.query(bot.Server).filter_by(server_id=str(GUILD_ID)).first()
+            assert srv.owner_id == str(OWNER_ID)
+            assert srv.owner_id != str(ADMIN_ID)
 
     def test_the_action_is_audited(self, monkeypatch, subscribed):
         self.setup_guild(monkeypatch)

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -78,6 +78,9 @@ def make_deps(written=None, **overrides) -> bot_api.BotAPIDeps:
     async def read_panel(guild_id):
         return {"posted": False}
 
+    async def read_audit(guild_id):
+        return []
+
     async def write_settings(guild_id, actor_id, changes):
         written.append((int(guild_id), int(actor_id), dict(changes)))
         return {"guild_id": str(guild_id), "fields": {}, "written": dict(changes)}
@@ -91,6 +94,7 @@ def make_deps(written=None, **overrides) -> bot_api.BotAPIDeps:
         read_roles=read_roles,
         read_channels=read_channels,
         read_panel=read_panel,
+        read_audit=read_audit,
         write_settings=write_settings,
     )
     defaults.update(overrides)
@@ -988,6 +992,7 @@ class TestWriteSurfaceIsExactlyOneThing:
                 "read_roles",
                 "read_channels",
                 "read_panel",
+                "read_audit",
                 "write_settings",
             }
         )
@@ -1588,6 +1593,52 @@ class TestSettingsWriter:
         make_server()
         result = write({"instructions_locale": "ja"})
         assert result == run(bot.read_dashboard_settings(GUILD_ID))
+
+
+class TestAuditReader:
+    def test_it_returns_this_guilds_changes_newest_first(self, subscribed):
+        make_server()
+        write({"instructions_locale": "de"})
+        write({"instructions_locale": "ja"})
+        entries = run(bot.read_dashboard_audit(GUILD_ID))
+        assert [e["new_value"] for e in entries] == ["ja", "de"]
+        assert all(e["actor_id"] == str(ADMIN_ID) for e in entries)
+
+    def test_it_never_returns_another_guilds_history(self, subscribed):
+        make_server()
+        write({"instructions_locale": "de"})
+        assert run(bot.read_dashboard_audit(OTHER_GUILD_ID)) == []
+
+    def test_an_actor_still_in_the_guild_is_named(self, monkeypatch, subscribed):
+        guild = FakeGuild()
+        guild._members[ADMIN_ID] = SimpleNamespace(display_name="Sasha")
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
+        make_server()
+        write({"instructions_locale": "de"})
+        assert run(bot.read_dashboard_audit(GUILD_ID))[0]["actor_name"] == "Sasha"
+
+    def test_an_actor_who_left_is_still_an_entry(self, monkeypatch, subscribed):
+        """The admin who left is exactly the row worth keeping."""
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: FakeGuild())
+        make_server()
+        write({"instructions_locale": "de"})
+        entry = run(bot.read_dashboard_audit(GUILD_ID))[0]
+        assert entry["actor_name"] is None
+        assert entry["actor_id"] == str(ADMIN_ID)
+
+    def test_the_row_count_is_bounded(self, subscribed):
+        make_server()
+        assert run(bot.read_dashboard_audit(GUILD_ID, limit=10_000)) is not None
+        # A hostile limit cannot turn one page load into a table scan.
+        assert bot.MAX_AUDIT_ROWS <= 50
+
+    def test_an_unreadable_trail_is_none_not_an_empty_history(self, monkeypatch):
+        """Empty and unavailable must not look the same to an admin."""
+        def boom():
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(bot, "session_scope", boom)
+        assert run(bot.read_dashboard_audit(GUILD_ID)) is None
 
 
 class TestBothHalvesTogether:

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -1272,6 +1272,53 @@ class TestSettingsWriter:
         write({"instructions_locale": "en-US"})
         assert audit_rows() == []
 
+    def restyles(self, monkeypatch):
+        seen = []
+
+        async def fake_restyle(guild_id):
+            seen.append(str(guild_id))
+            return "ok"
+
+        monkeypatch.setattr(bot, "restyle_instruction_panel", fake_restyle)
+        return seen
+
+    def test_a_saved_language_is_applied_to_the_live_panel(
+        self, monkeypatch, subscribed
+    ):
+        """Saving the setting is not the whole job -- the panel renders it.
+
+        Nothing else would: the fleet sweep refreshes the view but passes
+        rebuild_embed=False, so the embed would keep the old language until an
+        operator forced a full refresh.
+        """
+        seen = self.restyles(monkeypatch)
+        make_server()
+        write({"instructions_locale": "de"})
+        assert seen == [str(GUILD_ID)]
+
+    def test_saved_branding_is_applied_to_the_live_panel(
+        self, monkeypatch, subscribed
+    ):
+        seen = self.restyles(monkeypatch)
+        make_server()
+        write({"panel_embed_color": 0xFF0000})
+        assert seen == [str(GUILD_ID)]
+
+    def test_a_setting_the_panel_does_not_show_edits_no_panel(
+        self, monkeypatch, subscribed
+    ):
+        """A message edit per save would be a rate limit nobody asked for."""
+        seen = self.restyles(monkeypatch)
+        make_server()
+        write({"role_id": "70"})
+        assert seen == []
+
+    def test_a_no_op_language_save_edits_no_panel(self, monkeypatch, subscribed):
+        seen = self.restyles(monkeypatch)
+        make_server(instructions_locale="en-US")
+        write({"instructions_locale": "en-US"})
+        assert seen == []
+
     def test_half_a_branding_change_keeps_the_other_half(self, subscribed):
         make_server()
         write({"panel_embed_color": 0x00FF00, "panel_show_icon": True})

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -1316,10 +1316,21 @@ class TestSettingsWriter:
     def test_a_setting_the_panel_does_not_show_edits_no_panel(
         self, monkeypatch, subscribed
     ):
-        """A message edit per save would be a rate limit nobody asked for."""
+        """A message edit per save would be a rate limit nobody asked for.
+
+        The audit assertion is load-bearing, not decoration. A save that
+        silently did nothing would leave `seen` empty too, so without proof the
+        write landed this passes whether or not the field filter works -- which
+        is how it was written the first time, using a role id that never got
+        past the "role must be in this guild" check because no guild is mocked
+        in this class.
+        """
         seen = self.restyles(monkeypatch)
         make_server()
-        write({"role_id": "70"})
+        write({"custom_verification_requested_message": "Welcome aboard!"})
+        assert [row[0] for row in audit_rows()] == [
+            "custom_verification_requested_message"
+        ]
         assert seen == []
 
     def test_a_no_op_language_save_edits_no_panel(self, monkeypatch, subscribed):
@@ -1909,7 +1920,14 @@ class TestPanelAction:
     def test_nothing_is_replaced_when_the_message_cannot_be_read(
         self, monkeypatch, subscribed
     ):
-        """"Cannot tell" must not read as "safe to replace" -- that is a duplicate."""
+        """"Cannot tell" must not read as "safe to replace" -- that is a duplicate.
+
+        probe_instruction_panel is stubbed to succeed on purpose. Without it the
+        refresh branch would fail on its own against a disconnected bot and
+        return None too, so the assertion would hold whether or not the guard
+        existed -- it would pass for the wrong reason, which is worse than not
+        being written. Stubbed, "it wrongly carried on" shows up as "refreshed".
+        """
         sent = self.setup_guild(monkeypatch)
         make_server(instructions_channel_id="70", instructions_message_id="900")
 
@@ -1917,6 +1935,7 @@ class TestPanelAction:
             return None
 
         monkeypatch.setattr(bot, "_panel_is_webhook_owned", unreadable)
+        monkeypatch.setattr(bot, "probe_instruction_panel", _always("ok"))
         assert self.post() is None
         assert sent == []
 

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -1689,8 +1689,10 @@ def _always(outcome):
 class TestPanelAction:
     """Posting a panel is the one thing that shows up in somebody's server."""
 
-    def setup_guild(self, monkeypatch, sendable=True, sent=None):
+    def setup_guild(self, monkeypatch, sendable=True, sent=None, webhook_owned=False,
+                    deleted=None):
         sent = [] if sent is None else sent
+        deleted = [] if deleted is None else deleted
 
         class Sendable(FakeChannel):
             async def send(self, **kwargs):
@@ -1701,6 +1703,20 @@ class TestPanelAction:
                 return SimpleNamespace(
                     view_channel=True, send_messages=sendable, embed_links=sendable
                 )
+
+            async def fetch_message(self, message_id):
+                # webhook_id set means the panel was posted as a slash-command
+                # reply, which Discord will not let the bot edit the embed of.
+                return SimpleNamespace(
+                    id=message_id,
+                    webhook_id=1335738139825799188 if webhook_owned else None,
+                )
+
+            def get_partial_message(self, message_id):
+                async def delete():
+                    deleted.append(message_id)
+
+                return SimpleNamespace(id=message_id, delete=delete)
 
         guild = FakeGuild(
             channels=[Sendable(70, "verify"), Sendable(71, "general", position=1)]
@@ -1843,6 +1859,82 @@ class TestPanelAction:
             self.post("71")
         assert caught.value.reason == "channel_not_writable"
         assert sent == []
+
+    def test_a_panel_discord_will_not_let_us_edit_is_replaced(
+        self, monkeypatch, subscribed
+    ):
+        """The bug this whole path exists to survive.
+
+        A panel posted as a slash-command reply belongs to a webhook. Discord
+        answers 200 to an embed edit on one and keeps the old embed, so a
+        language change came out as new buttons above the old text. Refreshing
+        it again would be the same silent no-op, so it is replaced.
+        """
+        deleted = []
+        sent = self.setup_guild(monkeypatch, webhook_owned=True, deleted=deleted)
+        make_server(instructions_channel_id="70", instructions_message_id="900")
+        monkeypatch.setattr(bot, "probe_instruction_panel", _always("ok"))
+
+        result = self.post()
+
+        assert result["action"] == "replaced"
+        assert len(sent) == 1                    # a new message, not an edit
+        assert deleted == [900]                  # and the dead one is gone
+        with bot.session_scope() as session:
+            srv = session.query(bot.Server).filter_by(server_id=str(GUILD_ID)).first()
+            assert srv.instructions_message_id == "555070"
+
+    def test_an_ordinary_panel_is_still_refreshed_not_replaced(
+        self, monkeypatch, subscribed
+    ):
+        """Replacing an editable panel would throw away its pins and links."""
+        deleted = []
+        sent = self.setup_guild(monkeypatch, webhook_owned=False, deleted=deleted)
+        make_server(instructions_channel_id="70", instructions_message_id="900")
+        monkeypatch.setattr(bot, "probe_instruction_panel", _always("ok"))
+
+        assert self.post()["action"] == "refreshed"
+        assert sent == []
+        assert deleted == []
+
+    def test_nothing_is_replaced_when_the_message_cannot_be_read(
+        self, monkeypatch, subscribed
+    ):
+        """"Cannot tell" must not read as "safe to replace" -- that is a duplicate."""
+        sent = self.setup_guild(monkeypatch)
+        make_server(instructions_channel_id="70", instructions_message_id="900")
+
+        async def unreadable(_channel, _message_id):
+            return None
+
+        monkeypatch.setattr(bot, "_panel_is_webhook_owned", unreadable)
+        assert self.post() is None
+        assert sent == []
+
+    def test_a_failed_delete_does_not_undo_the_replacement(
+        self, monkeypatch, subscribed
+    ):
+        """The new panel is up and recorded; the stale one is a cleanup problem."""
+        sent = self.setup_guild(monkeypatch, webhook_owned=True)
+        make_server(instructions_channel_id="70", instructions_message_id="900")
+
+        class Boom(FakeChannel):
+            pass
+
+        def exploding_partial(_self, _mid):
+            async def delete():
+                raise RuntimeError("no manage messages")
+
+            return SimpleNamespace(delete=delete)
+
+        guild = bot.bot.get_guild(GUILD_ID)
+        channel = next(c for c in guild.text_channels if c.id == 70)
+        monkeypatch.setattr(
+            type(channel), "get_partial_message", exploding_partial, raising=False
+        )
+
+        assert self.post()["action"] == "replaced"
+        assert len(sent) == 1
 
     def test_the_action_is_audited(self, monkeypatch, subscribed):
         self.setup_guild(monkeypatch)

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -1699,8 +1699,17 @@ class TestSettingsWriter:
         assert result == run(bot.read_dashboard_settings(GUILD_ID))
 
 
+async def _noop_delete():
+    return None
+
+
+async def _style_ok(_guild_id, _guild):
+    """A resolvable panel style, so probe reaches the edit."""
+    return (0x5865F2, None)
+
+
 def _always(outcome):
-    async def probe(entry, rebuild_embed):
+    async def probe(entry, rebuild_embed, already_checked=False):
         return outcome
 
     return probe
@@ -1717,7 +1726,12 @@ class TestPanelAction:
         class Sendable(FakeChannel):
             async def send(self, **kwargs):
                 sent.append((self.id, kwargs))
-                return SimpleNamespace(id=555000 + self.id)
+                new_id = 555000 + self.id
+
+                async def delete():
+                    deleted.append(new_id)
+
+                return SimpleNamespace(id=new_id, delete=delete)
 
             def permissions_for(self, _member):
                 return SimpleNamespace(
@@ -1772,7 +1786,10 @@ class TestPanelAction:
         make_server(instructions_channel_id="70", instructions_message_id="900")
         probed = []
 
-        async def fake_probe(entry, rebuild_embed):
+        async def fake_probe(entry, rebuild_embed, already_checked=False):
+            # The panel button has already asked whether the message is
+            # editable, so probe must not spend a second fetch on it.
+            assert already_checked is True
             probed.append(entry)
             return "ok"
 
@@ -1798,7 +1815,7 @@ class TestPanelAction:
         sent = self.setup_guild(monkeypatch)
         make_server(instructions_channel_id="70", instructions_message_id="900")
 
-        async def gone(entry, rebuild_embed):
+        async def gone(entry, rebuild_embed, already_checked=False):
             return "gone"
 
         monkeypatch.setattr(bot, "probe_instruction_panel", gone)
@@ -1963,6 +1980,156 @@ class TestPanelAction:
 
         assert self.post()["action"] == "replaced"
         assert len(sent) == 1
+
+    def test_two_overlapping_posts_do_not_produce_two_panels(
+        self, monkeypatch, subscribed
+    ):
+        """The docstring's central promise, against a send that actually yields.
+
+        The fixture's send returns without suspending, so the existing tests
+        could never catch this: the function reads the recorded location and
+        then awaits three times before writing a new one, so two requests in
+        flight together both saw "nothing here" and both posted.
+        """
+        sent = []
+
+        class Slow(FakeChannel):
+            async def send(self, **kwargs):
+                await asyncio.sleep(0)  # a real HTTP call suspends; so does this
+                sent.append(self.id)
+                return SimpleNamespace(id=555000 + self.id)
+
+            def permissions_for(self, _member):
+                return SimpleNamespace(
+                    view_channel=True, send_messages=True, embed_links=True
+                )
+
+            async def fetch_message(self, message_id):
+                await asyncio.sleep(0)
+                return SimpleNamespace(id=message_id, webhook_id=None)
+
+            def get_partial_message(self, message_id):
+                return SimpleNamespace(id=message_id, delete=_noop_delete)
+
+        guild = FakeGuild(channels=[Slow(70, "verify")])
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
+        monkeypatch.setattr(bot, "build_instructions_embed", lambda *a, **k: SimpleNamespace())
+        monkeypatch.setattr(bot, "VRCVerifyInstructionView", lambda **k: SimpleNamespace())
+        # So the loser's refresh reports cleanly instead of failing against a
+        # disconnected bot -- which would return None and hide whether the lock
+        # worked behind a generic failure.
+        monkeypatch.setattr(bot, "probe_instruction_panel", _always("ok"))
+        make_server()
+
+        async def both():
+            return await asyncio.gather(
+                bot.post_dashboard_panel(GUILD_ID, ADMIN_ID, "70"),
+                bot.post_dashboard_panel(GUILD_ID, ADMIN_ID, "70"),
+            )
+
+        results = asyncio.run(both())
+
+        assert len(sent) == 1, "a double click posted two live panels"
+        # The second request found the first one's panel and refreshed it.
+        assert {r["action"] for r in results} == {"posted", "refreshed"}
+
+    def test_a_panel_that_cannot_be_recorded_is_taken_back_down(
+        self, monkeypatch, subscribed
+    ):
+        """An unrecorded panel has live buttons and nothing that can find it.
+
+        The admin sees a failure and clicks again, so leaving it up costs one
+        orphan per retry.
+        """
+        deleted = []
+        sent = self.setup_guild(monkeypatch, deleted=deleted)
+        make_server()
+
+        class Boom(Exception):
+            pass
+
+        real_scope = bot.session_scope
+        calls = {"n": 0}
+
+        def failing_scope(*args, **kwargs):
+            # Let the reads through; break only the write that records the ids.
+            calls["n"] += 1
+            if calls["n"] >= 2:
+                raise Boom("db down")
+            return real_scope(*args, **kwargs)
+
+        monkeypatch.setattr(bot, "session_scope", failing_scope)
+
+        assert self.post() is None
+        assert len(sent) == 1
+        assert deleted == [555070], "the unrecorded panel was left live"
+
+    def test_probe_skips_the_ownership_fetch_when_told_it_was_done(
+        self, monkeypatch
+    ):
+        """One question, one fetch. The panel button has already asked.
+
+        Without this the POST costs three Discord calls (two fetches and an
+        edit) where the design assumes one edit.
+        """
+        asked = []
+
+        async def spy(_channel, message_id):
+            asked.append(message_id)
+            return False
+
+        monkeypatch.setattr(bot, "_panel_is_webhook_owned", spy)
+        monkeypatch.setattr(bot, "resolve_panel_style", _style_ok)
+        monkeypatch.setattr(bot, "build_instructions_embed", lambda *a, **k: SimpleNamespace())
+        monkeypatch.setattr(bot, "VRCVerifyInstructionView", lambda **k: SimpleNamespace())
+
+        edits = []
+
+        class Msg:
+            async def edit(self, **payload):
+                edits.append(payload)
+
+        monkeypatch.setattr(
+            bot.bot, "get_partial_messageable",
+            lambda _cid: SimpleNamespace(get_partial_message=lambda _mid: Msg()),
+        )
+        entry = {"server_id": str(GUILD_ID), "channel_id": "70",
+                 "message_id": "900", "locale": "en-US"}
+
+        run(bot.probe_instruction_panel(entry, rebuild_embed=True, already_checked=True))
+        assert asked == [], "asked Discord a question the caller had answered"
+        assert len(edits) == 1
+
+        run(bot.probe_instruction_panel(entry, rebuild_embed=True))
+        assert asked == ["900"], "the default must still check"
+
+    def test_a_frozen_panel_makes_the_save_report_it(self, monkeypatch, subscribed):
+        """Storing the value is not the same as the panel showing it.
+
+        This is the production symptom that started the investigation: the
+        setting saved, the page showed the new language, and the panel silently
+        stayed as it was.
+        """
+        make_server()
+
+        async def frozen(_guild_id):
+            return "frozen"
+
+        monkeypatch.setattr(bot, "restyle_instruction_panel", frozen)
+        result = write({"instructions_locale": "de"})
+        assert result["fields"]["instructions_locale"]["value"] == "de"
+        assert result["panel_stale"] == "frozen"
+
+    def test_a_clean_restyle_says_nothing_about_staleness(
+        self, monkeypatch, subscribed
+    ):
+        make_server()
+
+        async def fine(_guild_id):
+            return "ok"
+
+        monkeypatch.setattr(bot, "restyle_instruction_panel", fine)
+        assert "panel_stale" not in write({"instructions_locale": "de"})
 
     def test_the_action_is_audited(self, monkeypatch, subscribed):
         self.setup_guild(monkeypatch)

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -1054,19 +1054,28 @@ class FakeRole:
 
 
 class FakeChannel:
-    def __init__(self, channel_id, name, position=0, news=False, sendable=True):
+    def __init__(self, channel_id, name, position=0, news=False, sendable=True,
+                 embeddable=None):
         self.id = channel_id
         self.name = name
         self.position = position
         self.category = None
         self._news = news
         self._sendable = sendable
+        # Defaults to following send_messages, because the interesting case is
+        # the channel that grants one and not the other -- which accepts the
+        # verification log and refuses the instructions panel.
+        self._embeddable = sendable if embeddable is None else embeddable
 
     def is_news(self):
         return self._news
 
     def permissions_for(self, _member):
-        return SimpleNamespace(view_channel=True, send_messages=self._sendable)
+        return SimpleNamespace(
+            view_channel=True,
+            send_messages=self._sendable,
+            embed_links=self._embeddable,
+        )
 
 
 class FakeGuild:
@@ -2156,6 +2165,31 @@ class TestChannelReader:
         monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
         assert run(bot.read_dashboard_channels(GUILD_ID))[0]["can_send"] is False
 
+    def test_send_without_embed_links_is_its_own_answer(self, monkeypatch):
+        """The permission pair that cost a long debugging session.
+
+        The verification log is plain text and only needs Send Messages; the
+        instructions panel is an embed and needs both. A channel granting one
+        and not the other reads as perfectly writable and then refuses the
+        panel, so the two questions get two flags.
+        """
+        guild = FakeGuild(
+            channels=[FakeChannel(1, "no-embeds", sendable=True, embeddable=False)]
+        )
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
+        channel = run(bot.read_dashboard_channels(GUILD_ID))[0]
+        assert channel["can_send"] is True
+        assert channel["can_embed"] is False
+
+    def test_a_channel_it_cannot_see_can_do_neither(self, monkeypatch):
+        guild = FakeGuild(
+            channels=[FakeChannel(1, "hidden", sendable=False, embeddable=True)]
+        )
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
+        channel = run(bot.read_dashboard_channels(GUILD_ID))[0]
+        assert channel["can_send"] is False
+        assert channel["can_embed"] is False
+
 
 class TestPanelReader:
     def test_no_panel_reads_as_not_posted(self, monkeypatch):
@@ -2178,6 +2212,16 @@ class TestPanelReader:
         panel = run(bot.read_dashboard_panel(GUILD_ID))
         assert panel["channel_exists"] is False
         assert panel["channel_postable"] is None
+
+    def test_a_channel_without_embed_links_is_not_postable(self, monkeypatch):
+        """Send Messages alone is not enough for a panel, and this is the only
+        place that says so before the post is attempted and refused."""
+        make_server(instructions_channel_id="1", instructions_message_id="55")
+        guild = FakeGuild(
+            channels=[FakeChannel(1, "verify", sendable=True, embeddable=False)]
+        )
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
+        assert run(bot.read_dashboard_panel(GUILD_ID))["channel_postable"] is False
 
     def test_a_locked_channel_reports_unpostable_not_broken(self, monkeypatch):
         """A panel in a channel the bot cannot send to is still a live panel.

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -1319,6 +1319,35 @@ class TestSettingsWriter:
         write({"instructions_locale": "en-US"})
         assert seen == []
 
+    def test_the_message_discord_receives_is_in_the_new_language(
+        self, monkeypatch, subscribed
+    ):
+        """The whole chain, faked only at the HTTP boundary.
+
+        Every step between the save and the edit is real -- the servers row,
+        load_instruction_panel, resolve_panel_style, build_instructions_embed --
+        because the halves each worked and the language still did not change.
+        """
+        edits = []
+
+        class FakeMessage:
+            async def edit(self, **payload):
+                edits.append(payload)
+
+        monkeypatch.setattr(
+            bot.bot,
+            "get_partial_messageable",
+            lambda _cid: SimpleNamespace(get_partial_message=lambda _mid: FakeMessage()),
+        )
+        make_server(instructions_channel_id="70", instructions_message_id="900")
+
+        write({"instructions_locale": "ja"})
+
+        assert len(edits) == 1
+        german = bot.build_instructions_embed("ja")
+        assert edits[0]["embed"].title == german.title
+        assert edits[0]["embed"].title != bot.build_instructions_embed("en-US").title
+
     def test_half_a_branding_change_keeps_the_other_half(self, subscribed):
         make_server()
         write({"panel_embed_color": 0x00FF00, "panel_show_icon": True})

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -1603,6 +1603,13 @@ class TestSettingsWriter:
         assert result == run(bot.read_dashboard_settings(GUILD_ID))
 
 
+def _always(outcome):
+    async def probe(entry, rebuild_embed):
+        return outcome
+
+    return probe
+
+
 class TestPanelAction:
     """Posting a panel is the one thing that shows up in somebody's server."""
 
@@ -1718,6 +1725,46 @@ class TestPanelAction:
         make_server()
         with pytest.raises(bot.SettingRejected) as caught:
             self.post()
+        assert caught.value.reason == "channel_not_writable"
+        assert sent == []
+
+    def test_a_locked_channel_can_still_have_its_own_panel_refreshed(
+        self, monkeypatch, subscribed
+    ):
+        """Send Messages is the wrong test for a refresh -- it edits.
+
+        The startup sweep edits this panel every restart with no permission
+        check at all, so refusing here would make the dashboard stricter than
+        the bot it configures.
+        """
+        sent = self.setup_guild(monkeypatch, sendable=False)
+        make_server(instructions_channel_id="70", instructions_message_id="900")
+        monkeypatch.setattr(
+            bot, "probe_instruction_panel", _always("ok")
+        )
+        assert self.post()["action"] == "refreshed"
+        assert sent == []
+
+    def test_a_refresh_discord_actually_refuses_is_reported(
+        self, monkeypatch, subscribed
+    ):
+        """Attempting the edit is the honest test; Forbidden is its answer."""
+        self.setup_guild(monkeypatch)
+        make_server(instructions_channel_id="70", instructions_message_id="900")
+        monkeypatch.setattr(bot, "probe_instruction_panel", _always("forbidden"))
+        with pytest.raises(bot.SettingRejected) as caught:
+            self.post()
+        assert caught.value.reason == "channel_not_writable"
+
+    def test_a_locked_channel_holding_no_panel_is_still_refused(
+        self, monkeypatch, subscribed
+    ):
+        """The relaxation is only for the channel the panel is already in."""
+        sent = self.setup_guild(monkeypatch, sendable=False)
+        make_server(instructions_channel_id="70", instructions_message_id="900")
+        monkeypatch.setattr(bot, "probe_instruction_panel", _always("ok"))
+        with pytest.raises(bot.SettingRejected) as caught:
+            self.post("71")
         assert caught.value.reason == "channel_not_writable"
         assert sent == []
 
@@ -1955,14 +2002,28 @@ class TestPanelReader:
         panel = run(bot.read_dashboard_panel(GUILD_ID))
         assert panel["posted"] is True
         assert panel["channel_name"] == "verify"
-        assert panel["channel_reachable"] is True
+        assert panel["channel_postable"] is True
 
     def test_a_deleted_channel_is_reported(self, monkeypatch):
         make_server(instructions_channel_id="999", instructions_message_id="55")
         monkeypatch.setattr(bot.bot, "get_guild", lambda _id: FakeGuild())
         panel = run(bot.read_dashboard_panel(GUILD_ID))
         assert panel["channel_exists"] is False
-        assert panel["channel_reachable"] is None
+        assert panel["channel_postable"] is None
+
+    def test_a_locked_channel_reports_unpostable_not_broken(self, monkeypatch):
+        """A panel in a channel the bot cannot send to is still a live panel.
+
+        Buttons are interactions and a refresh edits a message the bot owns, so
+        neither needs Send Messages. This flag is only about posting a new one.
+        """
+        make_server(instructions_channel_id="1", instructions_message_id="55")
+        guild = FakeGuild(channels=[FakeChannel(1, "verify", sendable=False)])
+        monkeypatch.setattr(bot.bot, "get_guild", lambda _id: guild)
+        panel = run(bot.read_dashboard_panel(GUILD_ID))
+        assert panel["posted"] is True
+        assert panel["channel_exists"] is True
+        assert panel["channel_postable"] is False
 
 
 def member(administrator=True):

--- a/tests/test_branding.py
+++ b/tests/test_branding.py
@@ -399,8 +399,11 @@ class TestRestylePanel:
     ):
         """A database blip must not restyle a paying server back to default.
 
-        The view is still refreshed — that is what the pass is for — but no
-        embed goes in the payload, so the panel keeps the look it has.
+        It used to send the view alone, on the reasoning that the panel then
+        keeps the look it has. That is true of the look and false of everything
+        else the view carries: the button labels are localized, so a language
+        change came out as Japanese buttons above English text, reported as a
+        successful refresh. Nothing goes at all now.
         """
         make_server(row_id=NEW_ID)
         set_branding()
@@ -409,11 +412,21 @@ class TestRestylePanel:
             bot, "load_panel_branding", lambda gid: bot.BRANDING_UNREADABLE
         )
 
+        assert run(bot.restyle_instruction_panel(GUILD_ID)) == "style_unreadable"
+        assert rec.edits == []
+
+    def test_a_half_updated_panel_is_never_sent(self, monkeypatch, premium):
+        """The embed and the buttons must always agree about the language."""
+        make_server(row_id=NEW_ID, instructions_locale="ja")
+        set_branding()
+        rec = PanelRecorder().install(monkeypatch)
+
         run(bot.restyle_instruction_panel(GUILD_ID))
 
         assert len(rec.edits) == 1
-        assert "embed" not in rec.edits[0]
-        assert isinstance(rec.edits[0]["view"], bot.VRCVerifyInstructionView)
+        # Both halves, or neither. The old code could send only the second.
+        assert "embed" in rec.edits[0] and "view" in rec.edits[0]
+        assert rec.edits[0]["embed"].title == bot.build_instructions_embed("ja").title
 
     def test_a_guild_with_no_panel_is_a_no_op(self, monkeypatch, premium):
         make_server(row_id=NEW_ID, with_panel=False)

--- a/tests/test_branding.py
+++ b/tests/test_branding.py
@@ -415,6 +415,44 @@ class TestRestylePanel:
         assert run(bot.restyle_instruction_panel(GUILD_ID)) == "style_unreadable"
         assert rec.edits == []
 
+    def test_a_panel_discord_will_not_edit_is_not_edited_at_all(
+        self, monkeypatch, premium
+    ):
+        """The other way a panel ends up in two languages.
+
+        Discord keeps the old embed on a webhook-owned message and applies the
+        components anyway, so sending the edit would relabel the buttons and
+        leave the text. Nothing is sent; the panel needs replacing, and only
+        the dashboard's panel button can do that.
+        """
+        make_server(row_id=NEW_ID, instructions_locale="ja")
+        set_branding()
+        rec = PanelRecorder().install(monkeypatch)
+
+        async def frozen(_channel, _message_id):
+            return True
+
+        monkeypatch.setattr(bot, "_panel_is_webhook_owned", frozen)
+
+        assert run(bot.restyle_instruction_panel(GUILD_ID)) == "frozen"
+        assert rec.edits == []
+
+    def test_an_unreadable_ownership_check_still_refreshes(
+        self, monkeypatch, premium
+    ):
+        """A fetch hiccup must not start refusing ordinary refreshes."""
+        make_server(row_id=NEW_ID, instructions_locale="ja")
+        set_branding()
+        rec = PanelRecorder().install(monkeypatch)
+
+        async def cannot_tell(_channel, _message_id):
+            return None
+
+        monkeypatch.setattr(bot, "_panel_is_webhook_owned", cannot_tell)
+
+        assert run(bot.restyle_instruction_panel(GUILD_ID)) == "ok"
+        assert len(rec.edits) == 1
+
     def test_a_half_updated_panel_is_never_sent(self, monkeypatch, premium):
         """The embed and the buttons must always agree about the language."""
         make_server(row_id=NEW_ID, instructions_locale="ja")

--- a/tests/test_branding.py
+++ b/tests/test_branding.py
@@ -560,7 +560,7 @@ class TestSaveOrdering:
     successful save into "This interaction failed" for the admin.
     """
 
-    def build_and_save(self, monkeypatch, premium_flag=True):
+    def build_and_save(self, monkeypatch, premium_flag=True, locale="en-US"):
         order = []
 
         async def fake_restyle(guild_id):
@@ -581,7 +581,7 @@ class TestSaveOrdering:
 
         view = bot.PagedSettingsView(
             True,
-            "en-US",
+            locale,
             True,
             auto_verify_available=True,
             page_index=bot.SETTINGS_LAST_PAGE,
@@ -601,9 +601,27 @@ class TestSaveOrdering:
         make_server(row_id=NEW_ID)
         assert self.build_and_save(monkeypatch) == ["reply", "panel_edit"]
 
-    def test_a_free_server_edits_no_panel(self, monkeypatch, enforced):
+    def test_a_free_server_changing_nothing_visible_edits_no_panel(
+        self, monkeypatch, enforced
+    ):
+        """Branding was not saved and the language is unchanged, so the panel
+        already shows what is stored. Editing it would be a wasted API call."""
         make_server(row_id=NEW_ID)
         assert self.build_and_save(monkeypatch, premium_flag=False) == ["reply"]
+
+    def test_a_free_server_changing_the_language_does_edit_the_panel(
+        self, monkeypatch, enforced
+    ):
+        """The panel is rendered in this language and the language is free.
+
+        Nothing else would apply it: the fleet sweep rebuilds the view but
+        passes rebuild_embed=False, so the embed would stay in the old language
+        until an operator forced a full refresh.
+        """
+        make_server(row_id=NEW_ID)
+        assert self.build_and_save(
+            monkeypatch, premium_flag=False, locale="ja"
+        ) == ["reply", "panel_edit"]
 
 
 # ---------------------------------------------------------------

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -193,6 +193,7 @@ class FakeBotAPI:
         channels=None,
         panel=None,
         audit=None,
+        panel_result=None,
         errors=None,
     ):
         self.installed = {str(g) for g in installed}
@@ -200,11 +201,16 @@ class FakeBotAPI:
         self.calls = []
         self.reads = []
         self.saves = []
+        self.panel_posts = []
         self._settings = settings
         self._roles = DEFAULT_ROLES if roles is None else roles
         self._channels = DEFAULT_CHANNELS if channels is None else channels
         self._panel = {"posted": False} if panel is None else panel
         self._audit = [] if audit is None else audit
+        self._panel_result = (
+            {"action": "posted", "channel_id": LOG_CHANNEL}
+            if panel_result is None else panel_result
+        )
         # {"settings": BotAPIError(...), ...} -- per-endpoint failures, so a
         # secondary read can be broken without breaking the page.
         self.errors = errors or {}
@@ -240,6 +246,12 @@ class FakeBotAPI:
 
     def audit(self, actor_id, guild_id):
         return self._answer("audit", actor_id, guild_id, self._audit)
+
+    def post_panel(self, actor_id, guild_id, channel_id):
+        self.panel_posts.append((str(actor_id), str(guild_id), str(channel_id)))
+        if "post_panel" in self.errors:
+            raise self.errors["post_panel"]
+        return self._panel_result
 
     def update_settings(self, actor_id, guild_id, changes):
         self.saves.append((str(actor_id), str(guild_id), dict(changes)))
@@ -1280,7 +1292,8 @@ class TestTheFormMatchesWhatTheBotAccepts:
             config, store, settings=make_settings(premium=True, writable=set())
         )
         page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
-        assert "<form" not in page.split("Instructions panel")[-1]
+        assert 'name="panel_embed_color"' not in page
+        assert 'name="instructions_locale"' not in page
         assert "Save changes" not in page
 
     def test_the_language_options_come_from_the_bot(self, config, store):
@@ -1307,8 +1320,23 @@ class TestTheFormMatchesWhatTheBotAccepts:
             config, store, settings=make_settings(premium=True)
         )
         page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
-        assert f'value="{LOG_CHANNEL}"' in page
-        assert f'value="{NEWS_CHANNEL}"' not in page
+        logging_section = page.split("<h2>Logging</h2>")[1]
+        assert f'value="{LOG_CHANNEL}"' in logging_section
+        assert f'value="{NEWS_CHANNEL}"' not in logging_section
+
+    def test_the_panel_picker_does_offer_announcement_channels(self, config, store):
+        """The opposite call from the log channel, and deliberately so.
+
+        A panel is public instructions and /vrcverify_instructions can be run
+        in an announcement channel, so excluding them would be stricter than
+        the bot. The log channel is excluded because the bot refuses it.
+        """
+        test_client, _api = settings_client(
+            config, store, settings=make_settings(premium=True)
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        panel_form = page.split('class="panel-post"')[1]
+        assert f'value="{NEWS_CHANNEL}"' in panel_form
 
     def test_a_channel_picker_with_nothing_to_pick_is_not_offered(self, config, store):
         test_client, _api = settings_client(
@@ -1437,6 +1465,85 @@ AUDIT_ENTRIES = [
         "changed_at": "2026-08-04T09:10:00+00:00",
     },
 ]
+
+
+class TestPostingThePanel:
+    """The one control that makes the bot act in a server."""
+
+    def logged_in(self, config, store, **kwargs):
+        api = FakeBotAPI(**kwargs)
+        app = create_app(config, store=store, client=api)
+        app.config.update(TESTING=True)
+        test_client = app.test_client()
+        return test_client, api, login_as(test_client, store)
+
+    def post(self, test_client, session, **form):
+        form.setdefault("csrf_token", session.csrf_token)
+        return test_client.post(f"/guild/{GUILD_IN}/panel/post", data=form)
+
+    def test_the_chosen_channel_reaches_the_bot(self, config, store):
+        test_client, api, session = self.logged_in(config, store)
+        response = self.post(test_client, session, panel_channel_id=LOG_CHANNEL)
+        assert response.status_code == 302
+        assert api.panel_posts == [(ACTOR, GUILD_IN, LOG_CHANNEL)]
+
+    @pytest.mark.parametrize(
+        "action, expected",
+        [
+            ("posted", "Panel posted."),
+            ("refreshed", "refreshed rather than posted again"),
+            ("moved", "old one is still up"),
+        ],
+    )
+    def test_what_the_bot_did_is_reported_back(self, config, store, action, expected):
+        """The bot decides between post, refresh and move; the page explains it."""
+        test_client, _api, session = self.logged_in(
+            config, store, panel_result={"action": action, "channel_id": LOG_CHANNEL}
+        )
+        response = self.post(test_client, session, panel_channel_id=LOG_CHANNEL)
+        page = test_client.get(response.headers["Location"]).data.decode()
+        assert expected in page
+
+    def test_an_unknown_action_says_nothing_rather_than_echoing_it(
+        self, config, store
+    ):
+        test_client, _api, session = self.logged_in(
+            config, store, panel_result={"action": "<script>alert(1)</script>"}
+        )
+        response = self.post(test_client, session, panel_channel_id=LOG_CHANNEL)
+        page = test_client.get(response.headers["Location"]).data.decode()
+        assert "alert(1)" not in page
+
+    def test_it_needs_the_csrf_token(self, config, store):
+        test_client, api, _session = self.logged_in(config, store)
+        response = test_client.post(
+            f"/guild/{GUILD_IN}/panel/post",
+            data={"csrf_token": "wrong", "panel_channel_id": LOG_CHANNEL},
+        )
+        assert response.status_code == 400
+        assert api.panel_posts == []
+
+    def test_a_signed_out_visitor_cannot_post_a_panel(self, client, bot_api):
+        response = client.post(
+            f"/guild/{GUILD_IN}/panel/post", data={"panel_channel_id": LOG_CHANNEL}
+        )
+        assert response.status_code == 302
+        assert not getattr(bot_api, "panel_posts", [])
+
+    def test_no_channel_means_no_call(self, config, store):
+        test_client, api, session = self.logged_in(config, store)
+        self.post(test_client, session)
+        assert api.panel_posts == []
+
+    def test_a_refusal_is_explained(self, config, store):
+        test_client, _api, session = self.logged_in(
+            config,
+            store,
+            errors={"post_panel": BotAPIError("channel_not_writable", 400)},
+        )
+        response = self.post(test_client, session, panel_channel_id=LOG_CHANNEL)
+        page = test_client.get(response.headers["Location"]).data.decode()
+        assert "can&#39;t post in that channel" in page
 
 
 class TestTheChangeHistory:
@@ -1582,6 +1689,8 @@ class TestWriteSurface:
             "/guild/<int:guild_id>/member",
             "/guild/<int:guild_id>/panel",
             "/guild/<int:guild_id>/logging",
+            # The one route that makes the bot act rather than store.
+            "/guild/<int:guild_id>/panel/post",
         }, f"an unexpected write route appeared: {posts}"
 
     def test_every_group_that_saves_names_a_route_that_exists(self, app, config):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -192,6 +192,7 @@ class FakeBotAPI:
         roles=None,
         channels=None,
         panel=None,
+        audit=None,
         errors=None,
     ):
         self.installed = {str(g) for g in installed}
@@ -203,6 +204,7 @@ class FakeBotAPI:
         self._roles = DEFAULT_ROLES if roles is None else roles
         self._channels = DEFAULT_CHANNELS if channels is None else channels
         self._panel = {"posted": False} if panel is None else panel
+        self._audit = [] if audit is None else audit
         # {"settings": BotAPIError(...), ...} -- per-endpoint failures, so a
         # secondary read can be broken without breaking the page.
         self.errors = errors or {}
@@ -235,6 +237,9 @@ class FakeBotAPI:
 
     def panel(self, actor_id, guild_id):
         return self._answer("panel", actor_id, guild_id, self._panel)
+
+    def audit(self, actor_id, guild_id):
+        return self._answer("audit", actor_id, guild_id, self._audit)
 
     def update_settings(self, actor_id, guild_id, changes):
         self.saves.append((str(actor_id), str(guild_id), dict(changes)))
@@ -649,6 +654,7 @@ class TestSettingsPage:
             "roles",
             "channels",
             "panel",
+            "audit",
         }
         for _what, actor, guild in api.reads:
             assert actor == ACTOR
@@ -870,6 +876,17 @@ class TestSecondaryReadsDegradeGracefully:
         )
         page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
         assert "no longer exists" not in page
+
+    def test_the_page_renders_without_the_audit_read(self, config, store):
+        """An empty history and an unavailable one are different facts."""
+        test_client, _api = settings_client(
+            config, store, errors={"audit": BotAPIError("unavailable", 503)}
+        )
+        response = test_client.get(f"/guild/{GUILD_IN}")
+        assert response.status_code == 200
+        page = response.data.decode()
+        assert "Couldn't load the history" in page
+        assert "No changes have been made" not in page
 
     def test_the_page_renders_without_the_panel_read(self, config, store):
         test_client, _api = settings_client(
@@ -1400,6 +1417,82 @@ class TestHardening:
 
     def test_healthz_says_nothing_useful(self, client):
         assert client.get("/healthz").get_json() == {"ok": True}
+
+
+AUDIT_ENTRIES = [
+    {
+        "actor_id": ACTOR,
+        "actor_name": "Sasha",
+        "field": "role_id",
+        "old_value": None,
+        "new_value": VERIFIED_ROLE,
+        "changed_at": "2026-08-04T09:15:00+00:00",
+    },
+    {
+        "actor_id": "555555555555",
+        "actor_name": None,
+        "field": "panel_embed_color",
+        "old_value": None,
+        "new_value": str(0xFF0000),
+        "changed_at": "2026-08-04T09:10:00+00:00",
+    },
+]
+
+
+class TestTheChangeHistory:
+    def test_it_names_the_setting_the_actor_and_both_values(self, config, store):
+        test_client, _api = settings_client(config, store, audit=AUDIT_ENTRIES)
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "Verified role" in page
+        assert "Sasha" in page
+        # The id is resolved to the role's name, as on the settings above.
+        assert "not set &rarr; Verified" in page or "not set → Verified" in page
+
+    def test_an_actor_who_left_is_shown_by_id(self, config, store):
+        test_client, _api = settings_client(config, store, audit=AUDIT_ENTRIES)
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "ID 555555555555" in page
+
+    def test_a_colour_reads_as_a_colour(self, config, store):
+        test_client, _api = settings_client(config, store, audit=AUDIT_ENTRIES)
+        assert "#ff0000" in test_client.get(f"/guild/{GUILD_IN}").data.decode()
+
+    def test_an_empty_history_says_so(self, config, store):
+        test_client, _api = settings_client(config, store, audit=[])
+        assert b"No changes have been made" in test_client.get(
+            f"/guild/{GUILD_IN}"
+        ).data
+
+    def test_a_long_value_is_truncated(self):
+        entries = [
+            {
+                "actor_id": ACTOR,
+                "actor_name": "Sasha",
+                "field": "custom_verification_requested_message",
+                "old_value": None,
+                "new_value": "x" * 500,
+                "changed_at": None,
+            }
+        ]
+        rendered = settings_view.build_audit(entries, DEFAULT_ROLES, DEFAULT_CHANNELS)
+        assert len(rendered[0]["new"]) <= settings_view.AUDIT_VALUE_MAX
+
+    def test_a_deleted_role_is_named_as_gone_not_as_an_id(self):
+        entries = [
+            {
+                "actor_id": ACTOR,
+                "actor_name": None,
+                "field": "role_id",
+                "old_value": "404404404404",
+                "new_value": VERIFIED_ROLE,
+                "changed_at": None,
+            }
+        ]
+        rendered = settings_view.build_audit(entries, DEFAULT_ROLES, DEFAULT_CHANNELS)
+        assert "no longer exists" in rendered[0]["old"]
+
+    def test_an_unavailable_trail_is_none_not_empty(self):
+        assert settings_view.build_audit(None, DEFAULT_ROLES, DEFAULT_CHANNELS) is None
 
 
 class TestSettingsViewModel:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1591,6 +1591,12 @@ class TestPostingThePanel:
         assert api.panel_posts == []
 
     def test_a_refusal_is_explained(self, config, store):
+        """In the panel's own words, not the log channel's.
+
+        Both raise channel_not_writable, but a panel is an embed, so it needs
+        Embed Links as well -- and "it can't log there" is a sentence about a
+        setting this button has nothing to do with.
+        """
         test_client, _api, session = self.logged_in(
             config,
             store,
@@ -1598,7 +1604,20 @@ class TestPostingThePanel:
         )
         response = self.post(test_client, session, panel_channel_id=LOG_CHANNEL)
         page = test_client.get(response.headers["Location"]).data.decode()
-        assert "can&#39;t post in that channel" in page
+        assert "Embed Links" in page
+        assert "can&#39;t log there" not in page
+
+    def test_an_unrecognised_panel_refusal_never_reaches_the_page_as_text(
+        self, config, store
+    ):
+        leak = "surprising-internal-detail"
+        test_client, _api, session = self.logged_in(
+            config, store, errors={"post_panel": BotAPIError(leak, 400)}
+        )
+        response = self.post(test_client, session, panel_channel_id=LOG_CHANNEL)
+        page = test_client.get(response.headers["Location"]).data.decode()
+        assert leak not in page
+        assert "couldn&#39;t be posted" in page
 
 
 class TestTheChangeHistory:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -169,6 +169,7 @@ DEFAULT_CHANNELS = [
         "position": 1,
         "is_news": False,
         "can_send": True,
+        "can_embed": True,
     },
     {
         "id": NEWS_CHANNEL,
@@ -177,6 +178,7 @@ DEFAULT_CHANNELS = [
         "position": 2,
         "is_news": True,
         "can_send": True,
+        "can_embed": True,
     },
 ]
 
@@ -869,12 +871,41 @@ class TestSettingsWarnings:
                     "position": 0,
                     "is_news": False,
                     "can_send": False,
+                    "can_embed": False,
                 },
             ],
         )
         page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
-        assert "cannot send new messages in that channel" in page
+        # Both permissions named: the panel is an embed, so Embed Links alone
+        # being off produces this with no other symptom anywhere on the page.
+        assert "Send Messages and Embed Links" in page
         assert "still works and can still be refreshed" in page
+
+    def test_a_channel_without_embed_links_is_not_offered_for_the_panel(
+        self, config, store
+    ):
+        """It would accept the log and refuse the panel, so it is not a choice.
+
+        The log picker still offers it -- the verification log is plain text.
+        """
+        channels = [
+            {
+                "id": LOG_CHANNEL,
+                "name": "verify-log",
+                "position": 0,
+                "is_news": False,
+                "can_send": True,
+                "can_embed": False,
+            },
+        ]
+        # Premium, so the log channel's own picker actually renders and the
+        # comparison means something.
+        test_client, _api = settings_client(
+            config, store, channels=channels, settings=make_settings(premium=True)
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        # Offered once, by the log channel's own select -- not by the panel's.
+        assert page.count(f'<option value="{LOG_CHANNEL}"') == 1
 
     def test_the_panels_own_channel_stays_in_the_picker_when_locked(
         self, config, store
@@ -895,6 +926,7 @@ class TestSettingsWarnings:
                     "position": 0,
                     "is_news": False,
                     "can_send": False,
+                    "can_embed": False,
                 },
                 {
                     "id": SHUT_CHANNEL,
@@ -902,6 +934,7 @@ class TestSettingsWarnings:
                     "position": 1,
                     "is_news": False,
                     "can_send": False,
+                    "can_embed": False,
                 },
             ],
         )

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1569,6 +1569,12 @@ class TestPostingThePanel:
         form.setdefault("csrf_token", session.csrf_token)
         return test_client.post(f"/guild/{GUILD_IN}/panel/post", data=form)
 
+    def settings_page_with(self, config, store, **params):
+        """The settings page as it renders after a redirect carrying `params`."""
+        test_client, _api, _session = self.logged_in(config, store)
+        query = "&".join(f"{k}={v}" for k, v in params.items())
+        return test_client.get(f"/guild/{GUILD_IN}?{query}").data.decode()
+
     def test_the_chosen_channel_reaches_the_bot(self, config, store):
         test_client, api, session = self.logged_in(config, store)
         response = self.post(test_client, session, panel_channel_id=LOG_CHANNEL)
@@ -1640,6 +1646,25 @@ class TestPostingThePanel:
         assert "Embed Links" in page
         assert "can&#39;t log there" not in page
 
+    def test_an_unrecognised_action_never_reaches_the_url(self, config, store):
+        """The one place a bot value used to travel without being looked up."""
+        test_client, _api, session = self.logged_in(
+            config, store, panel_result={"action": "\r\nSet-Cookie: x=1", "channel_id": "1"}
+        )
+        response = self.post(test_client, session, panel_channel_id=LOG_CHANNEL)
+        assert "Set-Cookie" not in response.headers["Location"]
+        assert "panel=posted" in response.headers["Location"]
+
+    def test_a_stale_panel_after_a_save_is_reported(self, config, store):
+        """Saved is true; "your panel shows it" is not, and only one is obvious."""
+        page = self.settings_page_with(config, store, panel_stale=1)
+        assert "still shows the old" in page
+
+    def test_a_clean_save_says_nothing_about_the_panel(self, config, store):
+        assert "still shows the old" not in self.settings_page_with(
+            config, store, saved=1
+        )
+
     def test_an_unrecognised_panel_refusal_never_reaches_the_page_as_text(
         self, config, store
     ):
@@ -1651,6 +1676,68 @@ class TestPostingThePanel:
         page = test_client.get(response.headers["Location"]).data.decode()
         assert leak not in page
         assert "couldn&#39;t be posted" in page
+
+
+class TestTheChangeHistoryOfPanelActions:
+    """The panel row is the one entry whose pair is not (before, after).
+
+    The bot stores (what it did, where), so both halves need resolving
+    differently -- without that it rendered as the raw column name and a bare
+    channel id, for the feature this branch exists to add.
+    """
+
+    def entry(self, action="posted", channel=LOG_CHANNEL):
+        return [
+            {
+                "field": "instructions_panel",
+                "old_value": action,
+                "new_value": channel,
+                "actor_id": ACTOR,
+                "actor_name": "Sasha",
+                "changed_at": "2026-08-11T07:11:36.118000+00:00",
+            }
+        ]
+
+    def test_it_reads_as_an_action_and_a_channel(self):
+        row = settings_view.build_audit(
+            self.entry(), DEFAULT_ROLES, DEFAULT_CHANNELS
+        )[0]
+        assert row["label"] == "Instructions panel"
+        assert row["old"] == "posted in"
+        assert row["new"] == "#verify-log"
+
+    def test_the_destructive_action_is_named_plainly(self):
+        row = settings_view.build_audit(
+            self.entry(action="replaced"), DEFAULT_ROLES, DEFAULT_CHANNELS
+        )[0]
+        assert row["old"] == "replaced in"
+
+    def test_a_failed_channel_read_does_not_claim_the_channel_is_gone(self):
+        """"We couldn't check" and "it was deleted" are different facts."""
+        row = settings_view.build_audit(self.entry(), DEFAULT_ROLES, None)[0]
+        assert "no longer exists" not in row["new"]
+        assert LOG_CHANNEL in row["new"]
+
+    def test_a_failed_role_read_does_not_claim_the_role_is_gone(self):
+        entries = [
+            {
+                "field": "role_id",
+                "old_value": None,
+                "new_value": VERIFIED_ROLE,
+                "actor_id": ACTOR,
+                "actor_name": "Sasha",
+                "changed_at": None,
+            }
+        ]
+        row = settings_view.build_audit(entries, None, DEFAULT_CHANNELS)[0]
+        assert "no longer exists" not in row["new"]
+
+    def test_a_timestamp_that_is_not_a_string_does_not_break_the_page(self):
+        entries = self.entry()
+        entries[0]["changed_at"] = 1234
+        assert settings_view.build_audit(entries, DEFAULT_ROLES, DEFAULT_CHANNELS)[0][
+            "when_text"
+        ] == ""
 
 
 class TestTheChangeHistory:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -635,6 +635,23 @@ def settings_client(config, store, **kwargs):
     return test_client, api
 
 
+PANEL_CHANNEL = "800000000003"
+SHUT_CHANNEL = "800000000004"
+
+
+def _locked_panel():
+    """A live panel in a channel VRCVerify may no longer send new messages to."""
+    return {
+        "posted": True,
+        "channel_id": PANEL_CHANNEL,
+        "message_id": "456",
+        "channel_name": "verify",
+        "channel_exists": True,
+        "channel_postable": False,
+        "locale": "en-US",
+    }
+
+
 class TestSettingsPage:
     def test_signed_out_visitors_are_sent_to_the_login_page(self, client):
         response = client.get(f"/guild/{GUILD_IN}")
@@ -837,22 +854,60 @@ class TestSettingsWarnings:
         page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
         assert "republish age disclosures" in page
 
-    def test_an_unreachable_panel_channel_is_called_out(self, config, store):
+    def test_a_locked_panel_channel_is_called_out_without_crying_wolf(
+        self, config, store
+    ):
+        """The panel is not broken -- it just cannot be replaced in place."""
         test_client, _api = settings_client(
             config,
             store,
-            panel={
-                "posted": True,
-                "channel_id": "123",
-                "message_id": "456",
-                "channel_name": "verify",
-                "channel_exists": True,
-                "channel_reachable": False,
-                "locale": "en-US",
-            },
+            panel=_locked_panel(),
+            channels=[
+                {
+                    "id": PANEL_CHANNEL,
+                    "name": "verify",
+                    "position": 0,
+                    "is_news": False,
+                    "can_send": False,
+                },
+            ],
         )
         page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
-        assert "can no longer post in that channel" in page
+        assert "cannot send new messages in that channel" in page
+        assert "still works and can still be refreshed" in page
+
+    def test_the_panels_own_channel_stays_in_the_picker_when_locked(
+        self, config, store
+    ):
+        """Choosing it refreshes, which needs no Send Messages.
+
+        The startup sweep refreshes this very panel unprompted; a page that
+        removed the option would be stricter than the bot it configures.
+        """
+        test_client, _api = settings_client(
+            config,
+            store,
+            panel=_locked_panel(),
+            channels=[
+                {
+                    "id": PANEL_CHANNEL,
+                    "name": "verify",
+                    "position": 0,
+                    "is_news": False,
+                    "can_send": False,
+                },
+                {
+                    "id": SHUT_CHANNEL,
+                    "name": "shut",
+                    "position": 1,
+                    "is_news": False,
+                    "can_send": False,
+                },
+            ],
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert f'<option value="{PANEL_CHANNEL}"' in page
+        assert f'<option value="{SHUT_CHANNEL}"' not in page
 
 
 class TestSecondaryReadsDegradeGracefully:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -197,6 +197,7 @@ class FakeBotAPI:
         audit=None,
         panel_result=None,
         errors=None,
+        saved=None,
     ):
         self.installed = {str(g) for g in installed}
         self.fail = fail
@@ -213,6 +214,9 @@ class FakeBotAPI:
             {"action": "posted", "channel_id": LOG_CHANNEL}
             if panel_result is None else panel_result
         )
+        # What the write endpoint answers with. The bot returns the re-read
+        # settings, plus `panel_stale` when the live panel did not follow.
+        self._saved = saved
         # {"settings": BotAPIError(...), ...} -- per-endpoint failures, so a
         # secondary read can be broken without breaking the page.
         self.errors = errors or {}
@@ -259,7 +263,11 @@ class FakeBotAPI:
         self.saves.append((str(actor_id), str(guild_id), dict(changes)))
         if "update_settings" in self.errors:
             raise self.errors["update_settings"]
-        return self._settings if self._settings is not None else make_settings()
+        answer = dict(
+            self._settings if self._settings is not None else make_settings()
+        )
+        answer.update(self._saved or {})
+        return answer
 
 
 @pytest.fixture
@@ -1025,7 +1033,10 @@ class TestSavingThePanelGroup:
             panel_show_icon="on",
         )
         assert response.status_code == 302
-        assert response.headers["Location"].endswith("saved=1")
+        # The notice is session state now, not a query parameter, so the
+        # redirect target is bare and "Saved." appears on the next render.
+        assert response.headers["Location"].endswith(f"/guild/{GUILD_IN}")
+        assert "Saved." in test_client.get(response.headers["Location"]).data.decode()
         actor, guild, changes = api.saves[-1]
         assert (actor, guild) == (ACTOR, GUILD_IN)
         assert changes == {
@@ -1136,20 +1147,28 @@ class TestSavingThePanelGroup:
             config, store, errors={"update_settings": BotAPIError(leak, 400)}
         )
         response = self.post(test_client, session, instructions_locale="ja")
-        assert "error=unknown" in response.headers["Location"]
+        assert leak not in response.headers["Location"]
         page = test_client.get(response.headers["Location"]).data.decode()
         assert leak not in page
         assert "couldn&#39;t be saved" in page
 
-    def test_an_arbitrary_error_code_in_the_url_is_not_reflected(
-        self, config, store
-    ):
+    def test_a_notice_cannot_be_conjured_from_the_url(self, config, store):
+        """Notices are session state, so a crafted link cannot show one.
+
+        They used to be query parameters, which meant anyone who could get an
+        admin to open a link could show them "Saved." for a save that never
+        happened -- most usefully to stop them noticing something was broken.
+        """
         test_client, _api, _session = self.logged_in(config, store)
         page = test_client.get(
-            f"/guild/{GUILD_IN}?error=%3Cimg+src%3Dx+onerror%3Dalert(1)%3E"
+            f"/guild/{GUILD_IN}?saved=1&panel=replaced&panel_stale=1"
+            "&error=%3Cimg+src%3Dx+onerror%3Dalert(1)%3E"
         ).data.decode()
         assert "onerror" not in page
-        assert "couldn&#39;t be saved" in page
+        assert "Saved." not in page
+        assert "replaced with a fresh one" not in page
+        assert "still shows the old" not in page
+        assert "couldn&#39;t be saved" not in page
 
 
 class TestSavingTheVerificationGroup:
@@ -1569,11 +1588,14 @@ class TestPostingThePanel:
         form.setdefault("csrf_token", session.csrf_token)
         return test_client.post(f"/guild/{GUILD_IN}/panel/post", data=form)
 
-    def settings_page_with(self, config, store, **params):
-        """The settings page as it renders after a redirect carrying `params`."""
-        test_client, _api, _session = self.logged_in(config, store)
-        query = "&".join(f"{k}={v}" for k, v in params.items())
-        return test_client.get(f"/guild/{GUILD_IN}?{query}").data.decode()
+    def page_after_saving(self, config, store, **api_kwargs):
+        """The settings page an admin lands on after a real save."""
+        test_client, _api, session = self.logged_in(config, store, **api_kwargs)
+        response = test_client.post(
+            f"/guild/{GUILD_IN}/panel",
+            data={"csrf_token": session.csrf_token, "instructions_locale": "ja"},
+        )
+        return test_client.get(response.headers["Location"]).data.decode()
 
     def test_the_chosen_channel_reaches_the_bot(self, config, store):
         test_client, api, session = self.logged_in(config, store)
@@ -1653,17 +1675,29 @@ class TestPostingThePanel:
         )
         response = self.post(test_client, session, panel_channel_id=LOG_CHANNEL)
         assert "Set-Cookie" not in response.headers["Location"]
-        assert "panel=posted" in response.headers["Location"]
+        page = test_client.get(response.headers["Location"]).data.decode()
+        assert "Panel posted." in page
 
     def test_a_stale_panel_after_a_save_is_reported(self, config, store):
         """Saved is true; "your panel shows it" is not, and only one is obvious."""
-        page = self.settings_page_with(config, store, panel_stale=1)
+        page = self.page_after_saving(config, store, saved={"panel_stale": "frozen"})
         assert "still shows the old" in page
 
     def test_a_clean_save_says_nothing_about_the_panel(self, config, store):
-        assert "still shows the old" not in self.settings_page_with(
-            config, store, saved=1
+        page = self.page_after_saving(config, store)
+        assert "Saved." in page
+        assert "still shows the old" not in page
+
+    def test_a_notice_is_shown_once_and_not_again_on_reload(self, config, store):
+        """Otherwise every later page load claims the last save just happened."""
+        test_client, _api, session = self.logged_in(config, store)
+        response = test_client.post(
+            f"/guild/{GUILD_IN}/panel",
+            data={"csrf_token": session.csrf_token, "instructions_locale": "ja"},
         )
+        target = response.headers["Location"]
+        assert "Saved." in test_client.get(target).data.decode()
+        assert "Saved." not in test_client.get(target).data.decode()
 
     def test_an_unrecognised_panel_refusal_never_reaches_the_page_as_text(
         self, config, store

--- a/tests/test_donations.py
+++ b/tests/test_donations.py
@@ -488,23 +488,25 @@ class TestInstructionsFollowupHint:
     def test_admin_gets_ephemeral_donate_followup(self, clean_servers):
         panel = []
         followups = []
-        message = SimpleNamespace(id=111)
 
-        async def send_message(embed=None, view=None):
+        # A real channel message, not the command's reply: Discord ignores
+        # embed edits on a reply, so a panel posted that way could never be
+        # restyled or translated afterwards.
+        async def channel_send(embed=None, view=None):
             panel.append(SimpleNamespace(embed=embed, view=view))
+            return SimpleNamespace(id=111)
 
-        async def original_response():
-            return message
+        async def defer(ephemeral=False):
+            pass
 
         async def followup_send(msg, ephemeral=False):
             followups.append(SimpleNamespace(msg=msg, ephemeral=ephemeral))
 
         interaction = SimpleNamespace(
             guild=SimpleNamespace(id=int(GUILD_ID)),
-            channel=SimpleNamespace(id=222),
+            channel=SimpleNamespace(id=222, send=channel_send),
             locale="en-US",
-            response=SimpleNamespace(send_message=send_message),
-            original_response=original_response,
+            response=SimpleNamespace(defer=defer),
             followup=SimpleNamespace(send=followup_send),
         )
 

--- a/tests/test_instruction_refresh.py
+++ b/tests/test_instruction_refresh.py
@@ -833,3 +833,82 @@ class TestGuildRemoveCleanup:
 
         monkeypatch.setattr(bot, "forget_instruction_panel", boom)
         run(bot.on_guild_remove(SimpleNamespace(id=111, name="Gone")))  # must not raise
+
+
+# ---------------------------------------------------------------
+# The panel has to be a message the bot can actually edit
+# ---------------------------------------------------------------
+class TestPanelIsAnOrdinaryMessage:
+    """/vrcverify_instructions must not reply with the panel.
+
+    An interaction reply belongs to a webhook, and Discord answers 200 to an
+    embed edit on a webhook-owned message and then keeps the old embed -- only
+    the components change. Panels posted that way could never be restyled or
+    translated: a language change came out as new button labels above the old
+    text, and every refresh reported success. Everything else in this file is
+    about refreshing panels correctly, which is worth nothing if the panel is
+    not editable in the first place.
+    """
+
+    def interaction(self, sends, send=None):
+        async def channel_send(embed=None, view=None):
+            sends.append(SimpleNamespace(embed=embed, view=view))
+            return SimpleNamespace(id=111)
+
+        async def defer(ephemeral=False):
+            pass
+
+        async def refuse(*_a, **_k):
+            raise AssertionError("the panel must not be the command's reply")
+
+        return SimpleNamespace(
+            guild=SimpleNamespace(id=int(GUILD_ID)),
+            channel=SimpleNamespace(id=222, send=send or channel_send),
+            user=SimpleNamespace(id=1),
+            locale="en-US",
+            response=SimpleNamespace(defer=defer, send_message=refuse),
+            followup=SimpleNamespace(send=lambda *a, **k: _noop()),
+        )
+
+    def test_the_panel_goes_out_as_a_channel_message(self, clean_servers):
+        sends = []
+        run(bot.vrcverify_instructions.callback(self.interaction(sends)))
+        assert len(sends) == 1
+        assert sends[0].embed is not None
+
+    def test_the_recorded_id_is_the_channel_messages(self, clean_servers):
+        sends = []
+        run(bot.vrcverify_instructions.callback(self.interaction(sends)))
+        with bot.session_scope() as session:
+            srv = session.query(bot.Server).filter_by(server_id=GUILD_ID).first()
+            assert srv.instructions_channel_id == "222"
+            assert srv.instructions_message_id == "111"
+
+    def test_a_channel_it_cannot_post_in_records_nothing(self, clean_servers):
+        """The reply always worked, so this failure mode is new. It must not
+        leave a Server row claiming a panel that was never posted."""
+        told = []
+
+        async def forbidden(embed=None, view=None):
+            raise discord.Forbidden(SimpleNamespace(status=403, reason="no"), "nope")
+
+        interaction = self.interaction([], send=forbidden)
+        interaction.followup = SimpleNamespace(
+            send=lambda msg, ephemeral=False: _record(told, msg)
+        )
+
+        run(bot.vrcverify_instructions.callback(interaction))
+
+        with bot.session_scope() as session:
+            srv = session.query(bot.Server).filter_by(server_id=GUILD_ID).first()
+            assert srv is None or not srv.instructions_message_id
+        assert told and "Send Messages" in told[0]
+
+
+async def _noop():
+    return None
+
+
+def _record(bucket, msg):
+    bucket.append(msg)
+    return _noop()

--- a/tests/test_panel_nudge.py
+++ b/tests/test_panel_nudge.py
@@ -797,22 +797,21 @@ class TestProbeOutcomes:
 # ---------------------------------------------------------------
 class TestInstructionsClearsNudge:
     def interaction(self):
-        async def send_message(embed=None, view=None):
-            pass
-
-        async def original_response():
+        async def channel_send(embed=None, view=None):
             return SimpleNamespace(id=111)
+
+        async def defer(ephemeral=False):
+            pass
 
         async def followup_send(msg, ephemeral=False):
             pass
 
         return SimpleNamespace(
             guild=SimpleNamespace(id=int(GUILD_ID)),
-            channel=SimpleNamespace(id=222),
+            channel=SimpleNamespace(id=222, send=channel_send),
             user=SimpleNamespace(id=int(OWNER_ID)),
             locale="en-US",
-            response=SimpleNamespace(send_message=send_message),
-            original_response=original_response,
+            response=SimpleNamespace(defer=defer),
             followup=SimpleNamespace(send=followup_send),
         )
 


### PR DESCRIPTION
Step 6 — the audit trail becomes readable and the dashboard can post the instructions panel — plus the fixes that came out of actually running it, and an adversarial review of the whole branch.

It grew well past step 6. The short version of everything after it: **a panel posted by `/vrcverify_instructions` could never be edited by Discord**, which had been silently breaking every colour, icon and language change since branding shipped. Finding that took most of a session, and fixing it properly meant changing how the panel gets posted in the first place.

---

## The change history

Recording since #74, unreadable without database access until now — most of the value missing.

```
Verified role              not set → Verified          Sasha · 2026-08-04 09:15 UTC
Panel colour               not set → #ff0000           ID 555555555555 · 09:10 UTC
Custom verification msg    not set → Welcome to the…   Sasha · 09:05 UTC
Nickname sync              off → on                    Sasha · 09:01 UTC
```

- **Ids resolved the way the settings above resolve them.** A history of raw snowflakes is not one anybody reads.
- **An actor who left is shown by id, not dropped** — precisely the entry worth keeping. Resolved from the gateway cache, no REST call, so history costs nothing per row.
- **An unreadable trail says "couldn't load", never "no changes have been made".** Different facts; only one is reassuring.
- **"We couldn't check" is not "it was deleted."** A failed role or channel read renders the id, not `a role that no longer exists`. The guard existed forty lines away in `_role_field` and the history never got it.
- The page states it covers **website changes only**, so an incomplete history doesn't look authoritative.

## Posting the panel

The one thing the website makes the bot *do* in a server rather than store — so the interesting question isn't whether it works, it's what happens when it's asked twice. **The bot decides**, since it's the only side that can see where the panel actually is:

| situation | what happens |
|---|---|
| panel already in the chosen channel | **refreshed** — the same one-call edit the fleet sweep uses. A double-click costs an edit, not a second live panel. |
| panel recorded in a different channel | **moved** — new one posted, ids re-pointed, admin told where the old one still is |
| Discord won't let the bot edit it | **replaced** — new one posted, old one deleted (see below) |
| recorded location unreadable | **nothing posted** |

That last row is the one `read_dashboard_panel`'s docstring warned about: `load_instruction_panel` returns `None` both for "never posted" and for "the row couldn't be read". `_stored_panel_location` **raises** rather than returning a sentinel, so a caller cannot forget to check.

**Move does not delete; replace does.** A move leaves the old panel alone in a different channel, where it is still the only panel there and removing it is the admin's call. A replace would otherwise leave a dead panel directly above its replacement, with live buttons and text nothing can ever correct. The delete is bounded to the message id the bot itself recorded and only runs once the replacement is up and saved.

### The two pickers disagree, on purpose

| | announcement channels | no Embed Links |
|---|---|---|
| panel picker | **offered** — `/vrcverify_instructions` can be run in one, and a panel is public instructions | **excluded** — a panel *is* an embed |
| log channel picker | **excluded** — `/vrcverify_logchannel` refuses them, since a followed channel would republish an age disclosure | **offered** — the log is plain text and doesn't need it |

Same rule — mirror the slash command — landing in opposite places twice.

---

## The bug that ate the session

**Discord accepts an embed edit on a webhook-owned message, answers 200, and discards it.** Only the components apply. `/vrcverify_instructions` replied *with* the panel, and an interaction reply is webhook-owned — so every panel that command ever posted was frozen the moment it went up. Confirmed against the live API: a `PATCH` carrying nothing but `embeds` came back 200 with the old title, and a re-read agreed.

It was invisible from inside the bot because the view *is* a component and does apply. A language change came out as new button labels above the old text, and the refresh logged a success — which was true as far as it could tell.

Three changes:

- **The command posts an ordinary channel message** and defers its reply. That makes the panel editable, and it makes posting able to *fail*, which replying never could — so a channel the bot can't send in now says so and records nothing, rather than leaving a row pointing at a panel that doesn't exist.
- **Existing frozen panels are replaced, not refreshed.** `_panel_is_webhook_owned` answers `None` when it can't tell, and that path bails — treating "can't tell" as "safe to replace" is how a server ends up with two panels.
- **Never send half a panel.** If the embed can't be rebuilt, nothing is sent at all. The old code sent the view alone on the reasoning that the panel keeps the look it has — true of the look, false of everything else the view carries.

### Saving a language now reaches the panel

`instructions_locale` was stored and nothing re-rendered the panel, so the change was invisible until an operator forced a fleet refresh. `PANEL_VISIBLE_FIELDS` names the three settings a posted panel actually renders; a save touching any of them re-edits it. Changing `role_id` doesn't, because a message edit and its rate limit shouldn't ride along with every save.

Same gap existed in `/vrcverify_settings`, gated on `branding_allowed` — but branding is premium and **the language is free**, so a free server could change it and never see it.

### Permissions the page can now answer for

`can_send` was doing double duty and getting one of the two jobs wrong. The verification log is plain text and needs Send Messages; the panel is an embed and needs Embed Links too. A channel granting one and not the other read as perfectly writable and then refused the panel — with the refusal arriving in the *log channel's* words, because the two shared a reason code.

---

## Adversarial review

Two reviewers over the bot and dashboard halves, plus mutation testing of the tests themselves. Clean on the things that would have mattered: no path to `users.verification_status`, no way to act on a guild the actor doesn't administer, the delete can't be aimed, XSS clean under active probing, CSRF on all six state-changing routes, and the 403/404 collapse byte-identical including headers.

What was real:

- **No concurrency guard on the panel button.** It reads the recorded location then suspends three times before writing a new one — two overlapping requests both posted, and on the replace path both deleted. Exactly the duplicate the docstring promises a double-click cannot cause. Serialised per guild.
- **A `"frozen"` restyle returned 200 and said nothing** — the production symptom that started all this, reintroduced on the settings page. The outcome now reaches the admin.
- **A panel that posted but couldn't be recorded was left live and untracked**, and the admin — seeing a failure — would click again. One orphan per retry. It's taken back down.
- **Notices were query parameters**, so anyone who could get an admin to open a link could show them "Saved." for a save that never happened. They're session state now, written by the request that did the thing, read once, cleared.
- **Writes pay their own rate budget.** The old limits were sized when every route was a cached GET costing Discord nothing; a panel post is now up to three REST calls against the same account-wide budget verification runs on.
- Smaller, all confirmed: `compare_digest` raising `TypeError` on non-ASCII turned a wrong CSRF token or OAuth `state` into an unhandled 500 — reachable unauthenticated via `/callback`. The bot's action string was the one value reaching a URL unclamped. The session cookie gained the `__Host-` prefix. `owner_id` on a panel-created `servers` row named whoever clicked rather than the guild's owner, quietly appointing them for config DMs.

Two comments were wrong and are corrected rather than deleted: the fleet sweep *does* reach the ownership check, and the pacer reserves one slot for what is now two calls — worth knowing before raising `INSTRUCTIONS_REFRESH_RATE`.

## The capability surface

`post_panel` is a second mutating capability on `BotAPIDeps`, named separately from `write_settings` because "store this value" and "post a message in somebody's server" are different kinds of authority. The pins that asserted *one writer* now assert *one writer and one action*, and `POST /api/v1/guilds/{id}/panel` joins the settings `PATCH` as the only non-GET routes.

Also corrected several docs that asserted the opposite of what ships — `bot_api.py`'s docstring still claimed no writer existed, and the README described the write surface as one route and the API as "read-only by construction". Both were true through step 4.

## Tests

**1076**, up from 1000. Every fix on this branch is pinned by a test that fails without it, checked by mutation rather than by reading — which caught **four tests that passed for the wrong reason**, two of them written in this PR.

## Deploying this

- **Everyone signed in gets logged out once.** The session cookie is renamed to `__Host-vrcverify_session` and the old name isn't read.
- **`sessions.sqlite` gets an `ALTER TABLE`** on first connect, for the one-shot `notice` column.
- Nothing after the language fix has been exercised against real Discord — only against tests.
