### PR TITLE
Close the audit items issue #65 raised against itself

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -166,7 +166,10 @@ LOG_LEVEL=INFO
 # user, the target guild and the operation. Must be IDENTICAL on the bot and
 # the dashboard, at least 32 characters, and generated randomly:
 #   python -c "import secrets; print(secrets.token_urlsafe(48))"
-# The bot refuses to start with a shorter one.
+# The bot refuses to start with a shorter one. To rotate it, follow the
+# procedure in scripts/gen_bot_api_certs.sh -- both ends have to change
+# together, and the short window where they disagree is the whole story.
+# Never pass it on a command line; edit this file and let the process read it.
 # BOT_API_TOKEN_SIGNING_KEY=
 #
 # Token lifetime and permitted clock drift, in seconds. Both are deliberately

--- a/README.md
+++ b/README.md
@@ -418,6 +418,19 @@ the page says so rather than implying the list is everything that ever
 happened. An unreadable trail renders as "couldn't load", never as "no changes
 have been made" — those are different facts and only one of them is reassuring.
 
+**Sessions can be revoked, not just expired.** Signing out ends the session in
+front of you — which is the one an attacker is *not* using. "Sign out
+everywhere" ends every session signed in as you, on every device, and it sits
+in the header bar on every page rather than on an account screen, because the
+moment you want it is the moment you should not have to go looking for it. It
+is scoped per user and never per guild: a session spans every server someone
+administers, so "revoke access to this server" would either cut off people who
+did nothing or cut off nothing at all.
+
+The session file is created owner-only, and the table prunes itself whenever a
+login starts — the only unauthenticated way to add a row to it is therefore
+also the thing that clears the abandoned ones, with no scheduler involved.
+
 Two rules the settings page exists to honour:
 
 - **It mirrors the bot field for field, including the inconsistencies.** Some

--- a/scripts/gen_bot_api_certs.ps1
+++ b/scripts/gen_bot_api_certs.ps1
@@ -1,7 +1,9 @@
 # Issues the certificates the bot API and the dashboard authenticate each other
 # with (issue #65). A direct port of gen_bot_api_certs.sh — read that one for
-# why a private CA exists at all, and for the rotation procedure. Keep the two
-# in step if you change either.
+# why a private CA exists at all, and for BOTH rotation procedures: the
+# certificates this script issues, and BOT_API_TOKEN_SIGNING_KEY, which it does
+# not issue but which is the other half of the same trust chain. Keep the two
+# scripts in step if you change either.
 #
 # Needs openssl on PATH. Git for Windows ships one; if `openssl` is not found,
 # add C:\Program Files\Git\usr\bin to PATH for this session.

--- a/scripts/gen_bot_api_certs.sh
+++ b/scripts/gen_bot_api_certs.sh
@@ -48,6 +48,51 @@
 #   doesn't say faster, and BOT_API_CLIENT_CN already pins which certificate is
 #   acceptable even if a second one exists.
 #
