### PR TITLE
Let premium come from a card as well as from Discord

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,31 @@ GMAIL_APP_PASSWORD=your-gmail-app-password
 # wedge the trigger watcher for the life of the process (default 3).
 # PREMIUM_CUTOVER_MAX_FAILURES=3
 
+# --- Premium tier: card subscriptions via Stripe (bot.py) ---
+# The second way to buy the identical premium bundle. Premium is granted if
+# EITHER source is live — a Discord entitlement, or an active card
+# subscription. Never one overriding the other.
+#
+# THIS IS THE KILL SWITCH, and it is the bot's own copy of it. Leave it unset
+# and the bot never reads the stripe_subscription table, never registers the
+# API route that writes it, and tells the dashboard there is no card option —
+# so this code ships and runs with behaviour identical to before.
+#
+# The dashboard has its own STRIPE_ENABLED, which gates the Stripe secrets and
+# the checkout buttons. They are not redundant, and the order matters: turn
+# THIS one on first. With the dashboard's on and this one off, a customer
+# completes checkout, is charged, Stripe's webhook is answered 404 for three
+# days and then gives up, and premium never switches on. See VPS_RUNBOOK.md.
+#
+# The bot holds no Stripe credential of any kind, switched on or off. It reads
+# a table the dashboard fills in over mTLS, and that is the whole integration.
+# STRIPE_ENABLED=1
+# Seconds a resolved card subscription is trusted before re-reading the table
+# (default 900). Purchases don't wait for this either — the webhook write
+# invalidates the guild in the same process. This only bounds a *missed*
+# webhook.
+# STRIPE_STATUS_TTL=900
+
 # Verification activity log. Entries are buffered and posted in batches, not
 # one message per verification: Discord allows ~5 messages per 5s per channel
 # and that budget is shared with verification DMs and command replies.

--- a/README.md
+++ b/README.md
@@ -51,13 +51,15 @@ See the sections below for details and configuration.
 
 - **Database:**  
   Utilizes SQLAlchemy to manage these models:
-  - **Server:** Holds configuration for each Discord server (guild), including role assignments. (Its `subscription_status` / `email` / `last_renewal_date` columns are dormant leftovers from a removed Stripe integration and are not used by anything — premium keys off Discord entitlements instead.)
+  - **Server:** Holds configuration for each Discord server (guild), including role assignments. (Its `subscription_status` / `email` / `last_renewal_date` columns are dormant leftovers from a Stripe integration removed years ago, and are still not used by anything. The current Stripe support deliberately did not resurrect them — see **StripeSubscription** below.)
   - **User:** Stores individual user verification statuses and VRChat IDs.
   - **PendingVerification:** Temporarily holds verification requests until they are processed.
   - **PremiumCutoverNotice:** Which guilds have already had the one-time premium announcement DM.
   - **PremiumGrandfatherLine:** Single row holding `MAX(servers.id)` as of the moment the premium tier was switched on. Servers at or below it keep the grandfathered features free, permanently. Captured once, never moved.
   - **InstructionPanelBranding:** A premium server's chosen embed colour and whether to show its server icon on the instructions panel. Both default to off, so the row existing does not by itself restyle anything.
   - **VerificationLogChannel:** Where a guild posts its verification activity log.
+  - **StripeSubscription:** A guild's card subscription, mirrored from Stripe so the premium gate stays a database read rather than an API call. Stripe remains the source of truth; the bot holds no Stripe credential and never talks to Stripe — the dashboard verifies each webhook signature and forwards a normalised summary over the existing mTLS channel. Premium is granted if **either** this or a Discord entitlement is live.
+  - **StripeEvent:** Every webhook event id already acted on. Stripe retries a delivery for up to three days, so duplicates are expected traffic; this is what makes applying one idempotent.
 
 - **Messaging with RabbitMQ:**  
   Uses the pika library to handle two queues:

--- a/src/api_tokens.py
+++ b/src/api_tokens.py
@@ -46,6 +46,32 @@ OP_GUILD_OVERVIEW = "GET /api/v1/guilds/{guild_id}/overview"
 OP_UPDATE_SETTINGS = "PATCH /api/v1/guilds/{guild_id}/settings"
 # An action, not a setting: it makes the bot post in a server.
 OP_POST_PANEL = "POST /api/v1/guilds/{guild_id}/panel"
+# The only operation with no human behind it: a Stripe webhook, verified on the
+# dashboard and forwarded here. See SYSTEM_ACTOR_ID.
+OP_PUT_STRIPE_SUBSCRIPTION = "PUT /api/v1/guilds/{guild_id}/stripe-subscription"
+
+# The actor named by a token that no person asked for.
+#
+# Every other token in this scheme names a signed-in Discord user, and the bot
+# then checks that person is an Administrator of the guild. A subscription
+# renewal a year from now has no such person: the admin who checked out may
+# have left the server, and taking the actor from the webhook body would mean
+# authority coming from a request body, which is the one thing this design
+# forbids everywhere else.
+#
+# So system operations name this instead. Zero is not a valid Discord snowflake
+# (they are timestamp-derived and start well above it), so it cannot collide
+# with a real user, and it is not a value the dashboard can be talked into
+# producing for a human -- the operation is what selects it, not the caller.
+#
+# The bot skips its Administrator check for exactly the operations it has
+# decided are system operations, and for no others. See `bot_api._authorize`.
+SYSTEM_ACTOR_ID = 0
+# Which operations are allowed to arrive with SYSTEM_ACTOR_ID. An allowlist
+# rather than a flag on the token, so a token cannot claim to be a system one:
+# both ends derive it from the operation, which is bound to the method and path
+# the router actually matched.
+SYSTEM_OPERATIONS = frozenset({OP_PUT_STRIPE_SUBSCRIPTION})
 
 # Tokens are minted per request and used immediately. Thirty seconds is
 # generous for a call across a tunnel and short enough that a captured token is

--- a/src/bot.py
+++ b/src/bot.py
@@ -480,7 +480,7 @@ class VerificationDaily(Base):
 
 
 class StripeSubscription(Base):
