### PR TITLE
Tell admins how to buy Premium, and stop telling them the page is read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,26 @@ It also surfaces things the bot could previously only discover mid-verification
 announcement channel other servers could follow — while an admin is looking at
 the setting rather than when a member is waiting.
 
+**Buying Premium stays inside Discord.** A server that isn't subscribed gets an
+upgrade block, and it points at `/vrcverify_subscription` rather than carrying a
+buy button of its own. Discord's Store deep link
+(`/application-directory/{app}/store/{sku}`) takes an application and a SKU and
+nothing else — there is no guild parameter — so a link from a page about *this*
+server cannot actually name it, and for a guild-scoped SKU choosing the wrong
+one at checkout means billing the wrong server. The slash command's button is
+already bound to the guild it was run in, so it leads; the store link is offered
+alongside as somewhere to read the price and perks, and says plainly that
+checkout is where the server gets picked. The SKU id travels in the settings
+payload rather than being configured on the dashboard, for the same reason the
+language list does: a second copy is a second thing to get wrong, and with
+`PREMIUM_SKU_ID` unset the bot sends none and the block never renders — there is
+nothing to sell when every gate already answers "allowed".
+
+Grandfathered servers see the block too, with different wording. They keep their
+three features permanently either way, but the premium-only set is still closed
+to them, so treating them as already-sold would leave a badge with no route past
+it.
+
 ---
 
 ## Tech Stack

--- a/src/bot.py
+++ b/src/bot.py
@@ -763,12 +763,14 @@ SETTINGS_FIELDS_BY_NAME = {field.name: field for field in SETTINGS_FIELDS}
 # Which of those the dashboard may WRITE today. Everything else is readable and
 # refused on save, including fields that will open later.
 #
-# Step 5 of issue #65 opens the instructions panel group and nothing else. The
-# order is deliberate: every value here is a constrained type — one of a fixed
-# set of language codes, a 24-bit integer, a boolean — so the first write path
-# this project has ever had can be about the plumbing (authorisation, the audit
-# record, refusing a locked field) rather than about validating free text or
-# reasoning about role hierarchies at the same time.
+# Step 5 of issue #65 opened the instructions panel group first and nothing
+# else, and the order was deliberate: every one of those values is a constrained
+# type — one of a fixed set of language codes, a 24-bit integer, a boolean — so
+# the first write path this project ever had could be about the plumbing
+# (authorisation, the audit record, refusing a locked field) rather than about
+# validating free text or reasoning about role hierarchies at the same time.
+# The remaining groups followed once that plumbing was proven, so this is now
+# every setting the dashboard offers.
 #
 # This list is the enforcement point, not the dashboard's form. The website is
 # untrusted: it renders whatever it likes, and the bot decides.
@@ -4889,6 +4891,14 @@ async def read_dashboard_settings(guild_id) -> Optional[dict]:
                 "enforced": PREMIUM_ENFORCED,
                 "premium": flags.premium,
                 "grandfathered": flags.grandfathered,
+                # What the website may link to for an upgrade. Sent rather than
+                # configured over there for the same reason the locale list is:
+                # a second copy of the SKU id is a second thing to change, and
+                # the failure mode is a purchase link pointing at the wrong
+                # product. With the kill switch off this is None and the
+                # dashboard offers no upgrade at all, which is correct -- there
+                # is nothing to sell when every gate answers "allowed".
+                "sku_id": str(PREMIUM_SKU_ID) if PREMIUM_SKU_ID is not None else None,
             },
             # A column the deployed database is missing is reported as such
             # rather than silently rendered as a working toggle.

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -343,6 +343,9 @@ def _register_routes(app: Flask) -> None:
             groups=settings_view.build_groups(settings, roles, channels, panel),
             audit=settings_view.build_audit(audit, roles, channels),
             premium=settings.get("premium") or {},