+# ROTATING BOT_API_TOKEN_SIGNING_KEY (audit item A-6)
+# ---------------------------------------------------
+#   This script does not generate that key, but it is the second half of the
+#   same trust chain and rotating it is documented here so the two procedures
+#   sit together rather than one being remembered and the other not.
+#
+#   WHAT IT IS. A shared secret, identical on both hosts, that signs the
+#   per-request token naming the acting Discord user, the target guild and the
+#   exact method-and-path. mTLS proves which MACHINE is calling; this proves
+#   WHICH REQUEST it is making on whose behalf. A leak of it is serious in a
+#   way a leaked cert is not: anyone holding it can mint a token naming any
+#   actor, including a guild's owner, and the audit trail will record that
+#   name (see A-22).
+#
+#   GENERATE:  python -c "import secrets; print(secrets.token_urlsafe(48))"
+#   The bot refuses to start on anything under 32 bytes (MIN_SIGNING_KEY_BYTES
+#   in src/api_tokens.py), which is a floor and not a target.
+#
+#   ROTATE. There is deliberately no second-key overlap: the bot accepts one
+#   key, so the two ends disagree for as long as it takes to restart both.
+#
+#     1. Generate the new key.
+#     2. Write it to BOTH .env files -- homelab and VPS -- before restarting
+#        either. Keep the files CRLF-free; a trailing \r becomes part of the
+#        secret on one side and not the other, and the failure looks exactly
+#        like a wrong key.
+#     3. Restart the dashboard, then the bot. Order barely matters because the
+#        gap is the outage either way, but restarting the public side first
+#        means the broken window is one nobody is mid-request in.
+#     4. Load a settings page. A mismatch is a 401 from the bot and an error
+#        page on the site -- it fails closed and loudly, never open.
+#
+#   No token outlives the swap: they are valid for 30 seconds (DEFAULT_TOKEN_TTL)
+#   with 5 seconds of clock skew, so there is nothing minted under the old key
+#   still circulating half a minute later. That is the whole reason this needs
+#   no grace period.
+#
+#   WHAT KEEPS WORKING THROUGHOUT: verification. The bot API is only the
+#   dashboard's door -- members verifying through Discord never touch it, so a
+#   botched rotation costs the website and not the product.
+#
+#   NEVER put this key on a command line (A-19). Edit the .env file and let the
+#   process read it; a shell that echoes a failing request can put the secret
+#   into a terminal, a log, or a transcript.
+#
 set -euo pipefail
 
 # Under Git Bash / MSYS on Windows, an argument starting with "/" is rewritten

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -523,6 +523,31 @@ def _register_routes(app: Flask) -> None:
         response.delete_cookie(SESSION_COOKIE, path="/")
         return response
 
+    @app.post("/logout/everywhere")
+    def logout_everywhere():
+        """End every session this Discord user has, not just this browser's.
+
+        A separate route rather than a field on /logout, because the two are
+        different promises and a mis-parsed form field must not silently
+        downgrade this one into an ordinary sign-out. The count is logged: a
+        user revoking four sessions when they only remember opening one is
+        exactly the event this control exists for, and it is invisible unless
+        somebody writes it down.
+        """
+        session = _require_login()
+        if session is not None:
+            if not _csrf_ok(session):
+                abort(400)
+            ended = _store().destroy_all_for(session.discord_id)
+            logger.info(
+                "actor=%s signed out of %s session(s) everywhere",
+                session.discord_id,
+                ended,
+            )
+        response = redirect(url_for("index"))
+        response.delete_cookie(SESSION_COOKIE, path="/")
+        return response
+
     @app.errorhandler(404)
     def not_found(_error):
         return render_template("error.html", message="Page not found."), 404

--- a/src/dashboard/sessions.py
+++ b/src/dashboard/sessions.py
@@ -23,11 +23,16 @@ logs in again.
 from __future__ import annotations
 
 import json
+import logging
+import os
 import secrets
 import sqlite3
+import stat
 import time
 from dataclasses import dataclass
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 # 32 bytes of urandom, url-safe. The session id is the only thing standing
 # between a cookie and an account, so it is generated the same way the API
@@ -85,6 +90,34 @@ class SessionStore:
         self.path = path
         self.max_age = max_age
         self._connect().close()
+        self._restrict_permissions()
+
+    def _restrict_permissions(self) -> None:
+        """Owner-only on the file holding every live session id.
+
+        These ids are bearer credentials: anything that can read this file can
+        act as any admin signed in right now, without a password, a cookie, or
+        Discord. It sits on the public host, which section 2 of the audit tells
+        you to assume is compromised eventually -- so the point is not to stop
+        an attacker who is already root, it is to keep the file out of reach of
+        a second process, a stray backup, or another container user.
+
+        A failure is logged, never fatal. Refusing to serve because a chmod
+        returned EPERM would take the dashboard down over a hardening measure,
+        and on Windows -- where developers run this -- the call is close to a
+        no-op anyway. The log line is what turns it into something an operator
+        can notice.
+        """
+        try:
+            os.chmod(self.path, stat.S_IRUSR | stat.S_IWUSR)
+        except OSError as error:
+            logger.warning(
+                "Could not restrict permissions on the session database at %s "
+                "(%s). Every live session id is readable by anything that can "
+                "open it; check the file mode by hand.",
+                self.path,
+                error,
+            )
 
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(self.path, timeout=10)
@@ -129,8 +162,23 @@ class SessionStore:
 
     # ----- lifecycle -----
     def begin_login(self, oauth_state: str, now: Optional[float] = None) -> Session:
-        """Create the pre-auth row that carries OAuth state across the redirect."""
+        """Create the pre-auth row that carries OAuth state across the redirect.
+
+        Sweeps expired rows on the way in, and that placement is the point.
+        Starting a login is the only unauthenticated way to add a row to this
+        file, so the request that grows the table is the request that prunes
+        it. Nothing schedules this and nothing needs to: with the Cloudflare
+        Access policy removed (A-14) `/login` faces the open internet, and
+        anybody hammering it to pile up abandoned pre-auth rows is also
+        clearing the ones they made ten minutes ago.
+
+        `load()` already drops an expired row it is handed, but only that one,
+        and only when someone presents its id -- which is exactly what an
+        abandoned row never gets. Lazy deletion alone leaves the file growing
+        forever.
+        """
         current = int(now if now is not None else time.time())
+        self.purge_expired(current)
         session = Session(
             sid=secrets.token_urlsafe(SESSION_ID_BYTES),
             discord_id=None,
@@ -230,6 +278,32 @@ class SessionStore:
             return
         with self._connect() as conn:
             conn.execute("DELETE FROM sessions WHERE sid = ?", (sid,))
+
+    def destroy_all_for(self, discord_id: Optional[str]) -> int:
+        """Every session belonging to one Discord user. Returns how many.
+
+        The answer to "my laptop was stolen" and to "I think someone has my
+        cookie". Signing out normally ends the session in front of you, which
+        is precisely the one an attacker is not using -- theirs stays good
+        until `max_age`, and nothing else in this codebase would ever cut it
+        off.
+
+        Scoped per USER and never per guild, even though a guild is what an
+        admin would think to secure. A session is one person's, and it spans
+        every server they administer; "revoke everyone's access to this
+        server" would either destroy sessions belonging to people who did
+        nothing, or destroy nothing at all. Neither is what the words promise.
+
+        Pre-auth rows are untouched: they carry no identity to match on, hold
+        no authority, and expire in ten minutes.
+        """
+        if not discord_id:
+            return 0
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "DELETE FROM sessions WHERE discord_id = ?", (str(discord_id),)
+            )
+            return cursor.rowcount
 
     def purge_expired(self, now: Optional[float] = None) -> int:
         current = int(now if now is not None else time.time())