-    """A guild's card subscription, mirrored from Stripe (issue #88).
+    """One Stripe subscription, mirrored (issue #88). A guild may have several.
 
     Stripe is the source of truth. This is a local copy so the premium gate
     stays a database read rather than an API call on every verification — and
@@ -492,18 +492,33 @@ class StripeSubscription(Base):
     / `last_renewal_date` columns on `servers` stay dead — they could not hold
     a customer id, a subscription id or a price id even if they were wanted.
 
-    The row survives a lapsed subscription, like VerificationLogChannel and
+    **Keyed by the Stripe subscription, not by the guild**, which is the one
+    place this departs from the issue's schema. A guild really can hold two
+    live subscriptions at once — the issue's own Double billing section says to
+    expect it and warn about it — and a table that cannot represent that does
+    not merely lose a warning, it loses money in the customer's disfavour: with
+    one row per guild, an ordinary renewal of the older subscription overwrites
+    the newer one, and the older one's eventual cancellation then switches off
+    a server that is still being billed for the other. That was found by
+    probing this code rather than reasoning about it, and no guard on a
+    one-row-per-guild table closes it, because the state it needs to hold has
+    two subscriptions in it.
+
+    So: the gate asks whether *any* row for the guild is paid, and the
+    double-billing warning is a row count rather than a special case.
+
+    Rows survive a lapsed subscription, like VerificationLogChannel and
     InstructionPanelBranding do. Resubscribing is then a status change rather
     than a re-onboarding, and the website can say "your subscription ended on
     the 3rd" instead of pretending the server was never a customer.
     """
 
     __tablename__ = "stripe_subscription"
-    # Keyed by Discord guild id like every other table here, not by Stripe's
-    # customer id: everything that reads this starts from a guild.
-    server_id = Column(String, primary_key=True)
+    stripe_subscription_id = Column(String, primary_key=True)
+    # Indexed rather than unique: every read starts from a guild, and a guild
+    # may legitimately have more than one row.
+    server_id = Column(String, index=True, nullable=False)
     stripe_customer_id = Column(String, nullable=False)
-    stripe_subscription_id = Column(String, nullable=False, unique=True)
     # Which of the three plans. Stored rather than derived, because the price
     # id is the only thing the webhook reports and the labels live in the
     # dashboard's config.
@@ -515,7 +530,8 @@ class StripeSubscription(Base):
     status = Column(String, nullable=False)
     current_period_end = Column(DateTime(timezone=True), nullable=False)
     cancel_at_period_end = Column(Boolean, nullable=False, default=False)
-    # Ordering guard. Stripe does not promise events arrive in order, and a
+    # Ordering guard, per subscription — which is the scope Stripe's ordering
+    # actually concerns. It does not promise events arrive in order, and a
     # delayed `subscription.updated` overwriting a newer `subscription.deleted`
     # would silently restore premium to a server that cancelled.
     last_event_created = Column(DateTime(timezone=True), nullable=False)
@@ -531,12 +547,22 @@ class StripeEvent(Base):
     the event is a replay, which is the same pattern capture_grandfather_line()
     uses to settle its race. Stripe retries a webhook for up to three days, so
     duplicates are expected traffic rather than an anomaly.
+
+    Pruned by the same function that inserts, deliberately rather than by a
+    scheduled job — the A-24 pattern, where the only thing that can add a row
+    is also the thing that removes them, so nothing here needs a scheduler to
+    stay correct. Anything older than STRIPE_EVENT_RETENTION_DAYS is far
+    outside Stripe's three-day retry window and can no longer be replayed at
+    us, so keeping it buys nothing and grows forever.
     """
 
     __tablename__ = "stripe_event"
     event_id = Column(String, primary_key=True)
+    # Indexed because the sweep filters on it on every insert.
     received_at = Column(
-        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+        DateTime(timezone=True),
+        index=True,
+        default=lambda: datetime.now(timezone.utc),
     )
 
 
@@ -865,6 +891,18 @@ STRIPE_STATUS_TTL = _int_env("STRIPE_STATUS_TTL", 900)
 # how the Discord side already behaves. The two payment paths must not disagree
 # about what cancelling means.
 STRIPE_PAID_STATUSES = frozenset({"active", "trialing", "past_due"})
+
+# How long a processed webhook event id is kept before the ledger forgets it.
+#
+# Its only job is to recognise a redelivery, and Stripe stops retrying after
+# three days — so anything older than that can no longer be replayed at us and
+# keeping it buys nothing. Thirty days is an order of magnitude of headroom on
+# a number that is not ours to change.
+#
+# This exists because the alternative is a table that grows one row per webhook
+# forever, which is A-24 exactly: `SessionStore.purge_expired` was written and
+# never called, and the table grew unbounded on the VPS until somebody noticed.
+STRIPE_EVENT_RETENTION_DAYS = _int_env("STRIPE_EVENT_RETENTION_DAYS", 30)
 
 # Premium guilds get a shorter throttle on actions that hit the shared VRChat
 # account. 0 disables the wait entirely.
@@ -1303,16 +1341,21 @@ def stripe_active(guild_id) -> bool:
     try:
         now = datetime.now(timezone.utc)
         with session_scope() as session:
-            row = (
+            # Any paid row wins. A guild can hold more than one subscription
+            # (see the model docstring), and being double-billed must not be
+            # able to switch premium off — the warning about it is the
+            # website's job, and the gate's only job is to keep saying yes.
+            rows = (
                 session.query(
                     StripeSubscription.status,
                     StripeSubscription.current_period_end,
                 )
                 .filter_by(server_id=key)
-                .first()
+                .all()
             )
-            active = row is not None and _stripe_row_is_paid(
-                row.status, row.current_period_end, now
+            active = any(
+                _stripe_row_is_paid(row.status, row.current_period_end, now)
+                for row in rows
             )
         stripe_status_cache.set(key, active)
         return active
@@ -1361,8 +1404,9 @@ def load_stripe_subscription(guild_id):
     if not STRIPE_ENABLED:
         return None
     try:
+        now = datetime.now(timezone.utc)
         with session_scope() as session:
-            row = (
+            rows = (
                 session.query(
                     StripeSubscription.status,
                     StripeSubscription.price_id,
@@ -1370,13 +1414,29 @@ def load_stripe_subscription(guild_id):
                     StripeSubscription.cancel_at_period_end,
                 )
                 .filter_by(server_id=panel_view_key(guild_id))
-                .first()
+                .all()
             )
-            if row is None:
+            if not rows:
                 return None
-            period_end = row.current_period_end
-            if period_end is not None and period_end.tzinfo is None:
-                period_end = period_end.replace(tzinfo=timezone.utc)
+
+            normalised = []
+            for row in rows:
+                period_end = row.current_period_end
+                if period_end is not None and period_end.tzinfo is None:
+                    period_end = period_end.replace(tzinfo=timezone.utc)
+                normalised.append(
+                    (row, period_end, _stripe_row_is_paid(row.status, period_end, now))
+                )
+
+            # Which one the page describes: the paid subscription running
+            # longest, or — if none is paid — the one that ended most recently,
+            # so "your subscription ended on the 3rd" names the right date
+            # rather than an older lapsed one.
+            paid = [entry for entry in normalised if entry[2]]
+            row, period_end, _active = max(
+                paid or normalised,
+                key=lambda entry: entry[1] or datetime.min.replace(tzinfo=timezone.utc),
+            )
             return {
                 "status": row.status,
                 # The price id, not a plan name. Turning it into the words
@@ -1389,9 +1449,13 @@ def load_stripe_subscription(guild_id):
                     None if period_end is None else period_end.isoformat()
                 ),
                 "cancel_at_period_end": bool(row.cancel_at_period_end),
-                "active": _stripe_row_is_paid(
-                    row.status, period_end, datetime.now(timezone.utc)
-                ),
+                "active": bool(paid),
+                # How many subscriptions this guild is currently paying for.
+                # More than one *is* the double-billing case, and the whole
+                # reason it can be detected at all is that the table keys by
+                # subscription rather than by guild. The website warns; nothing
+                # here ever cancels or refunds anything.
+                "active_count": len(paid),
             }
     except Exception:
         logger.warning(
@@ -5043,6 +5107,10 @@ async def read_dashboard_settings(guild_id) -> Optional[dict]:
                 "cancel_at_period_end": bool(
                     (subscription or {}).get("cancel_at_period_end")
                 ),
+                # More than one means the server is paying twice. The page
+                # warns and links to the portal; nothing anywhere cancels or
+                # refunds on anyone's behalf.
+                "active_count": (subscription or {}).get("active_count", 0),
             },
             # A column the deployed database is missing is reported as such
             # rather than silently rendered as a working toggle.
@@ -5988,6 +6056,27 @@ def _parse_stripe_timestamp(raw) -> Optional[datetime]:
     return parsed.astimezone(timezone.utc)
 
 
+def _prune_stripe_events(session, now: datetime) -> None:
+    """Forget event ids too old to be replayed at us.
+
+    Called by the one function that inserts them, on the same transaction —
+    the A-24 pattern. The only way to add a row here is also the thing that
+    removes them, so this cannot become another `purge_expired` that exists and
+    is never called, and nothing needs a scheduler to stay correct.
+
+    Deliberately not allowed to fail the write it rides along with: losing a
+    subscription event because a housekeeping DELETE went wrong would be a far
+    worse trade than a table that stays large for another day.
+    """
+    try:
+        cutoff = now - timedelta(days=STRIPE_EVENT_RETENTION_DAYS)
+        session.query(StripeEvent).filter(StripeEvent.received_at < cutoff).delete(
+            synchronize_session=False
+        )
+    except Exception:
+        logger.warning("Could not prune the Stripe event ledger.", exc_info=True)
+
+
 def _stripe_event_recorded(event_id: str) -> bool:
     """Has this event id already been written? Used only to read an IntegrityError.
 
@@ -6039,15 +6128,24 @@ async def write_dashboard_stripe_subscription(guild_id, payload: dict):
        expected traffic — and putting the insert in the same transaction means
        a failure part-way through rolls back the ledger entry too, rather than
        marking an event processed that never was.
-    2. **Ordering.** Stripe does not promise events arrive in order. An event
-       no newer than the one already applied is recorded and dropped, because a
-       delayed `subscription.updated` overwriting a newer `subscription.deleted`
-       would silently restore premium to a server that cancelled.
-    3. **Supersession.** An event for a *different* subscription id than the
-       one on file is applied only if it grants premium. A server that bought a
-       second subscription and cancelled the first would otherwise have the
-       cancellation of the dead one wipe out the live one — with the ordering
-       guard waving it through, since that cancellation genuinely is newer.
+    2. **Ordering, per subscription.** Stripe does not promise events arrive in
+       order. An event no newer than the one already applied to *that
+       subscription* is recorded and dropped, because a delayed
+       `subscription.updated` overwriting a newer `subscription.deleted` would
+       silently restore premium to a server that cancelled.
+
+       **A constraint on whoever builds the forwarding half (#88 step 3):**
+       Stripe's `event.created` has one-second resolution, so two events for
+       the same subscription in the same second are indistinguishable in age
+       and the second one is dropped here — silently, because we answer 200 and
+       Stripe never retries. A purchase is safe (no row exists yet, so no
+       ordering check runs); it is follow-up events that can be lost. The fix
+       is on that side, and it is what Stripe recommends anyway: on any
+       subscription event, fetch the current subscription object and forward
+       *that*, rather than forwarding the event's own snapshot. Then every
+       delivery carries current truth and ordering stops mattering much.
+    3. **Ownership.** One Stripe subscription belongs to one guild. An event
+       naming a different one is an anomaly that needs a human, not a retry.
 
     Returns a small dict saying whether the change was applied, or None if the
     write could not be completed — which the API turns into a 503, which the
@@ -6066,7 +6164,7 @@ async def write_dashboard_stripe_subscription(guild_id, payload: dict):
     customer_id = payload.get("customer_id")
     price_id = payload.get("price_id")
     status = payload.get("status")
-    cancel_at_period_end = bool(payload.get("cancel_at_period_end"))
+    cancel_at_period_end = payload.get("cancel_at_period_end", False)
     period_end = _parse_stripe_timestamp(payload.get("current_period_end"))
     event_created = _parse_stripe_timestamp(payload.get("event_created"))
 
@@ -6083,6 +6181,12 @@ async def write_dashboard_stripe_subscription(guild_id, payload: dict):
         raise SettingRejected("current_period_end", "bad_current_period_end")
     if event_created is None:
         raise SettingRejected("event_created", "bad_event_created")
+    # Checked here as well as at the envelope, because bool("false") is True
+    # and this is the field that decides whether the page says "renews" or
+    # "ends". Coercing it would make a wrong statement about someone's money
+    # out of a normalisation slip.
+    if not isinstance(cancel_at_period_end, bool):
+        raise SettingRejected("cancel_at_period_end", "bad_cancel_at_period_end")
 
     now = datetime.now(timezone.utc)
     grants_premium = _stripe_row_is_paid(status, period_end, now)
@@ -6116,34 +6220,44 @@ async def write_dashboard_stripe_subscription(guild_id, payload: dict):
             # event would be marked processed without ever having been applied
             # and Stripe's retry would be answered "already done".
             session.add(StripeEvent(event_id=event_id))
+            _prune_stripe_events(session, now)
 
+            # Keyed by subscription, so an event only ever touches the
+            # subscription it is about. This is what removes the whole class of
+            # bug where a renewal of an older subscription overwrote a newer
+            # one and its later cancellation then switched off a server still
+            # being billed for the other.
             row = (
-                session.query(StripeSubscription).filter_by(server_id=key).first()
+                session.query(StripeSubscription)
+                .filter_by(stripe_subscription_id=subscription_id)
+                .first()
             )
 
             if row is not None:
+                if row.server_id != key:
+                    # One Stripe subscription cannot belong to two guilds. This
+                    # is an anomaly needing a human, not a transient failure —
+                    # so it is loud, and it is not applied.
+                    logger.error(
+                        "Stripe subscription %s is recorded against guild %s but "
+                        "this event names %s; refusing to move it. This needs "
+                        "looking at in Stripe.",
+                        subscription_id,
+                        row.server_id,
+                        key,
+                    )
+                    return {"applied": False, "reason": "guild_mismatch"}
                 stored_created = row.last_event_created
                 if stored_created is not None and stored_created.tzinfo is None:
                     stored_created = stored_created.replace(tzinfo=timezone.utc)
                 if stored_created is not None and event_created <= stored_created:
                     logger.info(
-                        "Stripe event %s for guild %s is older than the state on "
-                        "file; recorded but not applied.",
-                        event_id,
-                        key,
-                    )
-                    return {"applied": False, "reason": "out_of_order"}
-                if row.stripe_subscription_id != subscription_id and not grants_premium:
-                    logger.warning(
-                        "Stripe event %s concerns subscription %s, but guild %s is "
-                        "on %s and the event does not grant premium; recorded but "
-                        "not applied.",
+                        "Stripe event %s for subscription %s is older than the "
+                        "state on file; recorded but not applied.",
                         event_id,
                         subscription_id,
-                        key,
-                        row.stripe_subscription_id,
                     )
-                    return {"applied": False, "reason": "superseded_subscription"}
+                    return {"applied": False, "reason": "out_of_order"}
 
             # Everything an admin might later need to account for, in one
             # string. The renewal date and the cancel flag are in here on
@@ -6195,11 +6309,10 @@ async def write_dashboard_stripe_subscription(guild_id, payload: dict):
     except SettingRejected:
         raise
     except IntegrityError:
-        # Two constraints can produce this, and they mean opposite things.
+        # A concurrent delivery of this same event won the race to the ledger's
+        # primary key. Theirs is as good as ours — the same reasoning
+        # capture_grandfather_line uses when another writer gets there first.
         if _stripe_event_recorded(event_id):
-            # A concurrent delivery of this same event won the race. Theirs is
-            # as good as ours — the same reasoning capture_grandfather_line
-            # uses when another writer gets there first.
             logger.info(
                 "Stripe event %s for guild %s was recorded concurrently; "
                 "treating this delivery as the duplicate it is.",
@@ -6207,15 +6320,11 @@ async def write_dashboard_stripe_subscription(guild_id, payload: dict):
                 key,
             )
             return {"applied": False, "reason": "duplicate_event"}
-        # Otherwise the unique constraint on stripe_subscription_id fired:
-        # this subscription is already attached to a *different* guild. That is
-        # a real anomaly rather than a transient failure, and it needs a human,
-        # so say so loudly and let Stripe retry rather than pretending it
-        # landed.
+        # Anything else is unexplained. Let Stripe retry rather than pretending
+        # it landed.
         logger.error(
-            "Stripe subscription %s is already recorded against another guild; "
-            "refusing to move it to %s. This needs looking at in Stripe.",
-            subscription_id,
+            "Unexpected integrity error recording Stripe event %s for guild %s.",
+            event_id,
             key,
             exc_info=True,
         )

--- a/src/bot.py
+++ b/src/bot.py
@@ -479,6 +479,67 @@ class VerificationDaily(Base):
     count = Column(Integer, nullable=False, default=0)
 
 
+class StripeSubscription(Base):
+    """A guild's card subscription, mirrored from Stripe (issue #88).
+
+    Stripe is the source of truth. This is a local copy so the premium gate
+    stays a database read rather than an API call on every verification — and
+    so the bot never needs a Stripe credential to answer "is this server paid
+    up", which is the property that keeps every Stripe secret on the VPS.
+
+    A separate table for the same reason as the five above: create_all() adds
+    missing tables but never columns. The dead `subscription_status` / `email`
+    / `last_renewal_date` columns on `servers` stay dead — they could not hold
+    a customer id, a subscription id or a price id even if they were wanted.
+
+    The row survives a lapsed subscription, like VerificationLogChannel and
+    InstructionPanelBranding do. Resubscribing is then a status change rather
+    than a re-onboarding, and the website can say "your subscription ended on
+    the 3rd" instead of pretending the server was never a customer.
+    """
+
+    __tablename__ = "stripe_subscription"
+    # Keyed by Discord guild id like every other table here, not by Stripe's
+    # customer id: everything that reads this starts from a guild.
+    server_id = Column(String, primary_key=True)
+    stripe_customer_id = Column(String, nullable=False)
+    stripe_subscription_id = Column(String, nullable=False, unique=True)
+    # Which of the three plans. Stored rather than derived, because the price
+    # id is the only thing the webhook reports and the labels live in the
+    # dashboard's config.
+    price_id = Column(String, nullable=False)
+    # Stripe's own status string, verbatim and unmapped. A boolean here would
+    # throw away the difference between "cancelled" and "we could not charge
+    # the card yesterday", which is exactly the difference support questions
+    # are about.
+    status = Column(String, nullable=False)
+    current_period_end = Column(DateTime(timezone=True), nullable=False)
+    cancel_at_period_end = Column(Boolean, nullable=False, default=False)
+    # Ordering guard. Stripe does not promise events arrive in order, and a
+    # delayed `subscription.updated` overwriting a newer `subscription.deleted`
+    # would silently restore premium to a server that cancelled.
+    last_event_created = Column(DateTime(timezone=True), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+
+class StripeEvent(Base):
+    """Every webhook event id this bot has already acted on.
+
+    Insert first and let the primary key settle it: an IntegrityError means
+    the event is a replay, which is the same pattern capture_grandfather_line()
+    uses to settle its race. Stripe retries a webhook for up to three days, so
+    duplicates are expected traffic rather than an anomaly.
+    """
+
+    __tablename__ = "stripe_event"
+    event_id = Column(String, primary_key=True)
+    received_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+
 # Creates any missing tables. Note this does NOT add columns to tables that
 # already exist — those still need a manual ALTER.
 Base.metadata.create_all(engine)
@@ -673,12 +734,20 @@ async def on_app_command_error(
 
 
 # -------------------------------------------------------------------
-# Premium (Discord App Subscriptions)
+# Premium (Discord App Subscriptions, or a card via Stripe)
 # -------------------------------------------------------------------
-# A guild-scoped subscription SKU: one purchase by a server owner entitles the
-# whole guild. Gating reads Discord entitlements and nothing else — the
-# subscription_status / email / last_renewal_date columns on `servers` are dead
-# Stripe leftovers and are deliberately never consulted.
+# Guild-scoped either way: one purchase entitles the whole server. There are
+# two ways to buy the identical bundle, and premium is granted if *either* is
+# live — a Discord entitlement, or an active row in `stripe_subscription`.
+# Never "one overrides the other"; the gate is an OR.
+#
+# The `subscription_status` / `email` / `last_renewal_date` columns on `servers`
+# remain dead leftovers of a Stripe integration removed years before this one,
+# and issue #88 deliberately did NOT resurrect them: they cannot hold a customer
+# id, a subscription id or a price id, and create_all() cannot add columns to an
+# existing table anyway. Card subscriptions live in `stripe_subscription`. If
+# you are reading this because you found Stripe code and then found those
+# columns, they are still never consulted.
 
 
 def _optional_int_env(name: str) -> int | None:
@@ -753,6 +822,49 @@ PREMIUM_STATUS_TTL = _int_env("PREMIUM_STATUS_TTL", 900)
 # precisely when Discord is already struggling, and discord.py's 429 backoff
 # would then throttle the whole bot, verification DMs included.
 PREMIUM_FAILURE_TTL = _int_env("PREMIUM_FAILURE_TTL", 60)
+
+# The second kill switch, for the second way to pay. Unset, the bot never reads
+# `stripe_subscription`, never registers the API route that writes it, and tells
+# the dashboard `stripe.enabled: false` — so this whole feature ships dormant
+# and switches on separately, exactly like PREMIUM_SKU_ID and BOT_API_ENABLED.
+#
+# Note this is the *bot's* copy of the switch. The dashboard has its own, which
+# gates the Stripe secrets and the checkout buttons. They are not redundant:
+# the bot's answer is the one that travels in the settings payload, so the
+# website can never offer a Buy button for a purchase the bot would refuse to
+# record. Turning the dashboard's on without this one means Stripe retries a
+# 404 for three days and then gives up — see VPS_RUNBOOK.md before flipping
+# either.
+#
+# The bot holds no Stripe credential of any kind, switched on or off. It reads
+# a table the dashboard fills in over mTLS, and that is the entire integration.
+STRIPE_ENABLED = (os.getenv("STRIPE_ENABLED") or "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
+
+# How long a resolved card subscription is trusted before we re-read the table.
+# Purchases don't wait for this either: the webhook write invalidates the guild
+# in the same process, so the TTL only bounds how stale a *missed* webhook can
+# get. Longer than the Discord one would be safe — this is a local table, not a
+# third party — but matching it keeps one number to reason about.
+STRIPE_STATUS_TTL = _int_env("STRIPE_STATUS_TTL", 900)
+
+# Stripe's statuses that mean "this server has paid for what it is using".
+#
+# `past_due` is deliberately in this set. Stripe is still retrying the card;
+# the subscription is not cancelled, a charge is merely late. Cutting a paying
+# customer off on the first failed retry is the same mistake the entitlement
+# lookup's fail-open exists to avoid. `unpaid` is Stripe having given up, and
+# is not in the set.
+#
+# `canceled` is not here either, but see stripe_active(): a cancelled
+# subscription keeps premium until its paid period actually runs out, which is
+# how the Discord side already behaves. The two payment paths must not disagree
+# about what cancelling means.
+STRIPE_PAID_STATUSES = frozenset({"active", "trialing", "past_due"})
 
 # Premium guilds get a shorter throttle on actions that hit the shared VRChat
 # account. 0 disables the wait entirely.
@@ -1149,6 +1261,175 @@ class PremiumStatusCache:
 
 premium_status_cache = PremiumStatusCache(PREMIUM_STATUS_TTL)
 
+# The card half of the gate gets its own instance of the same class, never a
+# shared one. Two sources of truth sharing a cache means either can corrupt the
+# other's fallback — and their fallbacks point in opposite directions on
+# purpose (see stripe_active), so a collision would silently invert one of them.
+stripe_status_cache = PremiumStatusCache(STRIPE_STATUS_TTL)
+
+
+def stripe_active(guild_id) -> bool:
+    """Does this guild have a live card subscription?
+
+    Reads the mirrored `stripe_subscription` row through a TTL cache, so the
+    common answer costs nothing and a miss costs one indexed primary-key
+    lookup. The webhook write invalidates the guild directly, in this same
+    process, so a purchase takes effect immediately rather than waiting out the
+    TTL — the same reason on_entitlement_create invalidates the Discord cache.
+
+    **The failure rule here is the opposite of the Discord one, deliberately.**
+    guild_has_premium fails *open* to True, because a Discord API outage must
+    not switch off a paying customer. This one falls back to last-known, and to
+    **False** when there has never been one. That is not an inconsistency to be
+    tidied up: a server that has never had a card subscription cannot acquire
+    one during a database blip, so failing open here would hand premium to
+    every server in the bot the moment Postgres hiccups. Servers that *do* pay
+    by card are still covered, by exactly the same last-known layer the Discord
+    path uses. Do not "fix" this to fail open.
+    """
+    if not STRIPE_ENABLED:
+        # Nothing has been sold this way yet. Not merely False — no query at
+        # all, which is what keeps resolve_premium_flags_from_interaction free
+        # of I/O while the feature is dormant.
+        return False
+    if guild_id is None:
+        return False
+
+    key = panel_view_key(guild_id)
+    cached = stripe_status_cache.get_fresh(key)
+    if cached is not None:
+        return cached
+
+    try:
+        now = datetime.now(timezone.utc)
+        with session_scope() as session:
+            row = (
+                session.query(
+                    StripeSubscription.status,
+                    StripeSubscription.current_period_end,
+                )
+                .filter_by(server_id=key)
+                .first()
+            )
+            active = row is not None and _stripe_row_is_paid(
+                row.status, row.current_period_end, now
+            )
+        stripe_status_cache.set(key, active)
+        return active
+    except Exception:
+        last_known = stripe_status_cache.get_last_known(key)
+        answer = False if last_known is None else last_known
+        # Provisional, so a guess can never become the fallback it was derived
+        # from — and so a sustained outage doesn't turn every verification into
+        # another failing query.
+        stripe_status_cache.set_provisional(key, answer, PREMIUM_FAILURE_TTL)
+        logger.warning(
+            "Stripe subscription lookup failed for guild %s; falling back to %s "
+            "for %ss.",
+            key,
+            "last known value" if last_known is not None else "no subscription",
+            PREMIUM_FAILURE_TTL,
+            exc_info=True,
+        )
+        return answer
+
+
+# Same sentinel discipline as BRANDING_UNREADABLE: "we could not read this" is
+# a third answer, distinct from "there is no subscription". Collapsing the two
+# would put "not subscribed" next to a Buy button on the website during a
+# database blip, which is how you sell somebody a second subscription.
+STRIPE_UNREADABLE = object()
+
+
+def load_stripe_subscription(guild_id):
+    """One guild's mirrored subscription, for the website to describe.
+
+    Returns a plain dict, None when there has never been a card subscription,
+    or STRIPE_UNREADABLE when the table could not be read.
+
+    Deliberately reads the table directly rather than going through
+    stripe_active's cache: this is a page render, not the verification gate,
+    and it needs the fields behind the answer rather than the boolean. The
+    cache exists to keep the *gate* cheap, and borrowing it here would mean
+    either caching five more values or answering with a stale renewal date.
+
+    No customer id and no email leave this function. The page has nothing to do
+    with either — billing details are managed on Stripe's own domain, in the
+    portal — and shipping an id the website does not need across the wire is
+    how it ends up in a log on the internet-facing box.
+    """
+    if not STRIPE_ENABLED:
+        return None
+    try:
+        with session_scope() as session:
+            row = (
+                session.query(
+                    StripeSubscription.status,
+                    StripeSubscription.price_id,
+                    StripeSubscription.current_period_end,
+                    StripeSubscription.cancel_at_period_end,
+                )
+                .filter_by(server_id=panel_view_key(guild_id))
+                .first()
+            )
+            if row is None:
+                return None
+            period_end = row.current_period_end
+            if period_end is not None and period_end.tzinfo is None:
+                period_end = period_end.replace(tzinfo=timezone.utc)
+            return {
+                "status": row.status,
+                # The price id, not a plan name. Turning it into the words
+                # "6 months" needs the slug table, which is dashboard config
+                # precisely because test and live mode have different ids --
+                # and a second copy of that mapping over here would be a second
+                # thing to get wrong on a page about money.
+                "price_id": row.price_id,
+                "current_period_end": (
+                    None if period_end is None else period_end.isoformat()
+                ),
+                "cancel_at_period_end": bool(row.cancel_at_period_end),
+                "active": _stripe_row_is_paid(
+                    row.status, period_end, datetime.now(timezone.utc)
+                ),
+            }
+    except Exception:
+        logger.warning(
+            "Could not read the Stripe subscription for guild %s.",
+            guild_id,
+            exc_info=True,
+        )
+        return STRIPE_UNREADABLE
+
+
+def _stripe_row_is_paid(status, current_period_end, now: datetime) -> bool:
+    """Does this mirrored row mean the server has paid for what it is using?
+
+    Two independent conditions, both required:
+
+    * the status is one Stripe considers paid (STRIPE_PAID_STATUSES), **or**
+      the subscription is cancelled but its paid period has not run out yet;
+    * the paid period has not run out.
+
+    That second clause is what makes a `canceled` subscription keep working
+    until the date the customer paid through, matching the Discord side's
+    "a cancellation leaves it live until the paid period actually runs out".
+    """
+    if current_period_end is None:
+        return False
+    # SQLite hands back naive datetimes for a timezone-aware column, so a row
+    # written on Postgres and one written in a test compare differently unless
+    # this is normalised. Storing UTC is a project-wide invariant, so assuming
+    # it here is safe.
+    if current_period_end.tzinfo is None:
+        current_period_end = current_period_end.replace(tzinfo=timezone.utc)
+    if current_period_end <= now:
+        return False
+    # Past this point the period is still running. `canceled` reaches here and
+    # is granted on purpose; `unpaid`, `incomplete` and `incomplete_expired`
+    # are refused because no money ever arrived or Stripe has stopped trying.
+    return status in STRIPE_PAID_STATUSES or status == "canceled"
+
 
 def entitlements_grant_premium(entitlements) -> bool:
     """Does this collection of entitlements include a live one for our SKU?"""
@@ -1368,10 +1649,18 @@ class PremiumFlags:
 
 
 async def resolve_premium_flags(guild_id) -> PremiumFlags:
-    """Resolve every gate for a guild in one pass (no interaction available)."""
+    """Resolve every gate for a guild in one pass (no interaction available).
+
+    Premium is an OR over the two ways to buy it. The two sources are resolved
+    by separate functions with separate caches and deliberately opposite
+    failure rules, and neither is allowed to see the other's answer — see
+    stripe_active for why that matters.
+    """
     if not PREMIUM_ENFORCED:
         return PremiumFlags(premium=True, grandfathered=True)
-    premium = await guild_has_premium(guild_id)
+    # Short-circuit on the Discord answer: a server already entitled through
+    # Discord never needs the table read.
+    premium = await guild_has_premium(guild_id) or stripe_active(guild_id)
     # Only worth a DB hit when the answer could still change the outcome.
     grandfathered = False if premium else is_grandfathered(guild_id)
     return PremiumFlags(premium=premium, grandfathered=grandfathered)
@@ -1380,10 +1669,23 @@ async def resolve_premium_flags(guild_id) -> PremiumFlags:
 def resolve_premium_flags_from_interaction(
     interaction: discord.Interaction,
 ) -> PremiumFlags:
-    """Same, for a command or button where the payload already has the answer."""
+    """Same, for a command or button where the payload already has the answer.
+
+    `premium_from_interaction` is free — Discord ships the entitlements with
+    every interaction — and this function must stay nearly so, because it runs
+    on every slash command. The `or` below is what protects that: an entitled
+    server never reaches stripe_active at all, and an unentitled one pays one
+    cached lookup whose entry is invalidated on purchase rather than expiring
+    hot. With STRIPE_ENABLED unset, stripe_active does not query at all.
+
+    There is a test asserting the short-circuit, because losing it would put a
+    database query behind every interaction and nothing else would notice.
+    """
     if not PREMIUM_ENFORCED:
         return PremiumFlags(premium=True, grandfathered=True)
-    premium = premium_from_interaction(interaction)
+    premium = premium_from_interaction(interaction) or stripe_active(
+        interaction.guild_id
+    )
     grandfathered = False if premium else is_grandfathered(interaction.guild_id)
     return PremiumFlags(premium=premium, grandfathered=grandfathered)
 
@@ -4699,6 +5001,14 @@ async def read_dashboard_settings(guild_id) -> Optional[dict]:
         values["panel_show_icon"] = bool(show_icon)
         values["verification_log_channel_id"] = load_log_channel_id(guild_id)
 
+        subscription = load_stripe_subscription(guild_id)
+        if subscription is STRIPE_UNREADABLE:
+            # Same refusal as unreadable branding, and for a sharper reason:
+            # the Subscriptions page renders buy buttons from this block, and
+            # "we could not read it" rendered as "not subscribed" is a page
+            # inviting a paying customer to pay again.
+            return None
+
         return {
             "guild_id": str(guild_id),
             "premium": {
@@ -4713,6 +5023,26 @@ async def read_dashboard_settings(guild_id) -> Optional[dict]:
                 # dashboard offers no upgrade at all, which is correct -- there
                 # is nothing to sell when every gate answers "allowed".
                 "sku_id": str(PREMIUM_SKU_ID) if PREMIUM_SKU_ID is not None else None,
+            },
+            # Why the answer above is what it is, for the half of it Discord
+            # cannot explain. `premium.premium` stays the single answer to "is
+            # this server premium" -- this block never becomes a second thing
+            # the website ORs together itself, or there would be two gates to
+            # keep in step.
+            #
+            # `enabled` is the bot's own kill switch, sent for the same reason
+            # sku_id is: the website must never offer a Buy button for a
+            # purchase this process would refuse to record. With it false the
+            # page shows the Discord path only.
+            "stripe": {
+                "enabled": STRIPE_ENABLED,
+                "active": bool(subscription and subscription["active"]),
+                "status": (subscription or {}).get("status"),
+                "price_id": (subscription or {}).get("price_id"),
+                "current_period_end": (subscription or {}).get("current_period_end"),
+                "cancel_at_period_end": bool(
+                    (subscription or {}).get("cancel_at_period_end")
+                ),
             },
             # A column the deployed database is missing is reported as such
             # rather than silently rendered as a working toggle.
@@ -5629,13 +5959,299 @@ async def write_dashboard_settings(guild_id, actor_id, changes: dict):
     return settings
 
 
+# The actor recorded against every Stripe-driven change. A fixed, non-human,
+# obviously-not-a-snowflake string, so the audit trail can never attribute a
+# webhook to a person — and so a reader scanning the table can tell machine
+# writes from admin writes at a glance.
+STRIPE_AUDIT_ACTOR = "system:stripe"
+
+
+def _parse_stripe_timestamp(raw) -> Optional[datetime]:
+    """One ISO-8601 instant from the normalised payload, as aware UTC.
+
+    Returns None for anything unparseable rather than raising, so the caller
+    decides what a missing timestamp means — which differs between the two
+    fields that use this.
+    """
+    if isinstance(raw, datetime):
+        parsed = raw
+    elif isinstance(raw, str) and raw.strip():
+        try:
+            # Python's parser rejects the trailing "Z" Stripe and JSON both use.
+            parsed = datetime.fromisoformat(raw.strip().replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _stripe_event_recorded(event_id: str) -> bool:
+    """Has this event id already been written? Used only to read an IntegrityError.
+
+    False on a failed read, which sends the caller down the "retry" path rather
+    than the "already done" one. Being wrong in that direction costs a
+    redelivery; being wrong the other way loses a subscription event.
+    """
+    try:
+        with session_scope() as session:
+            return (
+                session.query(StripeEvent.event_id)
+                .filter_by(event_id=event_id)
+                .first()
+                is not None
+            )
+    except Exception:
+        logger.warning(
+            "Could not check whether Stripe event %s was already recorded.",
+            event_id,
+            exc_info=True,
+        )
+        return False
+
+
+def _stripe_audit_value(row) -> str:
+    """One subscription's meaningful state, as the audit trail records it."""
+    period_end = row.current_period_end
+    if isinstance(period_end, datetime) and period_end.tzinfo is None:
+        period_end = period_end.replace(tzinfo=timezone.utc)
+    return (
+        f"{row.status} {row.stripe_subscription_id} {row.price_id} "
+        f"ends={period_end.isoformat() if period_end else 'unknown'} "
+        f"cancel_at_period_end={bool(row.cancel_at_period_end)}"
+    )
+
+
+async def write_dashboard_stripe_subscription(guild_id, payload: dict):
+    """Mirror one Stripe subscription event into the database.
+
+    The only caller is the bot API's system route, which the dashboard reaches
+    after verifying a webhook's signature. Nothing here talks to Stripe: this
+    process holds no Stripe credential and never will, so everything it knows
+    arrives in `payload`, already normalised on the other side of the wire.
+
+    Three guards, in this order, and all three matter:
+
+    1. **Idempotency.** The event id is inserted first, in the same transaction
+       as the change. Stripe retries for up to three days, so duplicates are
+       expected traffic — and putting the insert in the same transaction means
+       a failure part-way through rolls back the ledger entry too, rather than
+       marking an event processed that never was.
+    2. **Ordering.** Stripe does not promise events arrive in order. An event
+       no newer than the one already applied is recorded and dropped, because a
+       delayed `subscription.updated` overwriting a newer `subscription.deleted`
+       would silently restore premium to a server that cancelled.
+    3. **Supersession.** An event for a *different* subscription id than the
+       one on file is applied only if it grants premium. A server that bought a
+       second subscription and cancelled the first would otherwise have the
+       cancellation of the dead one wipe out the live one — with the ordering
+       guard waving it through, since that cancellation genuinely is newer.
+
+    Returns a small dict saying whether the change was applied, or None if the
+    write could not be completed — which the API turns into a 503, which the
+    dashboard turns into a non-2xx, which makes Stripe retry. Losing an event
+    quietly is the one outcome this must never produce.
+
+    **It never touches the `servers` table.** A webhook can arrive for a guild
+    that has no row there, and inserting one would mint a fresh `servers.id`
+    above the captured grandfather line — silently costing that server the
+    features it was promised for free, forever, as a side effect of paying us.
+    There is a test for exactly this.
+    """
+    key = panel_view_key(guild_id)
+    event_id = payload.get("event_id")
+    subscription_id = payload.get("subscription_id")
+    customer_id = payload.get("customer_id")
+    price_id = payload.get("price_id")
+    status = payload.get("status")
+    cancel_at_period_end = bool(payload.get("cancel_at_period_end"))
+    period_end = _parse_stripe_timestamp(payload.get("current_period_end"))
+    event_created = _parse_stripe_timestamp(payload.get("event_created"))
+
+    for name, value in (
+        ("event_id", event_id),
+        ("subscription_id", subscription_id),
+        ("customer_id", customer_id),
+        ("price_id", price_id),
+        ("status", status),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            raise SettingRejected(name, f"bad_{name}")
+    if period_end is None:
+        raise SettingRejected("current_period_end", "bad_current_period_end")
+    if event_created is None:
+        raise SettingRejected("event_created", "bad_event_created")
+
+    now = datetime.now(timezone.utc)
+    grants_premium = _stripe_row_is_paid(status, period_end, now)
+
+    try:
+        with session_scope() as session:
+            # Read-then-insert rather than insert-and-catch, because catching
+            # here would mean a SAVEPOINT, and SAVEPOINT under pysqlite does not
+            # behave the way it does under Postgres. A guard that is only
+            # correct on the production database is a guard nothing can test.
+            #
+            # The genuine race — two concurrent deliveries of the same event —
+            # is still caught, by the primary key, at commit. See the
+            # IntegrityError branch below, which tells that apart from the
+            # other constraint in this table.
+            already_seen = (
+                session.query(StripeEvent.event_id)
+                .filter_by(event_id=event_id)
+                .first()
+            )
+            if already_seen is not None:
+                logger.info(
+                    "Stripe event %s for guild %s already processed; ignoring the "
+                    "retry.",
+                    event_id,
+                    key,
+                )
+                return {"applied": False, "reason": "duplicate_event"}
+            # In the same transaction as the change it authorises: a failure
+            # part-way through must roll back the ledger entry too, or the
+            # event would be marked processed without ever having been applied
+            # and Stripe's retry would be answered "already done".
+            session.add(StripeEvent(event_id=event_id))
+
+            row = (
+                session.query(StripeSubscription).filter_by(server_id=key).first()
+            )
+
+            if row is not None:
+                stored_created = row.last_event_created
+                if stored_created is not None and stored_created.tzinfo is None:
+                    stored_created = stored_created.replace(tzinfo=timezone.utc)
+                if stored_created is not None and event_created <= stored_created:
+                    logger.info(
+                        "Stripe event %s for guild %s is older than the state on "
+                        "file; recorded but not applied.",
+                        event_id,
+                        key,
+                    )
+                    return {"applied": False, "reason": "out_of_order"}
+                if row.stripe_subscription_id != subscription_id and not grants_premium:
+                    logger.warning(
+                        "Stripe event %s concerns subscription %s, but guild %s is "
+                        "on %s and the event does not grant premium; recorded but "
+                        "not applied.",
+                        event_id,
+                        subscription_id,
+                        key,
+                        row.stripe_subscription_id,
+                    )
+                    return {"applied": False, "reason": "superseded_subscription"}
+
+            # Everything an admin might later need to account for, in one
+            # string. The renewal date and the cancel flag are in here on
+            # purpose: "when did this server cancel" and "when did it last
+            # renew" are the two questions this trail exists to answer, and a
+            # descriptor of only the status would answer neither.
+            before = None if row is None else _stripe_audit_value(row)
+            after = _stripe_audit_value(
+                SimpleNamespace(
+                    status=status,
+                    stripe_subscription_id=subscription_id,
+                    price_id=price_id,
+                    current_period_end=period_end,
+                    cancel_at_period_end=cancel_at_period_end,
+                )
+            )
+
+            if row is None:
+                session.add(
+                    StripeSubscription(
+                        server_id=key,
+                        stripe_customer_id=customer_id,
+                        stripe_subscription_id=subscription_id,
+                        price_id=price_id,
+                        status=status,
+                        current_period_end=period_end,
+                        cancel_at_period_end=cancel_at_period_end,
+                        last_event_created=event_created,
+                        updated_at=now,
+                    )
+                )
+            else:
+                row.stripe_customer_id = customer_id
+                row.stripe_subscription_id = subscription_id
+                row.price_id = price_id
+                row.status = status
+                row.current_period_end = period_end
+                row.cancel_at_period_end = cancel_at_period_end
+                row.last_event_created = event_created
+                row.updated_at = now
+
+            if before != after:
+                _record_dashboard_audit(
+                    session,
+                    guild_id,
+                    STRIPE_AUDIT_ACTOR,
+                    [("stripe_subscription", before, after)],
+                )
+    except SettingRejected:
+        raise
+    except IntegrityError:
+        # Two constraints can produce this, and they mean opposite things.
+        if _stripe_event_recorded(event_id):
+            # A concurrent delivery of this same event won the race. Theirs is
+            # as good as ours — the same reasoning capture_grandfather_line
+            # uses when another writer gets there first.
+            logger.info(
+                "Stripe event %s for guild %s was recorded concurrently; "
+                "treating this delivery as the duplicate it is.",
+                event_id,
+                key,
+            )
+            return {"applied": False, "reason": "duplicate_event"}
+        # Otherwise the unique constraint on stripe_subscription_id fired:
+        # this subscription is already attached to a *different* guild. That is
+        # a real anomaly rather than a transient failure, and it needs a human,
+        # so say so loudly and let Stripe retry rather than pretending it
+        # landed.
+        logger.error(
+            "Stripe subscription %s is already recorded against another guild; "
+            "refusing to move it to %s. This needs looking at in Stripe.",
+            subscription_id,
+            key,
+            exc_info=True,
+        )
+        return None
+    except Exception:
+        logger.warning(
+            "Could not record the Stripe subscription for guild %s; the webhook "
+            "will be retried.",
+            key,
+            exc_info=True,
+        )
+        return None
+
+    # In-process, so a purchase takes effect on the very next verification
+    # rather than waiting out the TTL. This is the whole reason the write lands
+    # in the bot rather than being made by the dashboard against the database.
+    stripe_status_cache.invalidate(key)
+    logger.info(
+        "stripe WRITE guild=%s subscription=%s status=%s premium=%s event=%s",
+        key,
+        subscription_id,
+        status,
+        grants_premium,
+        event_id,
+    )
+    return {"applied": True, "status": status, "premium": grants_premium}
+
+
 def build_bot_api_deps() -> bot_api.BotAPIDeps:
     """Hand the API its complete set of capabilities.
 
-    One writer, named. `write_settings` is the only way the API can change a
-    row, and it can only change the fields DASHBOARD_WRITABLE_FIELDS names --
-    so widening what the website may touch is an edit to this file, reviewable
-    on its own, rather than a query string nobody noticed.
+    Every writer here is named for exactly what it writes. `write_settings` can
+    only change the fields DASHBOARD_WRITABLE_FIELDS names, and
+    `write_stripe_subscription` can only touch the `stripe_subscription` table
+    -- so widening what the website may touch is an edit to this file,
+    reviewable on its own, rather than a query string nobody noticed.
     """
     return bot_api.BotAPIDeps(
         is_ready=bot.is_ready,
@@ -5649,6 +6265,7 @@ def build_bot_api_deps() -> bot_api.BotAPIDeps:
         read_audit=read_dashboard_audit,
         read_overview=read_dashboard_overview,
         write_settings=write_dashboard_settings,
+        write_stripe_subscription=write_dashboard_stripe_subscription,
         post_panel=post_dashboard_panel,
     )
 

--- a/src/bot_api.py
+++ b/src/bot_api.py
@@ -890,6 +890,15 @@ async def handle_put_stripe_subscription(request: web.Request) -> web.Response:
     for value in subscription.values():
         if isinstance(value, str) and len(value) > MAX_STRIPE_FIELD_LEN:
             return _deny(request, 400, "field_too_long", actor=claims.actor_id)
+    # The one non-string field, checked for its actual type rather than left to
+    # be coerced. `bool("false")` is True, so a normalisation slip on the other
+    # side of the wire would silently turn "renews on the 3rd" into "ends on
+    # the 3rd" -- a wrong statement about somebody's money, arriving through
+    # the one field where a string and a boolean look equally plausible.
+    if "cancel_at_period_end" in subscription and not isinstance(
+        subscription["cancel_at_period_end"], bool
+    ):
+        return _deny(request, 400, "bad_cancel_at_period_end", actor=claims.actor_id)
 
     try:
         result = await deps.write_stripe_subscription(guild_id, subscription)

--- a/src/bot_api.py
+++ b/src/bot_api.py
@@ -6,12 +6,21 @@ SQLAlchemy. Everything it is allowed to touch arrives as a callable on
 
 That is not tidiness, it is the "least privilege on the API surface" control
 issue #65 asks for. There is no generic "write these columns" entry point here:
-`BotAPIDeps` carries exactly two mutating capabilities, `write_settings` and
-`post_panel`, and this module does not know which fields exist, which are
-premium, or what values are legal. It validates the envelope and hands the body
-to the bot, which decides. Adding a third means editing that dataclass and the
-test that pins it — a visible, reviewable diff rather than a new query string
-someone slipped past.
+`BotAPIDeps` carries exactly three mutating capabilities — `write_settings`,
+`write_stripe_subscription` and `post_panel` — each named for the one thing it
+changes, and this module does not know which fields exist, which are premium,
+or what values are legal. It validates the envelope and hands the body to the
+bot, which decides. Adding a fourth means editing that dataclass and the test
+that pins it — a visible, reviewable diff rather than a new query string someone
+slipped past.
+
+One of the three is unlike the others: `write_stripe_subscription` is reached by
+a route with **no human actor**, because a subscription renewal is not something
+a person asks for. It is authenticated identically in every other respect — mTLS,
+a signed token bound to this method, this path and this guild, the replay guard,
+the write budget — and it is the *only* operation for which the Administrator
+check is skipped, from an allowlist in `api_tokens.SYSTEM_OPERATIONS` that a
+token cannot talk its way into.
 
 Three things guard every request, in this order:
 
@@ -54,6 +63,9 @@ from api_tokens import (  # noqa: F401  (re-exported)
     DEFAULT_TOKEN_TTL,
     MIN_SIGNING_KEY_BYTES,
     OP_LIST_GUILDS,
+    OP_PUT_STRIPE_SUBSCRIPTION,
+    SYSTEM_ACTOR_ID,
+    SYSTEM_OPERATIONS,
     TOKEN_VERSION,
     TokenClaims,
     TokenError,
@@ -93,7 +105,10 @@ DEFAULT_GLOBAL_RATE_LIMIT = 600
 DEFAULT_WRITE_RATE_LIMIT = 10
 DEFAULT_GLOBAL_WRITE_RATE_LIMIT = 60
 
-# Nothing here accepts a body yet; this only has to be big enough for headers.
+# The ceiling aiohttp enforces before a handler sees anything. Comfortably
+# above the largest honest body — a settings patch of a few fields, or a
+# normalised Stripe subscription of eight short values — and far below anything
+# worth spending memory on.
 MAX_REQUEST_BYTES = 16 * 1024
 
 # The picker asks about the guilds the signed-in user is already a member of.
@@ -149,16 +164,17 @@ GLOBAL_WRITE_RATE_KEY: "web.AppKey" = web.AppKey("global_write_rate_limiter")
 class BotAPIDeps:
     """The complete list of things the API can do to the bot.
 
-    Ten of the twelve only read or check. `tests/test_bot_api.py` pins the
-    exact field set, so a third mutating capability cannot be added by accident
+    Ten of the thirteen only read or check. `tests/test_bot_api.py` pins the
+    exact field set, so a fourth mutating capability cannot be added by accident
     — adding one means editing that test on purpose, which is a reviewable diff
     rather than a quiet widening.
 
-    `write_settings` and `post_panel` are the whole mutating surface. Both are
-    named callables that validate against their own allowlist inside the bot,
-    not generic setters, so the worst a compromised dashboard can do is submit
-    valid values for the handful of fields the bot has decided are writable, and
-    ask for the one message it is allowed to post.
+    `write_settings`, `write_stripe_subscription` and `post_panel` are the whole
+    mutating surface. All three are named callables that validate against their
+    own rules inside the bot, not generic setters, so the worst a compromised
+    dashboard can do is submit valid values for the handful of fields the bot
+    has decided are writable, mirror a subscription into one table, and ask for
+    the one message it is allowed to post.
 
     Readers take and return plain data — ids, dicts, lists — never discord.py
     objects. Shaping a Guild into JSON is the bot's job, not this module's,
@@ -190,6 +206,15 @@ class BotAPIDeps:
     # the re-read settings, returns None because it could not complete, or
     # raises the bot's SettingRejected for anything the caller got wrong.
     write_settings: Callable[[int, int, dict], Awaitable[Optional[dict]]]
+    # Mirror one Stripe subscription event into the bot's own table. Takes
+    # (guild_id, payload) and returns whether it was applied, or None because
+    # it could not complete — which becomes a 503, which makes Stripe retry.
+    #
+    # No actor argument, unlike write_settings: there is no human behind a
+    # renewal, and the bot records a fixed system actor rather than anything
+    # this side could name. The payload is already normalised by the dashboard;
+    # nothing raw from Stripe crosses the wire.
+    write_stripe_subscription: Callable[[int, dict], Awaitable[Optional[dict]]]
     # The one action. Everything else here stores a value; this makes the bot
     # post a message in somebody's server, so it is named separately rather
     # than folded into write_settings.
@@ -228,6 +253,11 @@ class BotAPIConfig:
     global_rate_limit: int = DEFAULT_GLOBAL_RATE_LIMIT
     write_rate_limit: int = DEFAULT_WRITE_RATE_LIMIT
     global_write_rate_limit: int = DEFAULT_GLOBAL_WRITE_RATE_LIMIT
+    # With this off the Stripe route is never registered at all -- a 404, not a
+    # disabled handler that has to be trusted to refuse. Same discipline as
+    # BOT_API_ENABLED itself: the safest form of "switched off" is code that
+    # was never wired up.
+    stripe_enabled: bool = False
 
     @staticmethod
     def enabled() -> bool:
@@ -284,6 +314,7 @@ class BotAPIConfig:
             global_write_rate_limit=_int_env(
                 "BOT_API_GLOBAL_WRITE_RATE_LIMIT", DEFAULT_GLOBAL_WRITE_RATE_LIMIT
             ),
+            stripe_enabled=_truthy(os.getenv("STRIPE_ENABLED")),
         )
 
 
@@ -472,8 +503,28 @@ class _Denied(Exception):
         self.response = response
 
 
-async def _authorize(request: web.Request, *, guild_scoped: bool) -> TokenClaims:
-    """Run all three gates. Returns the claims, or raises _Denied."""
+async def _authorize(
+    request: web.Request, *, guild_scoped: bool, system: bool = False
+) -> TokenClaims:
+    """Run all three gates. Returns the claims, or raises _Denied.
+
+    `system=True` is for the one operation with no person behind it — a Stripe
+    webhook, verified on the dashboard and forwarded here. It changes exactly
+    two things and nothing else:
+
+    * the actor must be SYSTEM_ACTOR_ID, and the operation must be on the
+      `SYSTEM_OPERATIONS` allowlist. Both are checked, in both directions: a
+      system token cannot be used on a human route, and a human token cannot be
+      used on a system one. Since the operation is derived from the route the
+      router matched, neither is something a caller can assert.
+    * the Administrator check is skipped, because there is nobody to check. So
+      is `guild_present` — a renewal must still be recorded for a guild the bot
+      has been kicked from, or a server that re-adds the bot would find itself
+      unsubscribed despite still being billed.
+
+    Everything else is identical: mTLS, the signature, the guild binding, the
+    method binding, the replay guard and the write budget all still apply.
+    """
     config: BotAPIConfig = request.app[CONFIG_KEY]
     deps: BotAPIDeps = request.app[DEPS_KEY]
     operation = _operation_for(request)
@@ -520,6 +571,24 @@ async def _authorize(request: web.Request, *, guild_scoped: bool) -> TokenClaims
             )
         )
 
+    # --- Human or machine, and never the wrong one for this route ---
+    # Checked before the budgets so a mismatched token is refused rather than
+    # charged, and immediately after the signature so both sides of the test
+    # are on verified claims.
+    is_system_operation = operation in SYSTEM_OPERATIONS
+    if is_system_operation != system:
+        # Only reachable if a route was registered with the wrong flag; the
+        # allowlist and the handler would then disagree about what this is.
+        raise _Denied(
+            _deny(request, 403, "operation_not_permitted", actor=claims.actor_id)
+        )
+    if system and claims.actor_id != SYSTEM_ACTOR_ID:
+        raise _Denied(_deny(request, 403, "not_system_actor", actor=claims.actor_id))
+    if not system and claims.actor_id == SYSTEM_ACTOR_ID:
+        # The system actor has no Administrator to check, so it must never be
+        # able to reach a route whose only authority check is that one.
+        raise _Denied(_deny(request, 403, "system_actor_not_permitted", actor=claims.actor_id))
+
     # --- Budgets, charged to the authenticated actor ---
     limiter: RateLimiter = request.app[RATE_KEY]
     global_limiter: RateLimiter = request.app[GLOBAL_RATE_KEY]
@@ -543,7 +612,7 @@ async def _authorize(request: web.Request, *, guild_scoped: bool) -> TokenClaims
     if not deps.is_ready():
         raise _Denied(_deny(request, 503, "not_ready", actor=claims.actor_id))
 
-    if guild_scoped:
+    if guild_scoped and not system:
         if not deps.guild_present(guild_id):
             raise _Denied(_deny(request, 404, "guild_not_found", actor=claims.actor_id))
         # Re-checked here on every request, never cached against the session:
@@ -757,8 +826,86 @@ async def handle_post_panel(request: web.Request) -> web.Response:
     return _json(result)
 
 
+# The normalised subscription payload's complete field set. Listed here so the
+# envelope check is exhaustive rather than "the ones we happened to read": an
+# extra key means the two ends disagree about the contract, and the interesting
+# case is the one where the dashboard has been talked into sending more than it
+# should.
+STRIPE_PAYLOAD_FIELDS = frozenset(
+    {
+        "event_id",
+        "event_created",
+        "customer_id",
+        "subscription_id",
+        "price_id",
+        "status",
+        "current_period_end",
+        "cancel_at_period_end",
+    }
+)
+
+# No field in that payload is a free-text one. Stripe ids are short, statuses
+# are a closed set of words, timestamps are ISO-8601 — so anything long is
+# either a bug or someone probing what this will store.
+MAX_STRIPE_FIELD_LEN = 255
+
+
+async def handle_put_stripe_subscription(request: web.Request) -> web.Response:
+    """Record a card subscription's current state. The one route with no human.
+
+    Registered only when `STRIPE_ENABLED` is set on the bot; with it unset this
+    handler is not wired up at all and the path is a plain 404. That is the same
+    kill-switch discipline as `BOT_API_ENABLED` and for the same reason — the
+    most reliable way to be sure a handler cannot run is for it never to have
+    been added to the router.
+
+    The signature that makes this trustworthy is Stripe's, and it was checked on
+    the dashboard, which is where the public ingress is. What crosses this wire
+    is the dashboard's normalised summary of an event it already verified, and
+    it arrives with the same token, mTLS and replay protection as every other
+    call. This handler validates the envelope only; what any of it *means* — a
+    replay, an out-of-order event, a status that grants premium — is decided
+    inside the bot.
+    """
+    try:
+        claims = await _authorize(request, guild_scoped=True, system=True)
+    except _Denied as denied:
+        return denied.response
+
+    deps: BotAPIDeps = request.app[DEPS_KEY]
+    guild_id = int(request.match_info["guild_id"])
+
+    try:
+        body = await request.json()
+    except (ValueError, UnicodeDecodeError):
+        return _deny(request, 400, "bad_json", actor=claims.actor_id)
+    if not isinstance(body, dict):
+        return _deny(request, 400, "bad_json", actor=claims.actor_id)
+
+    subscription = body.get("subscription")
+    if not isinstance(subscription, dict) or not subscription:
+        return _deny(request, 400, "bad_subscription", actor=claims.actor_id)
+    if set(subscription) - STRIPE_PAYLOAD_FIELDS:
+        return _deny(request, 400, "unknown_field", actor=claims.actor_id)
+    for value in subscription.values():
+        if isinstance(value, str) and len(value) > MAX_STRIPE_FIELD_LEN:
+            return _deny(request, 400, "field_too_long", actor=claims.actor_id)
+
+    try:
+        result = await deps.write_stripe_subscription(guild_id, subscription)
+    except SettingRejected as rejected:
+        return _deny(request, 400, rejected.reason, actor=claims.actor_id)
+
+    if result is None:
+        # 503 rather than 200: the dashboard turns this into a non-2xx for
+        # Stripe, which retries for up to three days. A bot restart or a
+        # tunnel blip must never cost a subscription event.
+        return _deny(request, 503, "unavailable", actor=claims.actor_id)
+    return _json(result)
+
+
 def create_app(config: BotAPIConfig, deps: BotAPIDeps) -> web.Application:
-    """Wire the routes. One PATCH, one POST, everything else a GET."""
+    """Wire the routes. One PATCH, one POST, one conditional PUT, rest GET."""
     app = web.Application(client_max_size=MAX_REQUEST_BYTES)
     app[CONFIG_KEY] = config
     app[DEPS_KEY] = deps
@@ -788,6 +935,11 @@ def create_app(config: BotAPIConfig, deps: BotAPIDeps) -> web.Application:
         "/api/v1/guilds/{guild_id}/settings", handle_update_settings
     )
     app.router.add_post("/api/v1/guilds/{guild_id}/panel", handle_post_panel)
+    if config.stripe_enabled:
+        app.router.add_put(
+            "/api/v1/guilds/{guild_id}/stripe-subscription",
+            handle_put_stripe_subscription,
+        )
 
     app.on_response_prepare.append(_harden_response)
     return app

--- a/tests/test_bot_api.py
+++ b/tests/test_bot_api.py
@@ -49,15 +49,17 @@ def run(coro):
 # -------------------------------------------------------------------
 # Fakes
 # -------------------------------------------------------------------
-def make_deps(written=None, posted=None, **overrides) -> bot_api.BotAPIDeps:
+def make_deps(written=None, posted=None, mirrored=None, **overrides) -> bot_api.BotAPIDeps:
     """A permissive set of capabilities, so each test breaks exactly one thing.
 
-    `written` and `posted` collect what reached the two mutating capabilities,
-    so a test can assert the handler passed the body through unchanged -- and,
-    more usefully, that a refused request never reached them at all.
+    `written`, `posted` and `mirrored` collect what reached the three mutating
+    capabilities, so a test can assert the handler passed the body through
+    unchanged -- and, more usefully, that a refused request never reached them
+    at all.
     """
     written = [] if written is None else written
     posted = [] if posted is None else posted
+    mirrored = [] if mirrored is None else mirrored
 
     async def is_admin(guild_id, user_id):
         return int(user_id) == ADMIN_ID
@@ -104,6 +106,10 @@ def make_deps(written=None, posted=None, **overrides) -> bot_api.BotAPIDeps:
         written.append((int(guild_id), int(actor_id), dict(changes)))
         return {"guild_id": str(guild_id), "fields": {}, "written": dict(changes)}
 
+    async def write_stripe_subscription(guild_id, payload):
+        mirrored.append((int(guild_id), dict(payload)))
+        return {"applied": True, "status": payload.get("status"), "premium": True}
+
     defaults = dict(
         is_ready=lambda: True,
         guild_present=lambda guild_id: int(guild_id) == GUILD_ID,
@@ -116,6 +122,7 @@ def make_deps(written=None, posted=None, **overrides) -> bot_api.BotAPIDeps:
         read_audit=read_audit,
         read_overview=read_overview,
         write_settings=write_settings,
+        write_stripe_subscription=write_stripe_subscription,
         post_panel=post_panel,
     )
     defaults.update(overrides)
@@ -162,6 +169,12 @@ async def patch(client, path, token=None, json=None, data=None):
     headers = {"Authorization": f"Bearer {token}"} if token else {}
     kwargs = {"data": data} if data is not None else {"json": json}
     response = await client.patch(path, headers=headers, **kwargs)
+    return response.status, await response.json()
+
+
+async def put(client, path, token=None, json=None):
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    response = await client.put(path, headers=headers, json=json)
     return response.status, await response.json()
 
 
@@ -1016,7 +1029,337 @@ class TestTheWritePath:
         assert actor == ADMIN_ID
 
 
-class TestWriteSurfaceIsExactlyTwoThings:
+class TestTheSystemRoute:
+    """The one route with no human behind it (issue #88).
+
+    Everything about this endpoint is the same as the others except who is
+    asking: mTLS, a signed token bound to this method, this path and this
+    guild, the replay guard and the write budget all still apply. Only the
+    Administrator check is skipped, because there is nobody to check — a
+    renewal a year from now is asked for by Stripe, not by a person.
+
+    Which makes the interesting tests the ones about the *seam* between human
+    and machine tokens, since that seam is the only thing standing between "no
+    Administrator check needed here" and "no Administrator check needed".
+    """
+
+    OP = "PUT /api/v1/guilds/{guild_id}/stripe-subscription"
+
+    def path(self, guild_id=GUILD_ID):
+        return f"/api/v1/guilds/{guild_id}/stripe-subscription"
+
+    def config(self, **overrides):
+        return make_config(stripe_enabled=True, **overrides)
+
+    def body(self, **overrides):
+        payload = {
+            "event_id": "evt_1",
+            "event_created": "2026-08-13T00:00:00Z",
+            "customer_id": "cus_1",
+            "subscription_id": "sub_1",
+            "price_id": "price_1",
+            "status": "active",
+            "current_period_end": "2026-09-13T00:00:00Z",
+            "cancel_at_period_end": False,
+        }
+        payload.update(overrides)
+        return {"subscription": payload}
+
+    def system_token(self, guild_id=GUILD_ID):
+        return token_for(
+            self.OP, guild_id=guild_id, actor_id=bot_api.SYSTEM_ACTOR_ID
+        )
+
+    def test_the_route_does_not_exist_with_stripe_switched_off(self):
+        """The kill switch is a 404, not a handler that declines.
+
+        Nothing has to be trusted to refuse, because nothing was wired up.
+        """
+        mirrored = []
+
+        async def scenario(client):
+            response = await client.put(
+                self.path(),
+                headers={"Authorization": f"Bearer {self.system_token()}"},
+                json=self.body(),
+            )
+            return response.status, None
+
+        status, _ = serve(scenario, deps=make_deps(mirrored=mirrored))
+        assert status == 404
+        assert mirrored == []
+
+    def test_the_system_actor_can_write(self):
+        mirrored = []
+
+        async def scenario(client):
+            return await put(client, self.path(), self.system_token(), self.body())
+
+        status, body = serve(
+            scenario, config=self.config(), deps=make_deps(mirrored=mirrored)
+        )
+        assert status == 200
+        assert body["applied"] is True
+        assert len(mirrored) == 1
+        guild_id, payload = mirrored[0]
+        assert guild_id == GUILD_ID
+        assert payload["subscription_id"] == "sub_1"
+
+    def test_no_administrator_check_is_made(self):
+        """There is no human to check, so is_admin must never be consulted.
+
+        Calling it would not merely be pointless -- it would mean the route's
+        behaviour depended on whether SYSTEM_ACTOR_ID happened to administer
+        the guild, which is a question with no meaning.
+        """
+        asked = []
+
+        async def is_admin(guild_id, user_id):
+            asked.append((guild_id, user_id))
+            return False
+
+        async def scenario(client):
+            return await put(client, self.path(), self.system_token(), self.body())
+
+        status, _body = serve(
+            scenario, config=self.config(), deps=make_deps(is_admin=is_admin)
+        )
+        assert status == 200
+        assert asked == []
+
+    def test_a_guild_the_bot_has_left_is_still_recorded(self):
+        """A renewal must land even if the bot was kicked.
+
+        Otherwise a server that re-adds the bot finds itself unsubscribed while
+        still being billed, and the only evidence is in Stripe.
+        """
+        mirrored = []
+
+        async def scenario(client):
+            return await put(
+                client,
+                self.path(OTHER_GUILD_ID),
+                self.system_token(OTHER_GUILD_ID),
+                self.body(),
+            )
+
+        status, _body = serve(
+            scenario, config=self.config(), deps=make_deps(mirrored=mirrored)
+        )
+        assert status == 200
+        assert mirrored[0][0] == OTHER_GUILD_ID
+
+    def test_a_human_token_cannot_reach_it(self):
+        """An administrator is not allowed to write subscription state by hand.
+
+        This is the same rule as "no manual verify override", applied to money:
+        the only thing that may say a server has paid is Stripe.
+        """
+        mirrored = []
+
+        async def scenario(client):
+            return await put(
+                client,
+                self.path(),
+                token_for(self.OP, actor_id=ADMIN_ID),
+                self.body(),
+            )
+
+        status, body = serve(
+            scenario, config=self.config(), deps=make_deps(mirrored=mirrored)
+        )
+        assert status == 403
+        assert body["error"] == "not_system_actor"
+        assert mirrored == []
+
+    def test_a_system_token_cannot_reach_a_human_route(self):
+        """The other half of the seam, and the one that would actually hurt.
+
+        SYSTEM_ACTOR_ID has no Administrator to check, so if it could reach the
+        settings PATCH, that route would have no authority check left at all.
+        """
+        written = []
+
+        async def scenario(client):
+            return await patch(
+                client,
+                f"/api/v1/guilds/{GUILD_ID}/settings",
+                token_for(WRITE_OP, actor_id=bot_api.SYSTEM_ACTOR_ID),
+                json={"fields": {"instructions_locale": "de"}},
+            )
+
+        status, body = serve(
+            scenario, config=self.config(), deps=make_deps(written=written)
+        )
+        assert status == 403
+        assert body["error"] == "system_actor_not_permitted"
+        assert written == []
+
+    def test_the_system_actor_is_not_a_possible_discord_id(self):
+        """Zero cannot collide with a real user, and snowflakes never reach it."""
+        assert bot_api.SYSTEM_ACTOR_ID == 0
+        assert bot_api.SYSTEM_OPERATIONS == frozenset({self.OP})
+
+    def test_a_token_for_another_guild_does_not_work(self):
+        mirrored = []
+
+        async def scenario(client):
+            return await put(
+                client,
+                self.path(),
+                self.system_token(OTHER_GUILD_ID),
+                self.body(),
+            )
+
+        status, body = serve(
+            scenario, config=self.config(), deps=make_deps(mirrored=mirrored)
+        )
+        assert status == 403
+        assert body["error"] == "wrong_guild"
+        assert mirrored == []
+
+    def test_a_token_cannot_be_used_twice(self):
+        mirrored = []
+        token = self.system_token()
+
+        async def scenario(client):
+            first = await put(client, self.path(), token, self.body())
+            second = await put(client, self.path(), token, self.body())
+            return first, second
+
+        (first_status, _), (second_status, second_body) = serve(
+            scenario, config=self.config(), deps=make_deps(mirrored=mirrored)
+        )
+        assert first_status == 200
+        assert second_status == 401
+        assert second_body["error"] == "replayed"
+        assert len(mirrored) == 1
+
+    def test_no_token_is_a_401_and_writes_nothing(self):
+        mirrored = []
+
+        async def scenario(client):
+            return await put(client, self.path(), None, self.body())
+
+        status, body = serve(
+            scenario, config=self.config(), deps=make_deps(mirrored=mirrored)
+        )
+        assert status == 401
+        assert mirrored == []
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {},
+            {"subscription": None},
+            {"subscription": {}},
+            {"subscription": "sub_1"},
+            [1, 2, 3],
+        ],
+    )
+    def test_a_malformed_body_is_refused(self, body):
+        mirrored = []
+
+        async def scenario(client):
+            return await put(client, self.path(), self.system_token(), body)
+
+        status, _body = serve(
+            scenario, config=self.config(), deps=make_deps(mirrored=mirrored)
+        )
+        assert status == 400
+        assert mirrored == []
+
+    def test_an_unknown_field_is_refused_before_the_bot_is_asked(self):
+        """An extra key means the two ends disagree about the contract.
+
+        The interesting case is the one where the dashboard has been talked
+        into sending more than it should, so this refuses rather than ignores.
+        """
+        mirrored = []
+
+        async def scenario(client):
+            return await put(
+                client,
+                self.path(),
+                self.system_token(),
+                self.body(email="someone@example.com"),
+            )
+
+        status, body = serve(
+            scenario, config=self.config(), deps=make_deps(mirrored=mirrored)
+        )
+        assert status == 400
+        assert body["error"] == "unknown_field"
+        assert mirrored == []
+
+    def test_an_absurdly_long_value_is_refused(self):
+        mirrored = []
+
+        async def scenario(client):
+            return await put(
+                client,
+                self.path(),
+                self.system_token(),
+                self.body(status="x" * 5000),
+            )
+
+        status, body = serve(
+            scenario, config=self.config(), deps=make_deps(mirrored=mirrored)
+        )
+        assert status == 400
+        assert body["error"] == "field_too_long"
+        assert mirrored == []
+
+    def test_a_writer_that_cannot_complete_is_a_503_so_stripe_retries(self):
+        """Never 200-and-drop: Stripe retries a non-2xx for up to three days,
+        which comfortably covers a bot restart or a tunnel blip."""
+
+        async def write_stripe_subscription(guild_id, payload):
+            return None
+
+        async def scenario(client):
+            return await put(client, self.path(), self.system_token(), self.body())
+
+        status, body = serve(
+            scenario,
+            config=self.config(),
+            deps=make_deps(write_stripe_subscription=write_stripe_subscription),
+        )
+        assert status == 503
+        assert body["error"] == "unavailable"
+
+    def test_a_rejected_payload_becomes_a_400(self):
+        async def write_stripe_subscription(guild_id, payload):
+            raise bot_api.SettingRejected("status", "bad_status")
+
+        async def scenario(client):
+            return await put(client, self.path(), self.system_token(), self.body())
+
+        status, body = serve(
+            scenario,
+            config=self.config(),
+            deps=make_deps(write_stripe_subscription=write_stripe_subscription),
+        )
+        assert status == 400
+        assert body["error"] == "bad_status"
+
+    def test_the_guild_comes_from_the_path_not_the_body(self):
+        """The token binds the path's guild. A body naming another is ignored."""
+        mirrored = []
+
+        async def scenario(client):
+            return await put(
+                client,
+                self.path(),
+                self.system_token(),
+                self.body(),
+            )
+
+        serve(scenario, config=self.config(), deps=make_deps(mirrored=mirrored))
+        assert mirrored[0][0] == GUILD_ID
+
+
+class TestWriteSurfaceIsExactlyThreeThings:
     """These pin how far the API can change things, and no further.
 
     Editing any of them is how you widen what the website can do to a server,
@@ -1036,7 +1379,26 @@ class TestWriteSurfaceIsExactlyTwoThings:
             ("POST", "/api/v1/guilds/{guild_id}/panel"),
         }, f"an unexpected write route appeared: {writes}"
 
-    def test_the_api_holds_one_writer_and_one_action(self):
+    def test_the_stripe_route_appears_only_when_stripe_is_switched_on(self):
+        """The kill switch is the absence of a route, not a handler that says no.
+
+        Both halves are pinned: with STRIPE_ENABLED unset the path does not
+        exist at all, and with it set exactly one route appears -- so switching
+        Stripe on cannot quietly bring anything else with it.
+        """
+        app = bot_api.create_app(make_config(stripe_enabled=True), make_deps())
+        writes = {
+            (route.method, route.resource.canonical)
+            for route in app.router.routes()
+            if route.method not in {"GET", "HEAD"}
+        }
+        assert writes == {
+            ("PATCH", "/api/v1/guilds/{guild_id}/settings"),
+            ("POST", "/api/v1/guilds/{guild_id}/panel"),
+            ("PUT", "/api/v1/guilds/{guild_id}/stripe-subscription"),
+        }, f"an unexpected write route appeared: {writes}"
+
+    def test_the_api_holds_two_writers_and_one_action(self):
         assert bot_api.deps_field_names() == frozenset(
             {
                 "is_ready",
@@ -1050,6 +1412,7 @@ class TestWriteSurfaceIsExactlyTwoThings:
                 "read_audit",
                 "read_overview",
                 "write_settings",
+                "write_stripe_subscription",
                 "post_panel",
             }
         )

--- a/tests/test_stripe.py
+++ b/tests/test_stripe.py
@@ -491,6 +491,26 @@ class TestTheWriter:
         with pytest.raises(bot.SettingRejected):
             run(bot.write_dashboard_stripe_subscription(GUILD_ID, payload))
 
+    @pytest.mark.parametrize("value", ["false", "true", 0, 1, None])
+    def test_cancel_at_period_end_is_not_coerced(self, stripe_on, value):
+        """bool("false") is True.
+
+        This is the field that decides whether the page says "renews on the
+        3rd" or "ends on the 3rd", so a normalisation slip on the other side of
+        the wire would make a wrong statement about somebody's money. Refuse it
+        rather than guess.
+        """
+        payload = make_event()
+        payload["cancel_at_period_end"] = value
+        with pytest.raises(bot.SettingRejected):
+            run(bot.write_dashboard_stripe_subscription(GUILD_ID, payload))
+
+    def test_a_real_boolean_is_accepted(self, stripe_on):
+        payload = make_event(cancel_at_period_end=True)
+        assert run(bot.write_dashboard_stripe_subscription(GUILD_ID, payload))[
+            "applied"
+        ] is True
+
     def test_a_failed_write_reports_none_so_stripe_retries(self, stripe_on, monkeypatch):
         """Never 200-and-drop. A bot restart must not cost a subscription event."""
 
@@ -608,12 +628,45 @@ class TestOrdering:
         )
         assert result["applied"] is False
 
-    def test_a_cancellation_of_a_superseded_subscription_is_ignored(self, stripe_on):
-        """The ordering guard alone would wave this through, and it is newer.
+    def test_the_ordering_guard_is_per_subscription(self, stripe_on):
+        """A stale event for one subscription must not stall another.
 
-        A server that bought a second subscription and then cancelled the first
-        would otherwise lose the one it is still paying for.
+        Scoping the guard per guild would mean the newest event from *any*
+        subscription set the bar for all of them, so a guild with two would
+        start dropping legitimate events for whichever renewed second.
         """
+        run(
+            bot.write_dashboard_stripe_subscription(
+                GUILD_ID, make_event(event_created=in_days(5))
+            )
+        )
+        result = run(
+            bot.write_dashboard_stripe_subscription(
+                GUILD_ID,
+                make_event(
+                    event_id="evt_other",
+                    subscription_id="sub_SECOND",
+                    event_created=in_days(1),
+                ),
+            )
+        )
+        assert result["applied"] is True
+
+
+class TestTwoLiveSubscriptions:
+    """A guild really can be paying twice, and the table has to hold it.
+
+    Found by probing rather than by reasoning: with one row per guild, an
+    ordinary renewal of the older subscription overwrote the newer one, and the
+    older one's later cancellation then switched premium off for a server still
+    being billed for the other. No guard on a one-row table closes that, because
+    the state it needs to hold has two subscriptions in it.
+
+    Note this is exactly the case the issue's Double billing section says to
+    expect — so the bug fired precisely where it was most likely to be hit.
+    """
+
+    def both(self):
         run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))
         run(
             bot.write_dashboard_stripe_subscription(
@@ -626,7 +679,40 @@ class TestOrdering:
                 ),
             )
         )
-        result = run(
+
+    def test_both_are_stored(self, stripe_on):
+        self.both()
+        with bot.session_scope() as session:
+            ids = {
+                row.stripe_subscription_id
+                for row in session.query(bot.StripeSubscription).all()
+            }
+        assert ids == {SUBSCRIPTION, "sub_SECOND"}
+
+    def test_a_renewal_of_the_older_one_does_not_overwrite_the_newer(self, stripe_on):
+        self.both()
+        run(
+            bot.write_dashboard_stripe_subscription(
+                GUILD_ID,
+                make_event(event_id="evt_renew_first", event_created=in_days(2)),
+            )
+        )
+        with bot.session_scope() as session:
+            row = (
+                session.query(bot.StripeSubscription)
+                .filter_by(stripe_subscription_id="sub_SECOND")
+                .one()
+            )
+            assert row.price_id == PRICE_YEARLY
+
+    def test_cancelling_one_leaves_premium_on_for_the_other(self, stripe_on):
+        """The bug, stated as the behaviour it should have had.
+
+        Cancel the first subscription; the second is still being billed, so
+        premium stays on.
+        """
+        self.both()
+        run(
             bot.write_dashboard_stripe_subscription(
                 GUILD_ID,
                 make_event(
@@ -634,32 +720,133 @@ class TestOrdering:
                     subscription_id=SUBSCRIPTION,
                     status="canceled",
                     current_period_end=in_days(-1),
-                    event_created=in_days(2),
+                    event_created=in_days(3),
                 ),
             )
         )
-        assert result["applied"] is False
-        assert result["reason"] == "superseded_subscription"
+        bot.stripe_status_cache.clear()
         assert bot.stripe_active(GUILD_ID) is True
 
-    def test_a_new_paid_subscription_does_take_over(self, stripe_on):
+    def test_cancelling_both_does_end_premium(self, stripe_on):
+        self.both()
+        for event_id, subscription_id in (
+            ("evt_c1", SUBSCRIPTION),
+            ("evt_c2", "sub_SECOND"),
+        ):
+            run(
+                bot.write_dashboard_stripe_subscription(
+                    GUILD_ID,
+                    make_event(
+                        event_id=event_id,
+                        subscription_id=subscription_id,
+                        status="canceled",
+                        current_period_end=in_days(-1),
+                        event_created=in_days(3),
+                    ),
+                )
+            )
+        bot.stripe_status_cache.clear()
+        assert bot.stripe_active(GUILD_ID) is False
+
+    def test_double_billing_is_visible_to_the_website(self, enforced, stripe_on):
+        """A row count, not a special case -- which is only possible because
+        the table keys by subscription rather than by guild."""
+        make_server()
+        self.both()
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+        assert payload["stripe"]["active_count"] == 2
+        assert payload["stripe"]["active"] is True
+
+    def test_one_subscription_is_not_double_billing(self, enforced, stripe_on):
+        make_server()
         run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))
-        result = run(
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+        assert payload["stripe"]["active_count"] == 1
+
+    def test_the_page_describes_the_longest_running_paid_subscription(
+        self, enforced, stripe_on
+    ):
+        make_server()
+        run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))
+        run(
             bot.write_dashboard_stripe_subscription(
                 GUILD_ID,
                 make_event(
                     event_id="evt_second",
                     subscription_id="sub_SECOND",
                     price_id=PRICE_YEARLY,
-                    event_created=in_days(1),
+                    current_period_end=in_days(300),
                 ),
             )
         )
-        assert result["applied"] is True
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+        assert payload["stripe"]["price_id"] == PRICE_YEARLY
+
+    def test_a_subscription_cannot_be_moved_between_guilds(self, stripe_on):
+        """One Stripe subscription belongs to one guild. Anything else is an
+        anomaly needing a human, and is refused rather than applied."""
+        run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))
+        result = run(
+            bot.write_dashboard_stripe_subscription(
+                OTHER_GUILD_ID,
+                make_event(event_id="evt_steal", event_created=in_days(1)),
+            )
+        )
+        assert result["applied"] is False
+        assert result["reason"] == "guild_mismatch"
+        assert bot.stripe_active(OTHER_GUILD_ID) is False
+
+
+class TestTheEventLedgerIsPruned:
+    """A-24 again: a table that only ever grows is a table nobody pruned.
+
+    The sweep rides on the insert, so the only thing that can add a row is also
+    the thing that removes them. There is no scheduler to forget to run.
+    """
+
+    def test_events_past_the_retention_window_are_forgotten(self, stripe_on):
         with bot.session_scope() as session:
-            row = session.query(bot.StripeSubscription).one()
-            assert row.stripe_subscription_id == "sub_SECOND"
-            assert row.price_id == PRICE_YEARLY
+            session.add(
+                bot.StripeEvent(
+                    event_id="evt_ancient",
+                    received_at=datetime.now(timezone.utc) - timedelta(days=400),
+                )
+            )
+        run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))
+        with bot.session_scope() as session:
+            remaining = {row.event_id for row in session.query(bot.StripeEvent).all()}
+        assert remaining == {"evt_1"}
+
+    def test_events_inside_the_retry_window_are_kept(self, stripe_on):
+        """Stripe retries for three days. Forgetting an id inside that window
+        would make a redelivery look like a new event and apply it twice."""
+        with bot.session_scope() as session:
+            session.add(
+                bot.StripeEvent(
+                    event_id="evt_yesterday",
+                    received_at=datetime.now(timezone.utc) - timedelta(days=1),
+                )
+            )
+        run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))
+        with bot.session_scope() as session:
+            remaining = {row.event_id for row in session.query(bot.StripeEvent).all()}
+        assert remaining == {"evt_yesterday", "evt_1"}
+
+    def test_a_failed_prune_swallows_its_own_error(self):
+        """Losing a subscription event because a housekeeping DELETE went wrong
+        would be a far worse trade than a table that stays large for a day.
+
+        Exercises the real failure — the DELETE itself raising — rather than
+        the whole function being replaced, which would step over the guard
+        being tested.
+        """
+
+        class SabotagedSession:
+            def query(self, *args, **kwargs):
+                raise RuntimeError("delete failed")
+
+        # Must not raise.
+        bot._prune_stripe_events(SabotagedSession(), datetime.now(timezone.utc))
 
 
 class TestTheUnknownGuildTrap:

--- a/tests/test_stripe.py
+++ b/tests/test_stripe.py
@@ -1,0 +1,778 @@
+"""Unit tests for card subscriptions alongside Discord ones (issue #88, step 1).
+
+Step 1 is deliberately inert: with STRIPE_ENABLED unset nothing here can be
+bought, no route exists, and the premium gate behaves exactly as it did before.
+What these tests pin is that the plumbing under that switch is correct *before*
+anyone can pay through it, because the first time it runs for real there will
+be money on the other end of it.
+
+The themes, in the order they bite:
+
+- the gate is an OR over two independent sources, and neither may see or
+  corrupt the other's cached answer
+- the two sources fail in opposite directions on purpose, and the Stripe one
+  failing open would hand premium to every server in the bot
+- a webhook is untrusted *ordering*, not just untrusted content: Stripe retries
+  for three days and promises nothing about sequence
+- a payment must never cost a server its grandfathered features, which is what
+  writing a `servers` row for an unknown guild would silently do
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+import bot
+
+GUILD_ID = "987654321"
+OTHER_GUILD_ID = "123123123"
+OWNER_ID = "77"
+SKU_ID = 555000111
+
+CUSTOMER = "cus_TESTCUSTOMER"
+SUBSCRIPTION = "sub_TESTSUBSCRIPTION"
+PRICE_MONTHLY = "price_1U3q9eJZiVMQTim6LtcYV4x6"
+PRICE_YEARLY = "price_1U3q9eJZiVMQTim6AUOLZ59e"
+
+
+def run(coro):
+    """Run an async bot helper from a sync test (no pytest-asyncio needed)."""
+    return asyncio.run(coro)
+
+
+def in_days(days: int) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(days=days)
+
+
+def make_event(
+    *,
+    event_id="evt_1",
+    event_created=None,
+    subscription_id=SUBSCRIPTION,
+    customer_id=CUSTOMER,
+    price_id=PRICE_MONTHLY,
+    status="active",
+    current_period_end=None,
+    cancel_at_period_end=False,
+) -> dict:
+    """One normalised payload, exactly as the dashboard forwards it."""
+    return {
+        "event_id": event_id,
+        "event_created": (event_created or datetime.now(timezone.utc)).isoformat(),
+        "customer_id": customer_id,
+        "subscription_id": subscription_id,
+        "price_id": price_id,
+        "status": status,
+        "current_period_end": (current_period_end or in_days(30)).isoformat(),
+        "cancel_at_period_end": cancel_at_period_end,
+    }
+
+
+def store_subscription(
+    *,
+    server_id=GUILD_ID,
+    status="active",
+    price_id=PRICE_MONTHLY,
+    subscription_id=SUBSCRIPTION,
+    current_period_end=None,
+    cancel_at_period_end=False,
+    last_event_created=None,
+):
+    """Write a mirrored row directly, the way step 1 is meant to be exercised."""
+    with bot.session_scope() as session:
+        session.add(
+            bot.StripeSubscription(
+                server_id=server_id,
+                stripe_customer_id=CUSTOMER,
+                stripe_subscription_id=subscription_id,
+                price_id=price_id,
+                status=status,
+                current_period_end=current_period_end or in_days(30),
+                cancel_at_period_end=cancel_at_period_end,
+                last_event_created=last_event_created or datetime.now(timezone.utc),
+            )
+        )
+
+
+def make_server(server_id=GUILD_ID, row_id=100, **overrides):
+    fields = dict(
+        id=row_id,
+        server_id=server_id,
+        owner_id=OWNER_ID,
+        role_id="1",
+        instructions_locale="en-US",
+    )
+    fields.update(overrides)
+    with bot.session_scope() as session:
+        session.add(bot.Server(**fields))
+
+
+def make_interaction(entitlements=(), guild_id=GUILD_ID):
+    return SimpleNamespace(
+        guild_id=int(guild_id) if guild_id is not None else None,
+        entitlements=list(entitlements),
+        locale="en-US",
+        guild=SimpleNamespace(id=int(guild_id or 0), name="Test Server"),
+        user=SimpleNamespace(id=1),
+    )
+
+
+class FakeEntitlement:
+    """Enough of discord.Entitlement for the resolution helpers."""
+
+    def __init__(self, sku_id=SKU_ID, expired=False, deleted=False):
+        self.sku_id = sku_id
+        self.deleted = deleted
+        self._expired = expired
+
+    def is_expired(self) -> bool:
+        return self._expired
+
+
+def fake_entitlements_api(*items):
+    def _entitlements(**kwargs):
+        async def generate():
+            for item in items:
+                yield item
+
+        return generate()
+
+    return _entitlements
+
+
+@pytest.fixture(autouse=True)
+def clean_db():
+    def wipe():
+        with bot.session_scope() as session:
+            session.query(bot.StripeSubscription).delete()
+            session.query(bot.StripeEvent).delete()
+            session.query(bot.Server).delete()
+            session.query(bot.DashboardAudit).delete()
+            session.query(bot.PremiumGrandfatherLine).delete()
+
+    wipe()
+    bot.stripe_status_cache.clear()
+    bot.premium_status_cache.clear()
+    yield
+    wipe()
+    bot.stripe_status_cache.clear()
+    bot.premium_status_cache.clear()
+
+
+@pytest.fixture
+def stripe_on(monkeypatch):
+    """Switch the feature on, as STRIPE_ENABLED=1 would."""
+    monkeypatch.setattr(bot, "STRIPE_ENABLED", True)
+    bot.stripe_status_cache.clear()
+
+
+@pytest.fixture
+def enforced(monkeypatch):
+    """Turn the premium tier on, as PREMIUM_SKU_ID would."""
+    monkeypatch.setattr(bot, "PREMIUM_SKU_ID", SKU_ID)
+    monkeypatch.setattr(bot, "PREMIUM_ENFORCED", True)
+    monkeypatch.setattr(bot.bot, "entitlements", fake_entitlements_api())
+    bot.premium_status_cache.clear()
+
+
+# ---------------------------------------------------------------
+# The kill switch
+# ---------------------------------------------------------------
+class TestKillSwitch:
+    """With STRIPE_ENABLED unset this whole feature must be as if absent.
+
+    That is what lets step 1 ship to production ahead of a Stripe account
+    existing, which is the entire point of doing it first.
+    """
+
+    def test_a_stored_row_grants_nothing_while_the_switch_is_off(self):
+        store_subscription()
+        assert bot.stripe_active(GUILD_ID) is False
+
+    def test_the_table_is_not_even_queried(self, monkeypatch):
+        """Not merely False -- no query at all.
+
+        This is what keeps resolve_premium_flags_from_interaction free of I/O
+        while the feature is dormant, and a slash command is the hottest path
+        in the bot.
+        """
+
+        def boom():
+            raise AssertionError("the table must not be read with Stripe off")
+
+        monkeypatch.setattr(bot, "session_scope", boom)
+        assert bot.stripe_active(GUILD_ID) is False
+
+    def test_the_settings_payload_reports_it_off(self, enforced):
+        make_server()
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+        assert payload["stripe"]["enabled"] is False
+        assert payload["stripe"]["active"] is False
+        assert payload["stripe"]["status"] is None
+
+    def test_a_stored_row_is_invisible_to_the_page_while_off(self, enforced):
+        make_server()
+        store_subscription()
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+        assert payload["stripe"]["enabled"] is False
+        assert payload["stripe"]["active"] is False
+
+
+# ---------------------------------------------------------------
+# What counts as paid
+# ---------------------------------------------------------------
+class TestWhatCountsAsPaid:
+    @pytest.mark.parametrize(
+        "status, expected",
+        [
+            ("active", True),
+            ("trialing", True),
+            # Stripe is still retrying the card. A late charge is not a
+            # cancellation, and cutting a customer off on the first failed
+            # retry is the mistake the entitlement fail-open exists to avoid.
+            ("past_due", True),
+            # Stripe has given up retrying.
+            ("unpaid", False),
+            ("incomplete", False),
+            ("incomplete_expired", False),
+        ],
+    )
+    def test_status_decides(self, stripe_on, status, expected):
+        store_subscription(status=status)
+        assert bot.stripe_active(GUILD_ID) is expected
+
+    def test_cancelled_keeps_premium_until_the_paid_period_runs_out(self, stripe_on):
+        """The Discord side already behaves this way; the two must not disagree.
+
+        A cancellation leaves the subscription live until the period the
+        customer paid for actually ends. Only a refund takes it away sooner,
+        and Stripe reports that as a status change of its own.
+        """
+        store_subscription(
+            status="canceled", cancel_at_period_end=True, current_period_end=in_days(9)
+        )
+        assert bot.stripe_active(GUILD_ID) is True
+
+    def test_cancelled_stops_once_the_period_has_run_out(self, stripe_on):
+        store_subscription(status="canceled", current_period_end=in_days(-1))
+        assert bot.stripe_active(GUILD_ID) is False
+
+    def test_even_an_active_status_expires_with_its_period(self, stripe_on):
+        """Both conditions are required, not either.
+
+        A row left `active` because a final webhook never arrived must not
+        grant premium forever.
+        """
+        store_subscription(status="active", current_period_end=in_days(-1))
+        assert bot.stripe_active(GUILD_ID) is False
+
+    def test_no_row_at_all_is_not_subscribed(self, stripe_on):
+        assert bot.stripe_active(GUILD_ID) is False
+
+
+# ---------------------------------------------------------------
+# The failure rule
+# ---------------------------------------------------------------
+class TestTheFailureRule:
+    """The Stripe read fails CLOSED where the Discord read fails OPEN.
+
+    Read the docstring on stripe_active before changing anything here. The
+    asymmetry looks like an inconsistency and is not one: a server that has
+    never had a card subscription cannot acquire one during a database blip, so
+    failing open would hand premium to every server in the bot the moment
+    Postgres hiccups.
+    """
+
+    def test_a_failed_read_with_no_history_is_false(self, stripe_on, monkeypatch):
+        def boom():
+            raise RuntimeError("database is down")
+
+        monkeypatch.setattr(bot, "session_scope", boom)
+        assert bot.stripe_active(GUILD_ID) is False
+
+    def test_a_failed_read_falls_back_to_last_known(self, stripe_on, monkeypatch):
+        """A paying server is protected exactly as the Discord path protects one."""
+        store_subscription()
+        assert bot.stripe_active(GUILD_ID) is True  # seeds last-known
+        bot.stripe_status_cache.invalidate(GUILD_ID)
+
+        def boom():
+            raise RuntimeError("database is down")
+
+        monkeypatch.setattr(bot, "session_scope", boom)
+        assert bot.stripe_active(GUILD_ID) is True
+
+    def test_the_guess_never_becomes_the_fallback_it_came_from(
+        self, stripe_on, monkeypatch
+    ):
+        """A False guessed during an outage must not be recorded as last-known.
+
+        If it were, a server that later pays would still be answered from a
+        stale negative after its own webhook landed.
+        """
+
+        def boom():
+            raise RuntimeError("database is down")
+
+        monkeypatch.setattr(bot, "session_scope", boom)
+        assert bot.stripe_active(GUILD_ID) is False
+        assert bot.stripe_status_cache.get_last_known(GUILD_ID) is None
+
+
+# ---------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------
+class TestTheGate:
+    def test_premium_via_stripe_only(self, enforced, stripe_on):
+        make_server()
+        store_subscription()
+        flags = run(bot.resolve_premium_flags(GUILD_ID))
+        assert flags.premium is True
+        assert flags.allows(bot.FEATURE_BRANDED_PANEL)
+
+    def test_premium_via_discord_only(self, enforced, stripe_on, monkeypatch):
+        make_server()
+        monkeypatch.setattr(
+            bot.bot, "entitlements", fake_entitlements_api(FakeEntitlement())
+        )
+        flags = run(bot.resolve_premium_flags(GUILD_ID))
+        assert flags.premium is True
+
+    def test_premium_via_neither(self, enforced, stripe_on):
+        make_server(row_id=5000)
+        bot.capture_grandfather_line()
+        flags = run(bot.resolve_premium_flags(GUILD_ID))
+        assert flags.premium is False
+        assert flags.allows(bot.FEATURE_BRANDED_PANEL) is False
+
+    def test_premium_via_both(self, enforced, stripe_on, monkeypatch):
+        """Being double-billed must not also break something.
+
+        Detection and the warning belong to the website; the gate's only job is
+        to keep saying yes.
+        """
+        make_server()
+        store_subscription()
+        monkeypatch.setattr(
+            bot.bot, "entitlements", fake_entitlements_api(FakeEntitlement())
+        )
+        flags = run(bot.resolve_premium_flags(GUILD_ID))
+        assert flags.premium is True
+
+    def test_an_interaction_grants_premium_from_a_stripe_row(self, enforced, stripe_on):
+        make_server()
+        store_subscription()
+        flags = bot.resolve_premium_flags_from_interaction(make_interaction())
+        assert flags.premium is True
+
+    def test_a_stripe_row_for_another_guild_grants_nothing(self, enforced, stripe_on):
+        make_server()
+        store_subscription(server_id=OTHER_GUILD_ID, subscription_id="sub_OTHER")
+        flags = run(bot.resolve_premium_flags(GUILD_ID))
+        assert flags.premium is False
+
+    def test_the_two_caches_are_separate_instances(self):
+        """Sharing one would let either source corrupt the other's fallback.
+
+        Their fallbacks point in opposite directions, so a collision would not
+        merely be untidy -- it would silently invert one of them.
+        """
+        assert bot.stripe_status_cache is not bot.premium_status_cache
+
+
+class TestTheShortCircuit:
+    """premium_from_interaction is free, and this must keep it nearly so."""
+
+    def test_an_entitled_interaction_never_reads_the_table(
+        self, enforced, stripe_on, monkeypatch
+    ):
+        """Assert it, or the short-circuit regresses and nothing notices.
+
+        Losing it puts a database query behind every slash command in the bot,
+        which is invisible in tests and expensive in production.
+        """
+        reads = []
+        real_scope = bot.session_scope
+
+        def counting_scope():
+            reads.append(1)
+            return real_scope()
+
+        monkeypatch.setattr(bot, "session_scope", counting_scope)
+        flags = bot.resolve_premium_flags_from_interaction(
+            make_interaction([FakeEntitlement()])
+        )
+        assert flags.premium is True
+        assert reads == [], "an entitled interaction must not touch the database"
+
+    def test_an_unentitled_interaction_pays_one_cached_lookup(
+        self, enforced, stripe_on, monkeypatch
+    ):
+        store_subscription()
+        reads = []
+        real_scope = bot.session_scope
+
+        def counting_scope():
+            reads.append(1)
+            return real_scope()
+
+        monkeypatch.setattr(bot, "session_scope", counting_scope)
+        assert bot.resolve_premium_flags_from_interaction(make_interaction()).premium
+        first = len(reads)
+        assert bot.resolve_premium_flags_from_interaction(make_interaction()).premium
+        assert len(reads) == first, "the second interaction must be served from cache"
+
+
+# ---------------------------------------------------------------
+# The writer
+# ---------------------------------------------------------------
+class TestTheWriter:
+    def test_a_new_subscription_is_stored_and_grants_premium(self, stripe_on):
+        result = run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))
+        assert result["applied"] is True
+        assert result["premium"] is True
+        assert bot.stripe_active(GUILD_ID) is True
+
+    def test_the_write_invalidates_the_cache_immediately(self, stripe_on):
+        """A purchase must not wait out a TTL to take effect.
+
+        This is the property that justifies the write landing in the bot rather
+        than the dashboard writing the database itself: the row and the cache
+        are the same process.
+        """
+        assert bot.stripe_active(GUILD_ID) is False  # caches the negative
+        run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))
+        assert bot.stripe_active(GUILD_ID) is True
+
+    def test_a_cancellation_is_applied(self, stripe_on):
+        run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))
+        result = run(
+            bot.write_dashboard_stripe_subscription(
+                GUILD_ID,
+                make_event(
+                    event_id="evt_2",
+                    status="canceled",
+                    cancel_at_period_end=True,
+                    current_period_end=in_days(-1),
+                ),
+            )
+        )
+        assert result["applied"] is True
+        assert bot.stripe_active(GUILD_ID) is False
+
+    def test_the_audit_row_names_a_machine_not_a_person(self, stripe_on):
+        run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))
+        with bot.session_scope() as session:
+            rows = session.query(bot.DashboardAudit).all()
+            actors = [row.actor_id for row in rows]
+            fields = [row.field for row in rows]
+        assert actors == [bot.STRIPE_AUDIT_ACTOR]
+        assert fields == ["stripe_subscription"]
+        assert not bot.STRIPE_AUDIT_ACTOR.isdigit(), (
+            "the Stripe actor must never be mistakable for a Discord id"
+        )
+
+    @pytest.mark.parametrize(
+        "field",
+        ["event_id", "subscription_id", "customer_id", "price_id", "status"],
+    )
+    def test_a_missing_required_field_is_refused(self, stripe_on, field):
+        payload = make_event()
+        payload[field] = ""
+        with pytest.raises(bot.SettingRejected):
+            run(bot.write_dashboard_stripe_subscription(GUILD_ID, payload))
+
+    @pytest.mark.parametrize("field", ["current_period_end", "event_created"])
+    def test_an_unparseable_timestamp_is_refused(self, stripe_on, field):
+        payload = make_event()
+        payload[field] = "not a date"
+        with pytest.raises(bot.SettingRejected):
+            run(bot.write_dashboard_stripe_subscription(GUILD_ID, payload))
+
+    def test_a_failed_write_reports_none_so_stripe_retries(self, stripe_on, monkeypatch):
+        """Never 200-and-drop. A bot restart must not cost a subscription event."""
+
+        def boom():
+            raise RuntimeError("database is down")
+
+        monkeypatch.setattr(bot, "session_scope", boom)
+        assert run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event())) is None
+
+
+class TestIdempotency:
+    def test_the_same_event_twice_writes_once(self, stripe_on):
+        first = run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))
+        second = run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))
+        assert first["applied"] is True
+        assert second["applied"] is False
+        assert second["reason"] == "duplicate_event"
+        with bot.session_scope() as session:
+            assert session.query(bot.DashboardAudit).count() == 1
+            assert session.query(bot.StripeEvent).count() == 1
+
+    def test_a_replayed_cancellation_does_not_re_apply(self, stripe_on):
+        run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))
+        cancel = make_event(
+            event_id="evt_cancel", status="canceled", current_period_end=in_days(-1)
+        )
+        run(bot.write_dashboard_stripe_subscription(GUILD_ID, cancel))
+        # A later renewal, then Stripe retries the cancellation it already sent.
+        run(
+            bot.write_dashboard_stripe_subscription(
+                GUILD_ID,
+                make_event(event_id="evt_renew", event_created=in_days(1)),
+            )
+        )
+        assert bot.stripe_active(GUILD_ID) is True
+        assert (
+            run(bot.write_dashboard_stripe_subscription(GUILD_ID, cancel))["applied"]
+            is False
+        )
+        assert bot.stripe_active(GUILD_ID) is True
+
+    def test_a_failed_apply_does_not_mark_the_event_processed(
+        self, stripe_on, monkeypatch
+    ):
+        """The ledger entry and the change are one transaction, or neither.
+
+        Recording an event that was never applied would lose it permanently:
+        Stripe's retry would be answered "already processed" and the change
+        would never land.
+        """
+        real_scope = bot.session_scope
+
+        class Sabotage(RuntimeError):
+            pass
+
+        def fail_after_the_ledger(*args, **kwargs):
+            raise Sabotage("apply failed")
+
+        monkeypatch.setattr(bot, "_record_dashboard_audit", fail_after_the_ledger)
+        assert run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event())) is None
+        monkeypatch.undo()
+
+        with real_scope() as session:
+            assert session.query(bot.StripeEvent).count() == 0
+            assert session.query(bot.StripeSubscription).count() == 0
+        # And the retry now lands.
+        assert run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))[
+            "applied"
+        ] is True
+
+
+class TestOrdering:
+    """Stripe does not promise events arrive in order."""
+
+    def test_an_older_event_is_recorded_but_not_applied(self, stripe_on):
+        run(
+            bot.write_dashboard_stripe_subscription(
+                GUILD_ID,
+                make_event(
+                    event_id="evt_cancel",
+                    event_created=in_days(0),
+                    status="canceled",
+                    current_period_end=in_days(-1),
+                ),
+            )
+        )
+        stale = make_event(
+            event_id="evt_stale", event_created=in_days(-1), status="active"
+        )
+        result = run(bot.write_dashboard_stripe_subscription(GUILD_ID, stale))
+
+        assert result["applied"] is False
+        assert result["reason"] == "out_of_order"
+        # The event is still recorded, so a retry of it is cheap.
+        with bot.session_scope() as session:
+            assert session.query(bot.StripeEvent).count() == 2
+        # And the cancellation stands: a delayed `updated` must never resurrect
+        # premium for a server that cancelled.
+        assert bot.stripe_active(GUILD_ID) is False
+
+    def test_an_event_of_identical_age_is_not_applied(self, stripe_on):
+        moment = datetime.now(timezone.utc)
+        run(
+            bot.write_dashboard_stripe_subscription(
+                GUILD_ID, make_event(event_id="evt_a", event_created=moment)
+            )
+        )
+        result = run(
+            bot.write_dashboard_stripe_subscription(
+                GUILD_ID,
+                make_event(
+                    event_id="evt_b", event_created=moment, status="canceled"
+                ),
+            )
+        )
+        assert result["applied"] is False
+
+    def test_a_cancellation_of_a_superseded_subscription_is_ignored(self, stripe_on):
+        """The ordering guard alone would wave this through, and it is newer.
+
+        A server that bought a second subscription and then cancelled the first
+        would otherwise lose the one it is still paying for.
+        """
+        run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))
+        run(
+            bot.write_dashboard_stripe_subscription(
+                GUILD_ID,
+                make_event(
+                    event_id="evt_second",
+                    subscription_id="sub_SECOND",
+                    price_id=PRICE_YEARLY,
+                    event_created=in_days(1),
+                ),
+            )
+        )
+        result = run(
+            bot.write_dashboard_stripe_subscription(
+                GUILD_ID,
+                make_event(
+                    event_id="evt_cancel_first",
+                    subscription_id=SUBSCRIPTION,
+                    status="canceled",
+                    current_period_end=in_days(-1),
+                    event_created=in_days(2),
+                ),
+            )
+        )
+        assert result["applied"] is False
+        assert result["reason"] == "superseded_subscription"
+        assert bot.stripe_active(GUILD_ID) is True
+
+    def test_a_new_paid_subscription_does_take_over(self, stripe_on):
+        run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))
+        result = run(
+            bot.write_dashboard_stripe_subscription(
+                GUILD_ID,
+                make_event(
+                    event_id="evt_second",
+                    subscription_id="sub_SECOND",
+                    price_id=PRICE_YEARLY,
+                    event_created=in_days(1),
+                ),
+            )
+        )
+        assert result["applied"] is True
+        with bot.session_scope() as session:
+            row = session.query(bot.StripeSubscription).one()
+            assert row.stripe_subscription_id == "sub_SECOND"
+            assert row.price_id == PRICE_YEARLY
+
+
+class TestTheUnknownGuildTrap:
+    """A payment must never cost a server its grandfathered features.
+
+    Inserting a `servers` row for a guild that has none would mint a fresh
+    `servers.id` above the captured grandfather line -- silently and
+    permanently withdrawing features the server was promised for free, as a
+    side effect of paying us. This is the subtlest failure in the whole issue
+    and it gets its own class.
+    """
+
+    def test_a_webhook_for_an_unknown_guild_creates_no_server_row(self, stripe_on):
+        result = run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))
+        assert result["applied"] is True
+        with bot.session_scope() as session:
+            assert session.query(bot.Server).count() == 0
+            assert session.query(bot.StripeSubscription).count() == 1
+
+    def test_it_does_not_push_a_grandfathered_server_over_the_line(self, stripe_on):
+        """The full scenario, end to end, because the unit above is not enough.
+
+        A grandfathered server pays by card. Its grandfathered status must be
+        exactly what it was before the payment.
+        """
+        make_server(row_id=100)
+        with bot.session_scope() as session:
+            session.add(bot.PremiumGrandfatherLine(id=1, max_server_id=820))
+        assert bot.is_grandfathered(GUILD_ID) is True
+
+        run(bot.write_dashboard_stripe_subscription(GUILD_ID, make_event()))
+
+        assert bot.is_grandfathered(GUILD_ID) is True
+        with bot.session_scope() as session:
+            assert session.query(bot.Server).count() == 1
+            assert session.query(bot.Server).one().id == 100
+
+    def test_grandfathering_never_consults_a_stripe_row(self, stripe_on):
+        """is_grandfathered is about when a server arrived, not what it pays."""
+        make_server(row_id=5000)
+        with bot.session_scope() as session:
+            session.add(bot.PremiumGrandfatherLine(id=1, max_server_id=820))
+        store_subscription()
+        assert bot.is_grandfathered(GUILD_ID) is False
+
+
+# ---------------------------------------------------------------
+# What the website is told
+# ---------------------------------------------------------------
+class TestTheSettingsPayload:
+    def test_it_describes_an_active_subscription(self, enforced, stripe_on):
+        make_server()
+        store_subscription(price_id=PRICE_YEARLY)
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+
+        assert payload["stripe"]["enabled"] is True
+        assert payload["stripe"]["active"] is True
+        assert payload["stripe"]["status"] == "active"
+        assert payload["stripe"]["price_id"] == PRICE_YEARLY
+        assert payload["stripe"]["current_period_end"] is not None
+        assert payload["stripe"]["cancel_at_period_end"] is False
+
+    def test_premium_premium_stays_the_single_answer(self, enforced, stripe_on):
+        """The stripe block explains why; it is not a second gate to OR."""
+        make_server()
+        store_subscription()
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+        assert payload["premium"]["premium"] is True
+
+    def test_past_due_is_reported_honestly_and_still_premium(self, enforced, stripe_on):
+        """The page needs both halves to write "premium is still on while
+        Stripe retries" -- a boolean alone could not say it."""
+        make_server()
+        store_subscription(status="past_due")
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+        assert payload["stripe"]["status"] == "past_due"
+        assert payload["stripe"]["active"] is True
+        assert payload["premium"]["premium"] is True
+
+    def test_a_lapsed_subscription_still_reports_its_status(self, enforced, stripe_on):
+        """The row survives so the page can say "ended on the 3rd"."""
+        make_server()
+        store_subscription(status="canceled", current_period_end=in_days(-5))
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+        assert payload["stripe"]["status"] == "canceled"
+        assert payload["stripe"]["active"] is False
+
+    def test_no_customer_id_ever_crosses_the_wire(self, enforced, stripe_on):
+        """The website has no use for it, and shipping it is how it ends up in
+        a log on the internet-facing box."""
+        make_server()
+        store_subscription()
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+        assert CUSTOMER not in repr(payload)
+
+    def test_an_unreadable_table_refuses_the_whole_read(
+        self, enforced, stripe_on, monkeypatch
+    ):
+        """Never "not subscribed" on a failed read.
+
+        "Not subscribed" next to a Buy button is how a paying customer is sold
+        a second subscription. The API turns None into a 503 and the page
+        apologises instead.
+        """
+        make_server()
+        real_scope = bot.session_scope
+        calls = []
+
+        def failing_scope():
+            calls.append(1)
+            if len(calls) > 2:
+                raise RuntimeError("database is down")
+            return real_scope()
+
+        monkeypatch.setattr(bot, "session_scope", failing_scope)
+        assert run(bot.read_dashboard_settings(GUILD_ID)) is None


