### PR TITLE
Give each settings group its own card

### DIFF
--- a/src/dashboard/static/style.css
+++ b/src/dashboard/static/style.css
@@ -184,9 +184,24 @@ button.link {
 .upgrade p:last-child { margin-bottom: 0; }
 .upgrade a { color: var(--accent); }
 
-.group { margin-top: 2rem; }
-.group h2 { font-size: 1.05rem; margin: 0; }
-.blurb { margin: 0.1rem 0 0.85rem; }
+/* Each settings group is its own card. Whitespace alone did not separate them:
+ * the settings *inside* a group are divided by a hairline, so a group boundary
+ * made of margin carried no more weight than the rows it was supposed to be
+ * containing. A card puts page background between sections, which is the one
+ * separator nothing inside a section can imitate. */
+.panel + .panel { margin-top: 1.25rem; }
+
+/* The heading gets its own rule and a little more size, so the top of a card
+ * announces itself even when the card above it has scrolled off. */
+.group h2 {
+  font-size: 1.15rem;
+  font-weight: 650;
+  margin: 0;
+  padding-bottom: 0.6rem;
+  border-bottom: 2px solid var(--line);
+}
+
+.blurb { margin: 0.7rem 0 0.4rem; }
 
 .settings { margin: 0; }
 

--- a/src/dashboard/templates/settings.html
+++ b/src/dashboard/templates/settings.html
@@ -12,6 +12,11 @@
 {% block content %}
 <p class="crumb"><a href="{{ url_for('index') }}">&larr; All servers</a></p>
 
+{# Each group below is its own card rather than a heading inside one long
+   panel. Settings within a group are separated by a hairline, so when the
+   groups were only separated by whitespace the two boundaries carried the
+   same visual weight and "which section am I in" had to be read rather than
+   seen. #}
 <section class="panel">
   <header class="guild-head">
     <span class="icon" aria-hidden="true">
@@ -105,10 +110,11 @@
       isn't in effect regardless of what it shows. Contact the bot operator.
     </p>
   {% endif %}
+</section>
 
-  {% for group in groups %}
-    {% set editable = group.fields | selectattr('editable') | list %}
-    <section class="group">
+{% for group in groups %}
+  {% set editable = group.fields | selectattr('editable') | list %}
+  <section class="panel group">
       <h2>{{ group.title }}</h2>
       <p class="muted blurb">{{ group.blurb }}</p>
 
@@ -281,10 +287,10 @@
           </span>
         </form>
       {% endif %}
-    </section>
-  {% endfor %}
+  </section>
+{% endfor %}
 
-  <section class="group">
+<section class="panel group">
     <h2>Recent changes</h2>
     <p class="muted blurb">
       Settings changed from this website. Changes made with slash commands in
@@ -308,6 +314,5 @@
         {% endfor %}
       </ul>
     {% endif %}
-  </section>
 </section>
 {% endblock %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1637,6 +1637,49 @@ class TestHardening:
         assert b'fill="#ff00ff"' in page   # the panel colour
         assert b'fill="#5865f2"' in page   # the verified role's colour
 
+    def test_the_settings_page_closes_every_container_it_opens(
+        self, config, store
+    ):
+        """Each settings group is its own `<section class="panel">`, which put
+        the open and close tags on opposite sides of a `{% for %}`.
+
+        A stray `</section>` renders fine in a browser -- it just silently
+        reparents everything after it -- so nothing else here would notice.
+        The groups are built in a loop, so getting it wrong once gets it wrong
+        for every server.
+        """
+        import html.parser
+
+        class Balance(html.parser.HTMLParser):
+            watched = {"section", "form", "dl", "div", "ul"}
+
+            def __init__(self):
+                super().__init__()
+                self.stack = []
+                self.errors = []
+
+            def handle_starttag(self, tag, _attrs):
+                if tag in self.watched:
+                    self.stack.append(tag)
+
+            def handle_endtag(self, tag):
+                if tag not in self.watched:
+                    return
+                if not self.stack:
+                    self.errors.append(f"</{tag}> with nothing open")
+                elif self.stack[-1] != tag:
+                    self.errors.append(f"</{tag}> closed a <{self.stack[-1]}>")
+                    self.stack.pop()
+                else:
+                    self.stack.pop()
+
+        test_client, _api = settings_client(config, store)
+        parser = Balance()
+        parser.feed(test_client.get(f"/guild/{GUILD_IN}").data.decode())
+
+        assert not parser.errors, parser.errors
+        assert not parser.stack, f"never closed: {parser.stack}"
+
     def test_logout_requires_the_csrf_token(self, client, store):
         session = login_as(client, store)
         assert client.post("/logout", data={"csrf_token": "wrong"}).status_code == 400


### PR DESCRIPTION
**Preview of the rendered result:** https://claude.ai/code/artifact/de089844-92bc-419e-afc9-ca8db5c37a69

That's the real page — the actual Flask app driven through the same fake bot API the tests use, with the real stylesheet inlined. Not a mockup.

## The problem

The settings groups were headings inside one long panel, separated by `margin-top: 2rem`. But the settings *within* a group are divided by `1px` hairlines — so a group boundary made of whitespace carried no more visual weight than the rows it was supposed to be containing. Which section you were in had to be read rather than seen, and the page got longer with every group that opened for saving.

## The change

Each group is now its own card, so page background shows between sections. That's the one separator nothing inside a section can imitate, which is why it beats adding another rule or more margin.

Headings go to `1.15rem` at weight `650` with a `2px` rule beneath — twice the weight of the dividers between settings, so the hierarchy resolves at a glance.

No new markup beyond moving where the panel opens and closes:

| card | holds |
|---|---|
| intro | guild header, notices, upgrade block |
| ×4 | one per settings group |
| history | Recent changes |

## A test the restructure needed

Splitting the panel put a section's open and close tags on **opposite sides of a `{% for %}`**. That's a mistake nothing here would have caught: a stray `</section>` renders perfectly well in a browser — it silently reparents everything after it — and every existing test asserts on substrings that survive that unharmed.

So there's now a test that parses the rendered page and checks every container closes. I verified it earns its place by deleting a real closing tag:

```
AssertionError: never closed: ['section', 'section', 'section', 'section']
```

It was the **only** test that failed. The rest of the suite rendered the broken page happily.

Suite green: 1087 tests.

## Note on branching

Off `main`, so this does **not** include the Docker base-image fix in #83 — that's unrelated and shouldn't ride along. #83 is still the one blocking a working build.
