### PR TITLE
Get off the Python release candidate that broke two of three builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,23 @@ updates:
       python-deps:
         patterns: ["*"]
 
-  # Base images in both Dockerfiles
+  # Base images in all three Dockerfiles
   - package-ecosystem: "docker"
     directory: "/docker"
     schedule:
       interval: "weekly"
+    ignore:
+      # Never offer a Python pre-release as a base image. #79 raised
+      # 3.14.6-slim -> 3.15.0rc1-slim, which merged looking like an ordinary
+      # patch bump and broke the bot and checker builds: psycopg2-binary
+      # publishes no wheel for a cp315 that does not exist yet, so pip fell
+      # back to building from source and died on a missing pg_config. The
+      # dashboard kept building, because it deliberately carries no database
+      # driver -- so the failure was partial, and a build script that builds
+      # every service at once then tagged and pushed a stale image without
+      # complaining. Released versions only.
+      - dependency-name: "python"
+        versions: ["*rc*", "*a*", "*b*"]
 
   # GitHub Actions used by CI (CodeQL workflow)
   - package-ecosystem: "github-actions"

--- a/docker/Dockerfile-bot
+++ b/docker/Dockerfile-bot
@@ -1,6 +1,6 @@
 # Dockerfile-bot
 
-FROM python:3.15.0rc1-slim AS runtime
+FROM python:3.14.6-slim AS runtime
 
 ENV PIP_NO_CACHE_DIR=1 \
 	PIP_DISABLE_PIP_VERSION_CHECK=1 \

--- a/docker/Dockerfile-dashboard
+++ b/docker/Dockerfile-dashboard
@@ -5,7 +5,7 @@
 # no discord.py, no bot token. Everything it knows, it asks the bot for over
 # mTLS, and the bot decides what it is allowed to know.
 
-FROM python:3.15.0rc1-slim AS runtime
+FROM python:3.14.6-slim AS runtime
 
 ENV PIP_NO_CACHE_DIR=1 \
 	PIP_DISABLE_PIP_VERSION_CHECK=1 \

--- a/docker/Dockerfile-online-checker
+++ b/docker/Dockerfile-online-checker
@@ -1,6 +1,6 @@
 # Dockerfile-online-checker
 
-FROM python:3.15.0rc1-slim AS runtime
+FROM python:3.14.6-slim AS runtime
 
 ENV PIP_NO_CACHE_DIR=1 \
 	PIP_DISABLE_PIP_VERSION_CHECK=1 \


### PR DESCRIPTION
**Two of the three images cannot be built on `main` right now.** This reverts the base image and stops it happening again.

## What broke

Dependabot #79 raised all three Dockerfiles from `python:3.14.6-slim` to `python:3.15.0rc1-slim`. It read as an ordinary patch bump and merged as one.

`psycopg2-binary` publishes no wheel for a cp315 that doesn't exist yet, so pip falls back to building from source and dies:

```
error: subprocess-exited-with-error
    Error: pg_config executable not found.
ERROR: Failed to build 'psycopg2-binary' when getting requirements to build wheel
```

The bot and the online checker can't build at all. **The dashboard still can** — it deliberately carries no database driver — and that's what made this hard to see. Exactly one of three images kept working.

## Why a partial failure did real damage

`tag_and_push_images` builds every service with one `docker-compose build`, then tags each image by name. The bot build fails, compose aborts before reaching the dashboard, and `docker tag dashboard italiandogs/vrcverify-dashboard:<version>` cheerfully relabels whatever local `dashboard` image was already lying around.

So a 14-hour-old image shipped as a fresh version tag with nothing in the output saying so. The VPS served a template that had been deleted from `main` an hour earlier, and every step of the deploy looked clean — the image was pushed, the tag was right, the container was running the tag it was told to.

## The fix

All three back to `3.14.6-slim`, and Dependabot told not to offer Python pre-releases. It's the right tool for base images and this isn't a reason to stop it — but an `rc` shouldn't arrive as a build that only half fails.

## Verified by building, not reading

All three images produce output on this branch:

| image | result |
|---|---|
| `discord-bot` | builds (161MB) |
| `vrc-online-checker` | builds (127MB) |
| `dashboard` | builds (125MB) |

And the dashboard image was checked for the content it was supposed to be carrying all along:

```
grep -c 'Only the instructions panel' → 0   # the stale notice, gone
grep -c 'vrcverify_subscription'      → 1   # the upgrade block, present
python -V                             → Python 3.14.6
```

Suite green: 1086 tests. No Python code changes here.

## Worth doing separately

`tag_and_push_images` should build only the image it's about to push, fail loudly, and refuse to push an image older than HEAD. That last check alone would have caught this in one line.