### PR DESCRIPTION
Step 1 of #88: the plumbing for card subscriptions, with nothing able to be bought through it.

With `STRIPE_ENABLED` unset the bot never reads the new table, never registers the route that writes it, and reports `stripe.enabled: false` to the dashboard. This ships to production with behaviour identical to before and gets switched on separately, like `PREMIUM_SKU_ID` and `BOT_API_ENABLED` before it. It is also the only step of the five that touches the gate every verification passes through, which is why it is first and why it cannot charge anyone.

## What changes

**Two tables.** `StripeSubscription` mirrors Stripe's state so the gate stays a database read rather than an API call, and `StripeEvent` is the ledger that makes applying a webhook idempotent. Separate tables for the settled reason — `create_all()` adds tables but never columns. Stripe's status string is stored verbatim rather than as a boolean, because a boolean throws away the difference between "cancelled" and "we could not charge the card yesterday", which is the difference support questions are about.

**The gate becomes an OR.** `stripe_active()` reads through its own `PremiumStatusCache` instance, and the Discord answer short-circuits it — an entitled server never touches the table. `past_due` grants premium (Stripe is still retrying; a late charge is not a cancellation), and `canceled` keeps premium until the paid period runs out, matching what the Discord side already does. The two payment paths must not disagree about what cancelling means.