+            upgrade=settings_view.build_upgrade(
+                settings, _config().discord_client_id
+            ),
             names_resolved=roles is not None and channels is not None,
             auto_verify_column_present=settings.get("auto_verify_column_present", True),
             saved=notice == "saved",

--- a/src/dashboard/settings_view.py
+++ b/src/dashboard/settings_view.py
@@ -347,10 +347,11 @@ def build_groups(
             # rather than posts and so needs no Send Messages at all.
             "panel_channels": _panel_channels(channels, panel),
             "panel_channel_id": (panel or {}).get("channel_id") or "",
-            # The only group with a save path so far. The template renders a
-            # form when a group names an endpoint AND the bot said at least one
-            # of its fields is writable, so opening the next group is a change
-            # here and in DASHBOARD_WRITABLE_FIELDS, not in the template.
+            # The template renders a form when a group names an endpoint AND the
+            # bot said at least one of its fields is writable, so what a group
+            # can save is decided here and in DASHBOARD_WRITABLE_FIELDS, never
+            # in the template. A bot that has not opened a field yet renders it
+            # read-only without this side needing to know why.
             "save_endpoint": "save_panel_settings",
         },
         {
@@ -487,6 +488,50 @@ def _log_channel_field(settings: dict, channels: Optional[list]) -> Field:
         value="" if raw is None else str(raw),
         **_plan(state),
     )
+
+
+# Discord's own deep link to a SKU's Store page. It takes an application and a
+# SKU and NOTHING ELSE -- there is no guild parameter, which is the answer to
+# the open question issue #65 raised before this was built. So a link from here
+# can show an admin what Premium costs and includes, but it cannot pre-select
+# the server they are looking at, and for a guild-scoped SKU picking the wrong
+# server means billing the wrong server.
+#
+# Hence the split below: /vrcverify_subscription is the primary path, because
+# running it inside a server produces Discord's native purchase button already
+# bound to that guild, and the store page is offered as reading material.
+STORE_URL = "https://discord.com/application-directory/{app_id}/store/{sku_id}"
+
+
+def build_upgrade(settings: dict, application_id: Optional[str]) -> Optional[dict]:
+    """How this server buys Premium, or None when there is nothing to sell.
+
+    Three cases end in None, and they are different: the tier is switched off
+    entirely (`enforced` false, so every gate answers "allowed" and an upgrade
+    button would be selling a thing that is already free), the server already
+    subscribes, or the bot reported no SKU. The last one matters most -- it is
+    what a misconfigured deployment looks like, and a link built around a
+    missing id would 404 into Discord rather than fail here.
+
+    Grandfathered servers DO get this. They keep three features permanently and
+    lose nothing by ignoring it, but the premium-only set -- log channel,
+    branded panel, shorter cooldown, queue priority -- is still closed to them,
+    so treating them as already-sold would be wrong. The copy differs instead.
+    """
+    premium = settings.get("premium") or {}
+    if not premium.get("enforced"):
+        return None
+    if premium.get("premium"):
+        return None
+
+    sku_id = premium.get("sku_id")
+    if not sku_id or not application_id:
+        return None
+
+    return {
+        "grandfathered": bool(premium.get("grandfathered")),
+        "store_url": STORE_URL.format(app_id=application_id, sku_id=sku_id),
+    }
 
 
 # Labels for the audit list. Deliberately the same words the settings above

--- a/src/dashboard/static/style.css
+++ b/src/dashboard/static/style.css
@@ -168,7 +168,21 @@ button.link {
 .guild-head h1 { margin: 0; }
 .guild-head p { margin: 0.15rem 0 0; }
 
-.notice.read-only { background: none; color: var(--muted); border: 1px dashed var(--line); }
+/* The upgrade offer. Bordered rather than filled: it sits above settings an
+ * admin came here to change, and a block loud enough to compete with them
+ * would be an advertisement on a page they already paid attention to. */
+.upgrade {
+  margin: 1.25rem 0 0;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--accent);
+  border-radius: 6px;
+}
+
+.upgrade h2 { font-size: 1rem; margin: 0 0 0.4rem; }
+.upgrade p { margin: 0 0 0.5rem; font-size: 0.925rem; }
+.upgrade p:last-child { margin-bottom: 0; }
+.upgrade a { color: var(--accent); }
 
 .group { margin-top: 2rem; }
 .group h2 { font-size: 1.05rem; margin: 0; }