--- a/src/dashboard/static/style.css
+++ b/src/dashboard/static/style.css
@@ -53,6 +53,11 @@ body {
 
 .brand { font-weight: 650; color: var(--ink); text-decoration: none; }
 
+/* Two sign-out forms side by side. They wrap rather than shrink on a narrow
+ * screen: "Sign out everywhere" truncated to "Sign out" would be the one
+ * misreading in this bar that actually costs something. */
+.account { display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
+
 main { max-width: 60rem; margin: 0 auto; padding: 1.5rem 1.25rem 3rem; }
 
 .panel {

--- a/src/dashboard/templates/base.html
+++ b/src/dashboard/templates/base.html
@@ -11,11 +11,22 @@
 <body>
   <header class="bar">
     <a class="brand" href="{{ url_for('index') }}">VRCVerify</a>
+    {# Both live in the bar rather than on an account page, because the second
+       one is what you want when you have just realised somebody else has your
+       session -- and at that moment you should not have to go looking. #}
     {% if csrf_token %}
-      <form method="post" action="{{ url_for('logout') }}">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-        <button type="submit" class="link">Sign out</button>
-      </form>
+      <nav class="account">
+        <form method="post" action="{{ url_for('logout') }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+          <button type="submit" class="link">Sign out</button>
+        </form>
+        <form method="post" action="{{ url_for('logout_everywhere') }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+          <button type="submit" class="link"
+                  title="Ends every VRCVerify session signed in as you, on every device.">
+            Sign out everywhere</button>
+        </form>
+      </nav>
     {% endif %}
   </header>
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -20,7 +20,10 @@ must say exactly what the bot would:
 """
 
 import json
+import logging
+import os
 import sqlite3
+import stat
 import time
 from types import SimpleNamespace
 
@@ -32,6 +35,7 @@ from dashboard import oauth, settings_view  # noqa: E402
 from dashboard.app import CSP, SESSION_COOKIE, create_app  # noqa: E402
 from dashboard.botapi import BotAPIError  # noqa: E402
 from dashboard.config import DashboardConfig, DashboardConfigError  # noqa: E402
+from dashboard import sessions as sessions_module  # noqa: E402
 from dashboard.sessions import SessionStore  # noqa: E402
 
 ACTOR = "424242424242"
@@ -468,6 +472,138 @@ class TestSessions:
         assert store.purge_expired(now=time.time() + 601) == 1
         assert store.load(live.sid) is not None
         assert store.load(stale.sid) is None
+
+    def test_starting_a_login_sweeps_abandoned_ones(self, store):
+        """Nothing schedules a purge, so the growth path has to be the one
+        that prunes. Abandoned pre-auth rows are never presented again, so
+        `load()`'s lazy deletion never sees them and the file grows forever.
+
+        This matters specifically once the Cloudflare Access policy comes off
+        (A-14) and /login faces the open internet.
+        """
+        abandoned = [store.begin_login(f"s{n}").sid for n in range(3)]
+        signed_in = store.complete_login(store.begin_login("live").sid, ACTOR, GUILDS)
+
+        store.begin_login("much-later", now=time.time() + 601)
+
+        for sid in abandoned:
+            assert store.load(sid) is None
+        # The sweep is by expiry, not by age or by kind.
+        assert store.load(signed_in.sid) is not None
+
+    def test_the_sweep_uses_the_time_it_was_given(self, store):
+        """Otherwise the test above would pass on wall-clock luck alone."""
+        abandoned = store.begin_login("s").sid
+        store.begin_login("immediately-after")
+        assert store.load(abandoned) is not None
+
+
+class TestRevokingEverySessionAUserHas:
+    """A-20: signing out normally leaves the stolen session alone.
+
+    It ends the one in front of you, which is the one an attacker is not
+    using. Theirs stays valid until max_age, and nothing else in this codebase
+    would ever cut it off.
+    """
+
+    def test_it_ends_the_other_sessions_too(self, store):
+        first = store.complete_login(store.begin_login("a").sid, ACTOR, GUILDS)
+        second = store.complete_login(store.begin_login("b").sid, ACTOR, GUILDS)
+        third = store.complete_login(store.begin_login("c").sid, ACTOR, GUILDS)
+
+        assert store.destroy_all_for(ACTOR) == 3
+        for session in (first, second, third):
+            assert store.load(session.sid) is None
+
+    def test_it_ends_nobody_else_s(self, store):
+        mine = store.complete_login(store.begin_login("a").sid, ACTOR, GUILDS)
+        theirs = store.complete_login(store.begin_login("b").sid, "77777777", GUILDS)
+
+        assert store.destroy_all_for(ACTOR) == 1
+        assert store.load(mine.sid) is None
+        assert store.load(theirs.sid) is not None
+
+    def test_a_login_in_progress_is_left_alone(self, store):
+        """Pre-auth rows carry no identity to match on and no authority.
+
+        Matching them would mean matching on NULL, which in SQL is not equality
+        -- so this pins the behaviour rather than the accident.
+        """
+        pending = store.begin_login("mid-flight")
+        store.complete_login(store.begin_login("b").sid, ACTOR, GUILDS)
+
+        assert store.destroy_all_for(ACTOR) == 1
+        assert store.load(pending.sid) is not None
+
+    def test_an_empty_id_revokes_nothing(self, store):
+        """The hazard is a NULL match, not a falsy one.
+
+        Written as `WHERE discord_id IS ?` this would be SQL's `IS NULL` and
+        would delete every login in flight across the whole site -- signing
+        one person out would break everybody's. The early return in
+        `destroy_all_for` is belt over braces: `= ?` already matches neither
+        NULL nor a real id. What is pinned here is the outcome, which is what
+        survives someone rewriting the query.
+        """
+        session = store.complete_login(store.begin_login("a").sid, ACTOR, GUILDS)
+        pending = store.begin_login("mid-flight")
+
+        assert store.destroy_all_for(None) == 0
+        assert store.destroy_all_for("") == 0
+        assert store.load(session.sid) is not None
+        assert store.load(pending.sid) is not None
+
+
+class TestTheSessionFileIsOwnerOnly:
+    """A-21: every live session id sits in this file, in cleartext.
+
+    They are bearer credentials -- anything that can read the file can act as
+    any signed-in admin without a password, a cookie, or Discord.
+    """
+
+    def test_owner_only_is_asked_for_on_every_platform(self, tmp_path, monkeypatch):
+        """The portable half, and the one that actually runs.
+
+        The real mode check below is POSIX-only, and this project runs its
+        suite on Windows with no CI executing pytest at all -- so a test
+        skipped on Windows is a test that runs nowhere. This one pins the
+        request itself, which is platform-independent, and would catch the
+        mode being widened or the call being dropped.
+        """
+        asked = []
+        real_chmod = sessions_module.os.chmod
+        monkeypatch.setattr(
+            sessions_module.os,
+            "chmod",
+            lambda path, mode: (asked.append(mode), real_chmod(path, mode))[0],
+        )
+        SessionStore(str(tmp_path / "sessions.sqlite"), 3600)
+        assert asked == [0o600]
+
+    @pytest.mark.skipif(
+        os.name == "nt", reason="POSIX mode bits are not meaningful on Windows"
+    )
+    def test_the_database_is_not_readable_by_anyone_else(self, tmp_path):
+        """The real thing, on the platform this actually deploys to."""
+        path = tmp_path / "sessions.sqlite"
+        SessionStore(str(path), 3600)
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+    def test_a_refused_chmod_warns_instead_of_failing(self, tmp_path, monkeypatch, caplog):
+        """Taking the dashboard down over a hardening measure would be worse.
+
+        The warning is the whole mitigation in that case, so it is pinned.
+        """
+        def refuse(*_args, **_kwargs):
+            raise PermissionError("nope")
+
+        monkeypatch.setattr(sessions_module.os, "chmod", refuse)
+        with caplog.at_level(logging.WARNING):
+            store = SessionStore(str(tmp_path / "sessions.sqlite"), 3600)
+
+        # Still usable -- the store came up.
+        assert store.load(store.begin_login("s").sid) is not None
+        assert "Could not restrict permissions" in caplog.text
 
 
 class TestTokenIsNeverStored:
@@ -1649,6 +1785,47 @@ class TestHardening:
         assert response.status_code == 302
         assert store.load(session.sid) is None
 
+    def test_signing_out_everywhere_requires_the_csrf_token(self, client, store):
+        """Otherwise it is a one-click denial of service on any admin who can
+        be made to load an attacker's page."""
+        session = login_as(client, store)
+        other = store.complete_login(store.begin_login("b").sid, ACTOR, GUILDS)
+        assert (
+            client.post("/logout/everywhere", data={"csrf_token": "wrong"}).status_code
+            == 400
+        )
+        assert store.load(session.sid) is not None
+        assert store.load(other.sid) is not None
+
+    def test_signing_out_everywhere_ends_the_session_it_cannot_see(
+        self, client, store
+    ):
+        """The whole point: /logout leaves this one alive, and this does not."""
+        session = login_as(client, store)
+        elsewhere = store.complete_login(store.begin_login("b").sid, ACTOR, GUILDS)
+
+        response = client.post(
+            "/logout/everywhere", data={"csrf_token": session.csrf_token}
+        )
+        assert response.status_code == 302
+        assert store.load(session.sid) is None
+        assert store.load(elsewhere.sid) is None
+
+    def test_an_ordinary_sign_out_still_leaves_the_others_alone(self, client, store):
+        """Pins the difference, so the two routes cannot quietly converge."""
+        session = login_as(client, store)
+        elsewhere = store.complete_login(store.begin_login("b").sid, ACTOR, GUILDS)
+
+        client.post("/logout", data={"csrf_token": session.csrf_token})
+        assert store.load(elsewhere.sid) is not None
+
+    def test_both_sign_out_controls_are_on_the_page(self, client, store):
+        """A revocation control nobody can find revokes nothing."""
+        login_as(client, store)
+        page = client.get("/").data.decode()
+        assert 'action="/logout"' in page
+        assert 'action="/logout/everywhere"' in page
+
     def test_cf_access_headers_grant_nothing(self, client, store):
         """The Access policy comes off at launch (A-14).
 
@@ -2019,7 +2196,7 @@ class TestSettingsViewModel:
 
 
 class TestWriteSurface:
-    """Step 5 opens exactly one save path. Widening it means editing this."""
+    """One save path per group and nothing else. Widening it means editing this."""
 
     def test_the_post_routes_are_logout_and_one_save_per_group(self, app):
         posts = {
@@ -2029,6 +2206,7 @@ class TestWriteSurface:
         }
         assert posts == {
             "/logout",
+            "/logout/everywhere",
             "/guild/<int:guild_id>/verification",
             "/guild/<int:guild_id>/member",
             "/guild/<int:guild_id>/panel",


### PR DESCRIPTION
Closes the audit items #65 raised against its own work: **A-6**, **A-20**, **A-21**. **A-22** stays open as an accepted risk. **A-14** is ops, not code, and now has a written procedure instead of a checkbox.

Suite green: **1099 tests**, up 13 from main's 1086.

## A-20 — sessions could be destroyed, but never more than one

Signing out ends the session *in front of you*, which is precisely the one an attacker isn't using. Theirs stayed valid until `max_age`, and nothing in the codebase would ever have cut it off.

`SessionStore.destroy_all_for(discord_id)` now backs `POST /logout/everywhere`. It lives in the header bar on every page rather than on an account screen — the moment you want it is the moment you shouldn't have to go looking.

Scoped **per user, never per guild**. A session spans every server someone administers, so "revoke access to this server" would either cut off people who did nothing or cut off nothing at all. A test pins that ordinary `/logout` still leaves the others alone, so the two routes can't quietly converge.

## A-21 — the session file

Every live session id, in cleartext, on the public host. They're bearer credentials: anything that can read the file can act as any signed-in admin without a password, a cookie, or Discord.

Created `0600`. A refused `chmod` **warns rather than refusing to serve** — taking the dashboard down over a hardening measure is the worse failure, and on Windows the call is close to a no-op anyway.

## A-6 — signing-key rotation

Written into `gen_bot_api_certs.sh`'s header so both halves of the trust chain are documented in one place. Covers what the key actually is (mTLS proves *which machine*; this proves *which request, on whose behalf*), why there's deliberately no second-key overlap, why the 30s token TTL means no grace period is needed, that a mismatch fails closed as a 401 while verification keeps running, and the A-19 rule about never putting it on a command line.

## A-14 — the launch gate

I can't remove a Cloudflare policy, so what I did instead is `VPS_RUNBOOK.md` §14: a pre-flight table naming the **eleven controls that carry the dashboard once Access is gone** and the test pinning each one, the ordered cutover, what to re-verify from a cookie-less browser, and the rollback.

Worth saying plainly: that table is the first place this project lists the controls that hold the site up *on their own*. Until now every one of them has been behind a wall that let exactly one person through.

## Two things found while preparing that cutover

**`purge_expired` had never been called from anything but a test.** `load()` drops an expired row it's handed — but only that one, and only when someone presents its id, which an abandoned pre-auth row never gets. The Access policy hid this completely: with one permitted email, `/login` wasn't reachable enough to matter. Removing Access is exactly what turns it into unbounded growth from unauthenticated requests, which made it a prerequisite rather than a separate task.

`begin_login` now sweeps before inserting, so the only unauthenticated way to add a row is also the thing that prunes them — anyone hammering `/login` clears their own earlier attempts. Deliberately not a scheduled job. Recorded as **A-24**.

**Nothing in CI runs pytest.** `.github/workflows/` is CodeQL and nothing else. This surfaced when the new POSIX-only file-mode test turned out to run on *no machine involved in this project* — not the Windows dev box, not CI. Raised as **A-23** and left open; the portable half of that test now pins the mode being *asked* for, so it isn't decorative in the meantime.

## Verification

Mutation, not reading. Broken in a worktree and confirmed caught: the revoke-all query rewritten to match `sid`; rewritten to match NULL the way an `IS` comparison would; the empty-id guard removed; the login sweep removed; the file mode widened to `0644`; the `chmod` call dropped.

That pass caught one of my own tests being vacuous — `test_an_empty_id_revokes_nothing` passed with *and* without the guard, because `= 'None'` matches nothing either way. It now pins that a **login in flight survives**, which is the outcome that actually matters if someone rewrites the comparison to `IS`.

`SECURITY_AUDIT.md` and `VPS_RUNBOOK.md` are gitignored and updated locally, so they're not in this diff.