**One new route,** `PUT /api/v1/guilds/{guild_id}/stripe-subscription`, registered only when the switch is on.

## The parts worth reviewing carefully

**The two sources fail in opposite directions, deliberately.** The Discord lookup fails *open*, because a Discord outage must not switch off a paying customer. The Stripe read falls back to last-known and to `False` when there has never been one — a server that has never had a card subscription cannot acquire one during a database blip, and failing open there would hand premium to every server in the bot the moment Postgres hiccups. Servers that do pay by card keep the same last-known protection the Discord path gives. This looks like an inconsistency and is not one; the docstring and a test both say so.

**The first operation with no human actor.** A renewal a year from now is asked for by Stripe, not by a person, and taking the actor from the webhook body would mean authority coming from a request body — the one thing this design forbids everywhere else. So it names `api_tokens.SYSTEM_ACTOR_ID` (0, not a possible snowflake) against a `SYSTEM_OPERATIONS` allowlist. Everything else about the route is unchanged: mTLS, a token bound to this method, path and guild, the replay guard, the write budget. Only the Administrator check is skipped, because there is nobody to check.

The seam is enforced in both directions, and the direction that matters is the second one: a system token must not reach the settings `PATCH`, whose only authority check is precisely the one this actor has no answer for. Both directions are pinned by tests.