--- a/src/dashboard/templates/settings.html
+++ b/src/dashboard/templates/settings.html
@@ -55,10 +55,42 @@
     <p class="notice">{{ save_error }}</p>
   {% endif %}
 
-  <p class="notice read-only">
-    Only the instructions panel settings can be changed here so far. For
-    everything else, use <code>/vrcverify_settings</code> in your server.
-  </p>
+  {# Buying happens inside Discord, never here. The store link cannot name a
+     server -- see settings_view.STORE_URL -- so the slash command leads, and
+     the link is offered as somewhere to read the details. #}
+  {% if upgrade %}
+    <section class="upgrade">
+      <h2>
+        {% if upgrade.grandfathered %}
+          Add VRCVerify Premium
+        {% else %}
+          Upgrade to VRCVerify Premium
+        {% endif %}
+      </h2>
+      <p>
+        {% if upgrade.grandfathered %}
+          Your grandfathered extras stay free whatever you decide. Premium adds
+          the settings marked below, a shorter wait between verifications, and
+          priority in the verification queue.
+        {% else %}
+          Unlocks the settings marked below, shortens the wait between
+          verifications, and moves this server up the verification queue. 18+
+          verification itself stays free.
+        {% endif %}
+      </p>
+      <p>
+        Run <code>/vrcverify_subscription</code> in this server to subscribe.
+        Discord handles the payment, and the command's button is already
+        pointed at this server.
+      </p>
+      <p class="muted">
+        <a href="{{ upgrade.store_url }}" rel="noopener noreferrer" target="_blank">
+          See what's included on Discord's store page</a> — it lists the price
+        and perks, but you choose the server during checkout, so use the command
+        above if you administer more than one.
+      </p>
+    </section>
+  {% endif %}
 
   {% if not names_resolved %}
     <p class="notice">

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -1242,6 +1242,23 @@ class TestSettingsReader:
         assert fields["verification_log_channel_id"]["active"] is False
         assert fields["verification_log_channel_id"]["locked"] is True
 
+    def test_the_sku_travels_with_the_plan(self, free):
+        """So the dashboard's upgrade link cannot name the wrong product.
+
+        The website has no copy of this id and no way to derive one; if the bot
+        stops sending it the link disappears rather than going somewhere else.
+        """
+        make_server(row_id=9000)
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+        assert payload["premium"]["sku_id"] == str(SKU_ID)
+
+    def test_no_sku_is_sent_while_the_tier_is_off(self):
+        """PREMIUM_SKU_ID unset is the kill switch, and nothing is for sale."""
+        make_server()
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+        assert payload["premium"]["enforced"] is False
+        assert payload["premium"]["sku_id"] is None
+
     def test_branding_is_reported_when_stored(self):
         make_server()
         bot.save_panel_branding(GUILD_ID, 0xFF0000, True)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -905,6 +905,7 @@ class TestTheUpgradeOffer:
             settings=make_settings(premium=True, enforced=False, sku_id=None),
         )
         page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "Verified role" in page  # the settings page really rendered
         assert "/vrcverify_subscription" not in page
         assert "application-directory" not in page
 
@@ -929,6 +930,7 @@ class TestTheUpgradeOffer:
             config, store, settings=make_settings(sku_id=None)
         )
         page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "Verified role" in page  # the settings page really rendered
         assert "application-directory" not in page
         assert "store/None" not in page
 