**Three guards on the write.** Idempotency — Stripe retries for three days, so the event id is recorded in the same transaction as the change it authorises. Ordering, per subscription — an event no newer than the state on file for *that subscription* is recorded and dropped, because a delayed `subscription.updated` overwriting a newer `subscription.deleted` would silently restore premium to a server that cancelled. And ownership: one Stripe subscription belongs to one guild, and an event naming a different one is an anomaly needing a human rather than a retry.

**The table keys by subscription, not by guild** — the one place this departs from the issue's schema, and it is there because a guild really can hold two live subscriptions at once. See the adversarial-pass comment below for the premium-loss path that found this; the short version is that one row per guild cannot represent the double-billing case the issue's own Double billing section says to expect, and the failure mode is switching premium off for a server that is still being charged. The gate asks whether *any* row for the guild is paid, and double billing becomes an `active_count` the website can render rather than a case the data cannot express.

**Nothing here touches the `servers` table.** A webhook can arrive for a guild that has no row, and inserting one would mint a fresh `servers.id` above the captured grandfather line — silently and permanently withdrawing features that server was promised for free, as a side effect of paying us. It has its own test class.

## Three deliberate deviations from the issue

- **`stripe_subscription` keys by subscription id, not by guild.** See above and the adversarial-pass comment. Done now because there is no data yet; after step 5 it is a migration on a table holding live subscriptions.
- **The payload ships `price_id`, not a plan slug.** The slug table is dashboard config precisely because test and live mode need different ids, and a second copy on the bot would be a second thing to get wrong on a page about money.
- **The event ledger reads before it inserts,** rather than inserting and catching. Catching would mean a `SAVEPOINT`, and `SAVEPOINT` under pysqlite does not behave the way it does under Postgres — the first attempt passed a Postgres-shaped guard that the rollback-on-failure test caught. The real race is still caught by the primary key at commit, and the `IntegrityError` branch distinguishes it from the other constraint on that table: a subscription id already attached to a different guild, which is an anomaly needing a human rather than a retry.

## Tests

90 new (70 in `tests/test_stripe.py`, 20 in `TestTheSystemRoute`). **1289 passed, 1 skipped** locally — see A-23, nothing in CI runs pytest, so that is a human claim.

Covering: the kill switch (no query at all, not merely `False`); what counts as paid, per status; the failure rule, including that a guessed `False` never becomes the fallback it came from; the gate via Stripe only, Discord only, both, neither; the short-circuit doing no I/O; idempotency, including that a failed apply does not mark the event processed; ordering per subscription; two live subscriptions, including that cancelling one leaves premium on for the other; the event ledger's sweep; `cancel_at_period_end` refusing coercion; the unknown-guild trap end to end; and the human/system token seam both ways.

## Notes for the reviewer

- `SECURITY_AUDIT.md` is gitignored, so **A-26 is not in this diff**. It records the actorless operation: reviewed at design time, no open action while the route is unregistered, re-check at step 5. Its authority still rests on the signing key, so A-22 applies here too — a VPS-level attacker can mint a system token and grant a guild premium. That is a revenue loss, not an identity or verification compromise, and it is bounded by the same key the rest of the API already depends on.
- **A-25 is untouched and still blocks step 2.** The Cloudflare WAF skip rule for the webhook path has to exist, and be verified by a test-mode event actually reaching the origin, before anything can be bought.
- The comment claiming premium reads Discord entitlements and nothing else is accurate again, and now says why the dead `subscription_status` / `email` / `last_renewal_date` columns were not resurrected.
- The `premium_status_active` copy across the 12 locales still reads as though Discord is the only way to have bought it. Left for step 4 with the rest of the page copy — no server can have a Stripe row until then, so nothing renders wrongly in the meantime.

Part of #88. Steps 2 through 5 follow on their own branches.