@@ -937,6 +939,7 @@ class TestTheUpgradeOffer:
         sent admins to the slash commands past a working Save button."""
         test_client, _api = settings_client(config, store)
         page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "Verified role" in page  # the settings page really rendered
         assert "Only the instructions panel settings can be changed" not in page
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -111,7 +111,18 @@ WRITABLE = set(FREE_PLAN)  # step 5 is complete: every declared setting is open
 LOCALES = ["en-US", "es-ES", "ja", "de"]
 
 
-def make_settings(premium=False, values=None, auto_verify_column=True, writable=None):
+SKU_ID = "1533325058573865051"
+
+
+def make_settings(
+    premium=False,
+    values=None,
+    auto_verify_column=True,
+    writable=None,
+    grandfathered=False,
+    enforced=True,
+    sku_id=SKU_ID,
+):
     """A settings payload shaped exactly like read_dashboard_settings returns."""
     merged = dict(DEFAULT_VALUES)
     merged.update(values or {})
@@ -127,7 +138,12 @@ def make_settings(premium=False, values=None, auto_verify_column=True, writable=
         }
     return {
         "guild_id": GUILD_IN,
-        "premium": {"enforced": True, "premium": premium, "grandfathered": False},
+        "premium": {
+            "enforced": enforced,
+            "premium": premium,
+            "grandfathered": grandfathered,
+            "sku_id": sku_id,
+        },
         "auto_verify_column_present": auto_verify_column,
         "choices": {"instructions_locale": list(LOCALES)},
         "fields": fields,
@@ -825,6 +841,103 @@ class TestPlanBadgesMirrorTheBot:
         )
         page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
         assert "missing the auto-verify column" in page
+
+
+class TestTheUpgradeOffer:
+    """Buying is Discord's flow, and the page has to say so accurately.
+
+    The store URL takes an application and a SKU only, so it cannot name the
+    server being configured. For a guild-scoped SKU that is the difference
+    between subscribing this server and subscribing another one the admin also
+    runs, which is why /vrcverify_subscription leads and the link explains
+    itself rather than being presented as the buy button.
+    """
+
+    def test_a_free_server_is_told_how_to_subscribe(self, config, store):
+        test_client, _api = settings_client(config, store)
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "Upgrade to VRCVerify Premium" in page
+        assert "/vrcverify_subscription" in page
+        assert (
+            f"https://discord.com/application-directory/"
+            f"{config.discord_client_id}/store/{SKU_ID}" in page
+        )
+
+    def test_the_store_link_admits_it_cannot_pick_the_server(self, config, store):
+        """The whole reason the slash command is the primary path."""
+        test_client, _api = settings_client(config, store)
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "you choose the server during checkout" in page
+
+    def test_a_subscribed_server_is_not_sold_to(self, config, store):
+        test_client, _api = settings_client(
+            config, store, settings=make_settings(premium=True)
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "VRCVerify Premium is active" in page
+        assert "/vrcverify_subscription" not in page
+        assert "application-directory" not in page
+
+    def test_a_grandfathered_server_is_offered_the_rest(self, config, store):
+        """It keeps three features free forever, but not the premium-only set.
+
+        Treating it as already-sold would hide the log channel and branded
+        panel behind a badge with no way to reach them.
+        """
+        test_client, _api = settings_client(
+            config, store, settings=make_settings(grandfathered=True)
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "Add VRCVerify Premium" in page
+        assert "grandfathered extras stay free" in page
+        assert "/vrcverify_subscription" in page
+
+    def test_no_offer_when_the_tier_is_switched_off(self, config, store):
+        """PREMIUM_SKU_ID unset: every gate answers "allowed", so there is
+        nothing to sell and an upgrade block would be charging for what is
+        free. This is the payload the bot really sends in that state -- both
+        `premium` and `sku_id` say so, so it does not pin any one guard. The
+        `enforced` guard itself is pinned directly below.
+        """
+        test_client, _api = settings_client(
+            config,
+            store,
+            settings=make_settings(premium=True, enforced=False, sku_id=None),
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "/vrcverify_subscription" not in page
+        assert "application-directory" not in page
+
+    def test_enforced_alone_is_enough_to_withhold_the_offer(self):
+        """Defence in depth, tested on the pure function.
+
+        A payload saying "not subscribed, here is the SKU" while the tier is
+        switched off is not one the bot emits today. It is exactly what a
+        half-applied config change would look like, though, and selling a
+        subscription for features that are currently free to everyone is the
+        one outcome worth being redundant about.
+        """
+        settings = make_settings(premium=False, enforced=False, sku_id=SKU_ID)
+        assert settings_view.build_upgrade(settings, "123") is None
+
+    def test_a_missing_sku_produces_no_link_rather_than_a_broken_one(
+        self, config, store
+    ):
+        """What a half-configured deployment looks like. A link built around a
+        missing id would 404 inside Discord instead of failing here."""
+        test_client, _api = settings_client(
+            config, store, settings=make_settings(sku_id=None)
+        )
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "application-directory" not in page
+        assert "store/None" not in page
+
+    def test_the_stale_read_only_notice_is_gone(self, config, store):
+        """Every group saves now. The page said otherwise for a while, which
+        sent admins to the slash commands past a working Save button."""
+        test_client, _api = settings_client(config, store)
+        page = test_client.get(f"/guild/{GUILD_IN}").data.decode()
+        assert "Only the instructions panel settings can be changed" not in page
 
 
 class TestSettingsWarnings:


### PR DESCRIPTION
Two loose ends from #65. Everything else on that issue is built and merged; these are the last of it.

## The page was lying about itself

The settings page carried a notice reading *"Only the instructions panel settings can be changed here so far. For everything else, use `/vrcverify_settings` in your server."* That was true during step 5. It has not been true since the remaining groups opened, and it rendered unconditionally — directly above four working Save buttons.

Removed, along with two comments (`bot.py`, `settings_view.py`) that had drifted the same way.

## A free server had no way to buy anything

Four settings marked **Premium**, and no route past the badge. The issue specified an upgrade link and flagged it ⚠️ **verify before building** — specifically, whether a third-party page can link to a store page that purchases for a *specific* guild.

**It can't.** The scheme is `/application-directory/{app}/store/{sku}` and takes nothing else. There is no guild parameter. So a link from a page about one server cannot name that server, and with a guild-scoped SKU the wrong choice at checkout bills the wrong server.

So `/vrcverify_subscription` leads — its button is already bound to the guild it was run in — and the store page sits beside it as somewhere to read the price and perks, saying plainly that checkout is where the server gets picked. That is the issue's own fallback, with the link as well rather than instead.

### Two design calls

**The SKU id comes from the bot**, added to the `premium` block of the settings payload. Same reasoning as the locale list: a second copy on the dashboard is a second thing to get wrong, and the failure mode is a purchase link pointing at another product. It also keeps the kill switch working end to end — with `PREMIUM_SKU_ID` unset the bot sends `None`, the block never renders, and that is correct, because nothing is for sale when every gate already answers "allowed".

**Grandfathered servers see the block**, with different wording. They keep their three features permanently either way, but the premium-only set — log channel, branded panel, shorter cooldown, queue priority — is still shut to them. Treating them as already-sold would leave a badge with no route past it.

## Verification

Full suite green: **1086 tests**, up 10 from `main`'s 1076.

Each guard was checked by breaking it in a worktree rather than by reading it. The `enforced` check, the already-subscribed check, the missing-SKU check, the grandfathered wording, the URL format, the bot's `sku_id`, and the removal of the notice are each caught by exactly one test.

An adversarial pass over this PR then found that three of the new tests asserted only *absence*, which an error page also satisfies — breaking the settings route left them green. They now anchor on a field label first, and the second commit re-verifies both directions: all seven route tests fail against a broken page, and each guard mutation is still caught by exactly one test rather than by the anchor.

No new configuration — the application id was already `DISCORD_CLIENT_ID`.

## After this

#65 can be closed. What remains on it is **A-14** — removing the Cloudflare Access policy before real admins arrive — which is a launch step, not code.
