### PR TITLE
Open one door to the internet, and check it carefully

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -255,6 +255,49 @@ LOG_LEVEL=INFO
 # BOT_API_WRITE_RATE_LIMIT=10
 # BOT_API_GLOBAL_WRITE_RATE_LIMIT=60
 
+# --- Stripe, on the DASHBOARD host only (issue #88) ---
+# These belong in the dashboard's environment on the VPS. The bot must never
+# see them: it holds no Stripe credential of any kind, and the whole
+# integration on its side is a table the dashboard fills in over mTLS.
+#
+# STRIPE_ENABLED is the dashboard's own kill switch and it does three things:
+# registers POST /stripe/webhook (unset, that path is a plain 404), builds the
+# Stripe client, and makes everything below REQUIRED. The dashboard refuses to
+# boot if any of them is missing, because a webhook secret that is absent
+# rejects every event Stripe sends while the service looks perfectly healthy.
+#
+# ORDER MATTERS: turn the BOT's STRIPE_ENABLED on first. With this one on and
+# the bot's off, a customer completes checkout, is charged, the forward is
+# answered 404 for three days, and premium never switches on.
+#
+# BEFORE THIS GOES LIVE: the Cloudflare WAF skip rule for /stripe/webhook must
+# exist and be verified by a test-mode event actually reaching the origin
+# (SECURITY_AUDIT.md A-25). The hostname carries a managed challenge, Stripe is
+# not a browser, and the failure is silent -- Stripe sees 403, retries for three
+# days, and NOTHING reaches the origin, so nothing appears in these logs.
+# STRIPE_ENABLED=1
+#
+# Secret key (sk_ or a restricted rk_). A publishable pk_ is refused at boot.
+# STRIPE_SECRET_KEY=sk_live_...
+#
+# The signing secret from the webhook endpoint in Stripe -- whsec_..., NOT an
+# API key. The two are both opaque strings and confusing them rejects every
+# event, so this is checked at boot too.
+# STRIPE_WEBHOOK_SECRET=whsec_...
+#
+# The three plans. Test mode and live mode have different ids for the same
+# plans, which is exactly why these are environment and not constants in the
+# source -- switching modes must not be a code change. All three are required,
+# and they must be three DIFFERENT prices (two plans on one price means someone
+# pays for six months and is billed monthly).
+#
+# Prices must be created with "Include tax in price" = No (tax_behavior
+# exclusive); automatic tax refuses an unspecified one, and inclusive cannot be
+# changed afterwards.
+# STRIPE_PRICE_MONTHLY=price_...
+# STRIPE_PRICE_SIX_MONTHS=price_...
+# STRIPE_PRICE_YEARLY=price_...
+
 # --- docker-compose.deploy.yml only (not read by bot.py directly) ---
 # Pinned image tag to deploy; docker-compose.deploy.yml refuses to run
 # without it (never "latest" — see that file's header comment).

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -49,6 +49,7 @@ import logging
 import mimetypes
 import os
 import secrets
+import time
 from typing import Optional
 
 from flask import (
@@ -63,12 +64,54 @@ from flask import (
 )
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-from dashboard import oauth, overview_view, settings_view
+from dashboard import oauth, overview_view, settings_view, stripe_events
 from dashboard.botapi import BotAPIClient, BotAPIError
 from dashboard.config import DashboardConfig
 from dashboard.sessions import SessionStore
+from dashboard.stripe_api import StripeAPIError, StripeClient
 
 logger = logging.getLogger(__name__)
+
+# The webhook's own budget. Sized well above Stripe's honest traffic -- a
+# renewal storm across every subscribed guild is still a handful a second -- and
+# far below what it would take to make this endpoint interesting to point a
+# botnet at. Exceeding it returns 429, which Stripe treats as a retry rather
+# than a failure, so the cost of a burst is delay and never loss.
+STRIPE_WEBHOOK_RATE_LIMIT = 120
+STRIPE_WEBHOOK_RATE_WINDOW = 60
+
+# The hard ceiling on any request body reaching this app, applied globally in
+# create_app. Generous next to the largest honest body here and small enough
+# that buffering one costs nothing.
+MAX_REQUEST_BYTES = 256 * 1024
+
+
+class _RateLimiter:
+    """A fixed-window counter, per key.
+
+    Deliberately in-process and deliberately tiny. Cloudflare rate limiting
+    sits in front of this, but the webhook path is precisely the one that has
+    to be excepted from the managed challenge (A-25), so the edge protection on
+    it is weaker than on everything else here — which is exactly why the origin
+    keeps a budget of its own rather than trusting the one in front.
+    """
+
+    def __init__(self, limit: int, window: int):
+        self.limit = limit
+        self.window = window
+        self._buckets: dict = {}
+
+    def allow(self, key: str, *, now: float) -> bool:
+        window = int(now // self.window)
+        current, count = self._buckets.get(key, (window, 0))
+        if current != window:
+            current, count = window, 0
+        if count >= self.limit:
+            self._buckets[key] = (current, count)
+            return False
+        self._buckets[key] = (current, count + 1)
+        # Bounded by the number of distinct keys, and there is exactly one.
+        return True
 
 # The sidebar's collapsed state. A UI preference and nothing else: it is not
 # read by any authorisation decision, it names no guild, and forging it gets an
@@ -126,6 +169,7 @@ def create_app(
     *,
     store: Optional[SessionStore] = None,
     client: Optional[BotAPIClient] = None,
+    stripe: Optional[StripeClient] = None,
 ) -> Flask:
     config = config or DashboardConfig.from_env()
     app = Flask(__name__)
@@ -137,6 +181,18 @@ def create_app(
     # one hop is the whole chain.
     app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1, x_for=1)
 
+    # A ceiling on every request body, enforced by Werkzeug before a handler
+    # sees anything. This is not belt-and-braces on top of the webhook's own
+    # size check -- it is the half that actually holds: a request with
+    # `Transfer-Encoding: chunked` carries no Content-Length, so a handler
+    # checking `request.content_length` first sees None and then reads the
+    # whole thing into memory to measure it. Without this the one public,
+    # unauthenticated route on this host will buffer whatever it is sent.
+    #
+    # Nothing here uploads anything. The largest honest body is a settings form
+    # or a subscription event of a few KB.
+    app.config["MAX_CONTENT_LENGTH"] = MAX_REQUEST_BYTES
+
     app.config["STORE"] = store or SessionStore(
         config.session_db_path, config.session_max_age
     )
@@ -147,6 +203,23 @@ def create_app(
         ca_bundle=config.bot_api_ca,
         signing_key=config.bot_api_signing_key,
         timeout=config.request_timeout,
+    )
+
+    # Only built when Stripe is switched on, so a dashboard with the kill
+    # switch off holds no Stripe client and no secret key -- not even an
+    # unused one.
+    app.config["STRIPE"] = stripe or (
+        StripeClient(config.stripe_secret_key, timeout=config.request_timeout)
+        if config.stripe_enabled
+        else None
+    )
+    # Its own budget, deliberately not shared with anything else here. The
+    # webhook is the one route a third party is meant to reach, and it is the
+    # one route that must keep working when the session-authenticated ones are
+    # under load -- a subscription must not be lost because somebody is
+    # hammering /login.
+    app.config["STRIPE_RATE"] = _RateLimiter(
+        STRIPE_WEBHOOK_RATE_LIMIT, STRIPE_WEBHOOK_RATE_WINDOW
     )
 
     # Python's mimetypes table does not know WOFF2 on every platform, and Flask
@@ -286,6 +359,9 @@ def _register_routes(app: Flask) -> None:
     def healthz():
         """Liveness only. Says nothing about sessions, guilds or the bot."""
         return {"ok": True}
+
+    if app.config["DASHBOARD"].stripe_enabled:
+        _register_stripe_webhook(app)
 
     @app.get("/")
     def index():
@@ -841,6 +917,171 @@ PANEL_RESULTS = {
         "was replaced with a fresh one. Your settings apply to it now."
     ),
 }
+
+
+def _register_stripe_webhook(app: Flask) -> None:
+    """The one public, unauthenticated inbound route this project has.
+
+    Registered only when STRIPE_ENABLED is set, so with the switch off the path
+    is a plain 404 rather than a handler trusted to decline. Everything else on
+    this host is reached by a browser holding a session; this is reached by
+    Stripe's infrastructure holding a signature, and it is deliberately NOT
+    under `/guild/` so that no reviewer skimming the routes mistakes it for a
+    session-authenticated one.
+
+    Read the order of operations here as the security design, because it is:
+
+    1. Budget, before anything is read.
+    2. Size cap, before the body is taken into memory.
+    3. **Signature, before the body is parsed.** Until this passes, the bytes
+       are an unknown party's, and nothing has looked at them.
+    4. Only then: parse, decide whether it is an event we act on, fetch current
+       state, forward.
+
+    And read the response codes as the retry contract. Stripe retries a non-2xx
+    for up to three days, which comfortably covers a bot restart, a Tailscale
+    blip or a homelab power cut. So anything we could not complete must be a
+    non-2xx, and anything genuinely finished — including "this is not an event
+    we care about" — must be a 200, or Stripe spends three days redelivering
+    something that will never be actionable.
+    """
+
+    @app.post("/stripe/webhook")
+    def stripe_webhook():
+        config = _config()
+        now = time.time()
+
+        if not app.config["STRIPE_RATE"].allow("stripe", now=now):
+            logger.warning("stripe webhook rate limited")
+            return {"error": "rate_limited"}, 429
+
+        # Checked before reading, so an oversized body is refused rather than
+        # buffered. 413 is a client error and Stripe will not usefully retry
+        # it, which is correct: nothing legitimate is this large.
+        length = request.content_length
+        if length is not None and length > stripe_events.MAX_BODY_BYTES:
+            logger.warning("stripe webhook body too large: %s bytes", length)
+            return {"error": "too_large"}, 413
+
+        # get_data(), never get_json(): the HMAC covers the exact bytes, and
+        # letting Flask parse first would both defeat the signature and run the
+        # parser on unverified input.
+        payload = request.get_data(cache=False)
+        if len(payload) > stripe_events.MAX_BODY_BYTES:
+            return {"error": "too_large"}, 413
+
+        try:
+            stripe_events.verify_signature(
+                payload,
+                request.headers.get("Stripe-Signature"),
+                config.stripe_webhook_secret,
+                now=now,
+            )
+        except stripe_events.SignatureError as error:
+            # Logged like every other auth decision -- a run of these is the
+            # thing worth alerting on. The response says nothing useful: an
+            # endpoint that explains why a signature failed helps someone
+            # construct one that doesn't.
+            logger.warning("stripe webhook rejected: %s", error.reason)
+            return {"error": "invalid_signature"}, 400
+
+        try:
+            event = stripe_events.parse_event(payload)
+        except stripe_events.SignatureError as error:
+            logger.warning("stripe webhook unreadable: %s", error.reason)
+            return {"error": "invalid_payload"}, 400
+
+        event_id = event.get("id")
+        if not isinstance(event_id, str) or not event_id:
+            logger.warning("stripe webhook has no event id; ignoring")
+            return {"ok": True, "ignored": "no_event_id"}
+
+        subscription = stripe_events.subscription_from(event)
+        if subscription is None:
+            # Acknowledged and dropped. Somebody enabling an extra event type
+            # in the Stripe dashboard must not start a three-day retry storm.
+            return {"ok": True, "ignored": "event_type"}
+
+        guild_id = stripe_events.guild_id_from(subscription)
+        if guild_id is None:
+            # Nothing to route it to, and guessing is not an option. 200,
+            # because retrying will not add metadata that was never set --
+            # this is a checkout built wrong, and the log is where it gets
+            # noticed.
+            logger.error(
+                "Stripe subscription %s has no guild_id in its metadata; "
+                "nothing to record. Check how the Checkout Session is built.",
+                subscription.get("id"),
+            )
+            return {"ok": True, "ignored": "no_guild"}
+
+        # Current state rather than the event's snapshot -- see
+        # StripeClient.get_subscription for why ordering makes this the right
+        # read. A failure here is a non-2xx, so Stripe retries.
+        try:
+            current = app.config["STRIPE"].get_subscription(subscription["id"])
+        except StripeAPIError as error:
+            logger.warning("could not read subscription from Stripe: %s", error)
+            return {"error": "stripe_unavailable"}, 503
+
+        # We asked about one subscription; anything else coming back means the
+        # request did not go where this code believes it went. It should be
+        # impossible, which is exactly why it is checked rather than assumed:
+        # without this, a read that landed on a different object would be
+        # written to whichever guild *that* object names.
+        if current.get("id") != subscription["id"]:
+            logger.error(
+                "Asked Stripe for subscription %s and got %r back; refusing to "
+                "record it. Event %s.",
+                subscription["id"],
+                current.get("id"),
+                event_id,
+            )
+            return {"error": "subscription_mismatch"}, 503
+
+        # The guild binding prefers what Stripe just told us, because the
+        # fetched object is the authority on every other field and taking one
+        # field from the older copy is how the two quietly disagree. It falls
+        # back to the event's copy only when the fetched object carries no
+        # guild at all -- metadata being cleared should not unsubscribe a
+        # server that is still paying.
+        current_guild = stripe_events.guild_id_from(current)
+        if current_guild is not None:
+            guild_id = current_guild
+
+        normalised = stripe_events.normalise(
+            current, event_id=event_id, event_created=event.get("created")
+        )
+        if normalised is None:
+            logger.error(
+                "Stripe subscription %s is missing fields this cannot record; "
+                "ignoring. Event %s.",
+                subscription.get("id"),
+                event_id,
+            )
+            return {"ok": True, "ignored": "incomplete"}
+
+        try:
+            result = _bot_api().put_stripe_subscription(guild_id, normalised)
+        except BotAPIError as error:
+            # Never 200-and-drop. This is the failure the three-day retry
+            # window exists for, and answering 200 here is the one thing that
+            # loses a paid subscription permanently.
+            logger.warning(
+                "could not forward Stripe event %s for guild %s: %s",
+                event_id,
+                guild_id,
+                error,
+            )
+            return {"error": "bot_unavailable"}, 503
+
+        logger.info(
+            "stripe webhook applied=%s guild=%s event=%s",
+            result.get("applied"),
+            guild_id,
+            event_id,
+        )
+        return {"ok": True, "applied": bool(result.get("applied"))}
 
 
 def _read_checkbox(changes: dict, name: str) -> None:

--- a/src/dashboard/botapi.py
+++ b/src/dashboard/botapi.py
@@ -33,7 +33,9 @@ from api_tokens import (
     OP_GUILD_AUDIT,
     OP_POST_PANEL,
     OP_LIST_GUILDS,
+    OP_PUT_STRIPE_SUBSCRIPTION,
     OP_UPDATE_SETTINGS,
+    SYSTEM_ACTOR_ID,
     mint_token,
 )
 
@@ -246,6 +248,60 @@ class BotAPIClient:
             actor_id, guild_id, response.status_code, reason,
         )
         raise BotAPIError(reason or "bot API refused the panel post", response.status_code)
+
+    def put_stripe_subscription(self, guild_id, subscription: dict) -> dict:
+        """Forward one verified Stripe event to the bot, as the system actor.
+
+        The only call in this client with no signed-in user behind it. A
+        renewal a year from now is asked for by Stripe, not by a person, and
+        the admin who originally checked out may have left the server — so it
+        names SYSTEM_ACTOR_ID rather than borrowing somebody's identity, and
+        the bot records the change against a fixed non-human actor.
+
+        The authority here is Stripe's signature, checked before this is
+        reached. Everything this call adds is the same as every other: mTLS,
+        a token bound to this method, this path and this guild, single use.
+
+        A refusal is not swallowed. It becomes a non-2xx to Stripe, which
+        retries for up to three days — long enough to cover a bot restart, a
+        Tailscale blip or a homelab power cut. Answering 200 on a failed
+        forward is the one outcome that loses a subscription permanently.
+        """
+        token = mint_token(
+            self.signing_key,
+            actor_id=SYSTEM_ACTOR_ID,
+            operation=OP_PUT_STRIPE_SUBSCRIPTION,
+            guild_id=int(guild_id),
+        )
+        try:
+            response = self._session.put(
+                f"{self.base_url}/api/v1/guilds/{int(guild_id)}/stripe-subscription",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"subscription": subscription},
+                timeout=self.timeout,
+            )
+        except requests.exceptions.SSLError as error:
+            raise BotAPIError(f"TLS failure talking to the bot API: {error}") from error
+        except requests.RequestException as error:
+            raise BotAPIError(f"could not reach the bot API: {error}") from error
+
+        if response.status_code == 200:
+            return response.json()
+
+        reason = ""
+        try:
+            reason = response.json().get("error", "")
+        except ValueError:
+            pass
+        logger.warning(
+            "bot API refused a Stripe subscription write for guild %s: %s %s",
+            guild_id,
+            response.status_code,
+            reason,
+        )
+        raise BotAPIError(
+            reason or "bot API refused the subscription write", response.status_code
+        )
 
     def audit(self, actor_id: int, guild_id) -> list:
         return self._get(

--- a/src/dashboard/config.py
+++ b/src/dashboard/config.py
@@ -12,11 +12,15 @@ be dangerous to guess.
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Mapping, Optional
 from urllib.parse import urlparse
 
 from api_tokens import MIN_SIGNING_KEY_BYTES
+
+# The three plans, as slugs. The browser may name one of these and nothing
+# else; every price id is looked up server-side from the table below.
+STRIPE_PLAN_SLUGS = ("monthly", "six_months", "yearly")
 
 # Flask signs the session cookie with this. The cookie carries only an opaque
 # session id, but forging one is still forging a session, so it gets the same
@@ -53,6 +57,28 @@ class DashboardConfig:
     session_max_age: int = DEFAULT_SESSION_MAX_AGE
     guild_cache_ttl: int = DEFAULT_GUILD_CACHE_TTL
     request_timeout: int = 10
+    # --- Stripe (#88). All absent unless STRIPE_ENABLED is set. ---
+    stripe_enabled: bool = False
+    stripe_secret_key: str = ""
+    stripe_webhook_secret: str = ""
+    # Slug -> price id. The browser can only ever supply the slug; the price is
+    # looked up here. A form-supplied price id would let anyone check out
+    # against any price on the account, including a $0 one made while testing.
+    stripe_prices: Mapping[str, str] = field(default_factory=dict)
+
+    def plan_for(self, price_id: str) -> Optional[str]:
+        """The plan slug for a price id, or None if it is not one of ours.
+
+        None is not an error and must never be treated as "not subscribed" —
+        see the callers. A price can be absent from this table for entirely
+        ordinary reasons: a plan switched in the billing portal, a price
+        replaced during a pricing change, an id rotated between test and live.
+        The subscription is real and paid for; only the label is unknown.
+        """
+        for slug, configured in self.stripe_prices.items():
+            if configured == price_id:
+                return slug
+        return None
 
     @classmethod
     def from_env(cls) -> "DashboardConfig":
@@ -89,6 +115,42 @@ class DashboardConfig:
                 "authentication, and plain http would discard it."
             )
 
+        stripe_enabled = _truthy(os.getenv("STRIPE_ENABLED"))
+        stripe_secret_key = ""
+        stripe_webhook_secret = ""
+        stripe_prices: dict = {}
+        if stripe_enabled:
+            # Refuse to boot rather than come up half-configured. A dashboard
+            # missing its webhook secret rejects every event Stripe sends and
+            # looks healthy doing it; one missing a price id renders a plan card
+            # that 500s when somebody clicks Buy. Both are worse than not
+            # starting, and both are one typo away.
+            stripe_secret_key = _require("STRIPE_SECRET_KEY")
+            stripe_webhook_secret = _require("STRIPE_WEBHOOK_SECRET")
+            if not stripe_secret_key.startswith(("sk_", "rk_")):
+                raise DashboardConfigError(
+                    "STRIPE_SECRET_KEY does not look like a Stripe secret key. "
+                    "A publishable key (pk_) here would fail every call."
+                )
+            if not stripe_webhook_secret.startswith("whsec_"):
+                raise DashboardConfigError(
+                    "STRIPE_WEBHOOK_SECRET must be the signing secret from the "
+                    "webhook endpoint (whsec_...), not an API key."
+                )
+            stripe_prices = {
+                slug: _require(f"STRIPE_PRICE_{slug.upper()}")
+                for slug in STRIPE_PLAN_SLUGS
+            }
+            duplicates = len(stripe_prices) - len(set(stripe_prices.values()))
+            if duplicates:
+                # Two plans on one price means someone pays for six months and
+                # is billed monthly, or the reverse. Cheap to check, expensive
+                # to discover from a customer.
+                raise DashboardConfigError(
+                    "STRIPE_PRICE_* must name three different prices; "
+                    f"{duplicates + 1} of them are the same id."
+                )
+
         return cls(
             discord_client_id=client_id,
             discord_client_secret=client_secret,
@@ -103,7 +165,15 @@ class DashboardConfig:
             session_max_age=_int_env("DASHBOARD_SESSION_MAX_AGE", DEFAULT_SESSION_MAX_AGE),
             guild_cache_ttl=_int_env("DASHBOARD_GUILD_CACHE_TTL", DEFAULT_GUILD_CACHE_TTL),
             request_timeout=_int_env("DASHBOARD_REQUEST_TIMEOUT", 10),
+            stripe_enabled=stripe_enabled,
+            stripe_secret_key=stripe_secret_key,
+            stripe_webhook_secret=stripe_webhook_secret,
+            stripe_prices=stripe_prices,
         )
+
+
+def _truthy(raw: Optional[str]) -> bool:
+    return (raw or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _require(name: str) -> str:

--- a/src/dashboard/stripe_api.py
+++ b/src/dashboard/stripe_api.py
@@ -1,0 +1,102 @@
+"""The little of Stripe's API this project actually calls.
+
+Two form-encoded requests over `requests`, which is already a dependency, in
+place of the official SDK. That is a deliberate trade recorded here rather than
+left as an omission: the SDK is a large dependency, and this is the
+internet-facing host whose compromise the threat model already assumes. Adding
+it would mean more code running next to a Stripe secret key for the sake of
+what fits on one screen.
+
+The secret key never leaves this process. The bot holds no Stripe credential at
+all, and nothing in `src/bot*.py` imports this module.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import requests
+
+from dashboard import stripe_events
+
+logger = logging.getLogger(__name__)
+
+STRIPE_API_BASE = "https://api.stripe.com/v1"
+
+# Stripe pins behaviour to the version the account is on unless asked
+# otherwise. Naming it means a Stripe-side upgrade cannot silently change the
+# shape of what `stripe_events.normalise` reads.
+STRIPE_API_VERSION = "2024-06-20"
+
+
+class StripeAPIError(Exception):
+    """Stripe could not be reached, or refused the call."""
+
+    def __init__(self, message: str, status: Optional[int] = None):
+        super().__init__(message)
+        self.status = status
+
+
+class StripeClient:
+    def __init__(self, secret_key: str, *, timeout: int = 10):
+        self._secret_key = secret_key
+        self.timeout = timeout
+        self._session = requests.Session()
+
+    def _headers(self) -> dict:
+        return {
+            "Authorization": f"Bearer {self._secret_key}",
+            "Stripe-Version": STRIPE_API_VERSION,
+        }
+
+    def get_subscription(self, subscription_id: str) -> dict:
+        """Read a subscription's *current* state.
+
+        Called on every webhook rather than trusting the event's own snapshot,
+        and the reason is ordering. Stripe promises nothing about the order
+        events arrive in, and `event.created` has one-second resolution — so two
+        events for one subscription in the same second are indistinguishable in
+        age, and the bot's ordering guard drops the second one. Fetching means
+        whichever delivery does apply carries current truth rather than a
+        snapshot that may already be stale, so a dropped sibling costs nothing.
+
+        It also means a redelivery three days later writes today's state, not
+        the state at the moment the event fired.
+
+        The cost is one API call per webhook and one more way to fail, and the
+        failure is the safe one: an exception here becomes a non-2xx to Stripe,
+        which retries for three days.
+        """
+        # Checked at the point the URL is built, as well as by the caller. This
+        # value arrives inside a signature-verified body, so it came from
+        # Stripe — which is why this should never fire, and not a reason to
+        # skip it. A `/` or a `?` here silently turns a read of one
+        # subscription into a request for something else entirely.
+        if not stripe_events.valid_object_id(subscription_id):
+            raise StripeAPIError("refusing to request a malformed subscription id")
+
+        try:
+            response = self._session.get(
+                f"{STRIPE_API_BASE}/subscriptions/{subscription_id}",
+                headers=self._headers(),
+                timeout=self.timeout,
+            )
+        except requests.RequestException as error:
+            raise StripeAPIError(f"could not reach Stripe: {error}") from error
+
+        if response.status_code == 200:
+            try:
+                payload = response.json()
+            except ValueError as error:
+                raise StripeAPIError("Stripe returned an unreadable body") from error
+            if not isinstance(payload, dict):
+                raise StripeAPIError("Stripe returned an unexpected body")
+            return payload
+
+        # Deliberately does not log the response body. Stripe error payloads can
+        # echo request parameters, and this runs on the public host.
+        logger.warning(
+            "Stripe refused a subscription read: %s", response.status_code
+        )
+        raise StripeAPIError("Stripe refused the request", response.status_code)

--- a/src/dashboard/stripe_events.py
+++ b/src/dashboard/stripe_events.py
@@ -1,0 +1,288 @@
+"""Verifying and reading Stripe webhooks. Pure — no Flask, no network, no clock.
+
+This is the module that decides whether a request claiming to be from Stripe
+actually is. It is deliberately the smallest, most boring code in the project,
+because it is the first thing a public unauthenticated request touches: until
+`verify_signature` returns, the body is a string of bytes an unknown party
+chose, and nothing here parses it.
+
+Stdlib only, and the reason is worth stating rather than assuming. Signature
+verification is an HMAC-SHA256 over `{timestamp}.{body}` compared with
+`hmac.compare_digest` — about fifteen lines. The official SDK would bring a
+large dependency onto the internet-facing host to do that and one form-encoded
+POST, on the box whose compromise this project's threat model already assumes.
+Every line saved there is a line nobody has to review.
+
+**The order of operations is the security property.** Verify, then parse.
+Reversed, an attacker gets our JSON parser to run on their bytes before we have
+established they are entitled to send us anything at all, which is exactly the
+foothold the signature exists to deny.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+import logging
+import re
+from hashlib import sha256
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# How far a webhook's own timestamp may be from our clock. Stripe's default,
+# and the number that makes a captured request worthless five minutes later:
+# without it a valid signature is valid forever, and a webhook recorded off the
+# wire could be replayed at any point in the future.
+DEFAULT_TOLERANCE = 300
+
+# Nothing legitimate is anywhere near this. A subscription event is a few KB;
+# the cap is here so a body has a bound before it is read into memory, not
+# because any real event approaches it.
+MAX_BODY_BYTES = 64 * 1024
+
+# The only events this endpoint acts on.
+#
+# Deliberately narrow, and not only for least privilege. A checkout completing
+# emits several events within the same second — `checkout.session.completed`,
+# `customer.subscription.created`, `invoice.paid` — and the bot's ordering guard
+# compares Stripe's `created`, which has one-second resolution. Subscribing to
+# one family of events keeps same-second pairs for a single subscription rare,
+# which is the residual risk noted in `write_dashboard_stripe_subscription`.
+#
+# Everything else Stripe might send is acknowledged and ignored. An endpoint
+# that 400s on an event type somebody enabled in the Stripe dashboard would
+# start a three-day retry storm over a checkbox.
+SUBSCRIPTION_EVENTS = frozenset(
+    {
+        "customer.subscription.created",
+        "customer.subscription.updated",
+        "customer.subscription.deleted",
+    }
+)
+
+
+# Stripe object ids are `prefix_` plus base-something alphanumerics. Nothing
+# else is ever legitimate, and this is checked before an id is interpolated
+# into an API URL.
+#
+# Yes, the id arrives inside a signature-verified body, so it came from Stripe.
+# That is an argument for *why this should never fire*, not for leaving it out:
+# a path separator or a query character in this value silently turns a read of
+# one subscription into a request for something else entirely, and the whole
+# point of the layered design here is that no single check is load-bearing on
+# its own.
+_OBJECT_ID = re.compile(r"\A[A-Za-z0-9_]{1,255}\Z")
+
+
+def valid_object_id(value) -> bool:
+    """Is this safe to put in a URL path segment?"""
+    return isinstance(value, str) and bool(_OBJECT_ID.match(value))
+
+
+class SignatureError(Exception):
+    """The request did not prove it came from Stripe.
+
+    Carries a short machine reason for the log. It is never shown to the
+    caller: an endpoint that explains *why* a signature failed is an endpoint
+    that helps someone construct one that doesn't.
+    """
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
+def verify_signature(
+    payload: bytes,
+    header: Optional[str],
+    secret: str,
+    *,
+    now: float,
+    tolerance: int = DEFAULT_TOLERANCE,
+) -> None:
+    """Authenticate one webhook. Raises SignatureError, or returns None.
+
+    `now` is passed in rather than read here so the whole module stays pure and
+    the expiry cases are testable without sleeping or patching a clock.
+
+    The header looks like `t=1699999999,v1=abc...,v1=def...`. More than one v1
+    is normal and expected — it is how Stripe rolls a signing secret without an
+    outage — so any matching one is enough.
+    """
+    if not header:
+        raise SignatureError("missing_signature")
+
+    timestamps: list[str] = []
+    signatures: list[str] = []
+    for part in header.split(","):
+        key, _, value = part.strip().partition("=")
+        if key == "t":
+            timestamps.append(value)
+        elif key == "v1":
+            signatures.append(value)
+
+    if not timestamps or not signatures:
+        raise SignatureError("malformed_signature")
+    # Stripe sends exactly one `t`. Several is either a broken sender or
+    # someone probing which one this implementation believes — and whichever
+    # answer it gave would be arbitrary. Neither ambiguity can forge a
+    # signature, since the timestamp is inside the signed string, but a parser
+    # with an opinion nobody chose is not one to keep.
+    if len(timestamps) > 1:
+        raise SignatureError("malformed_signature")
+    timestamp = timestamps[0]
+
+    try:
+        issued = int(timestamp)
+    except ValueError:
+        raise SignatureError("malformed_signature")
+
+    # Checked before the HMAC so a flood of stale replays costs a comparison
+    # rather than a hash over an attacker-sized body.
+    if abs(now - issued) > tolerance:
+        raise SignatureError("timestamp_out_of_tolerance")
+
+    signed = f"{timestamp}.".encode("utf-8") + payload
+    expected = hmac.new(secret.encode("utf-8"), signed, sha256).hexdigest()
+
+    # compare_digest, never ==. The naive comparison returns early on the first
+    # wrong byte, which leaks how much of a guess was right.
+    if not any(hmac.compare_digest(expected, candidate) for candidate in signatures):
+        raise SignatureError("bad_signature")
+
+
+def parse_event(payload: bytes) -> dict:
+    """Read a webhook body. Only ever called on a body that has verified.
+
+    Raises SignatureError rather than a parse error, because from the caller's
+    point of view an unreadable body on an authenticated request is the same
+    refusal with the same response: something is wrong at the sender and there
+    is nothing here to act on.
+    """
+    try:
+        event = json.loads(payload)
+    except (ValueError, UnicodeDecodeError):
+        raise SignatureError("unreadable_body")
+    if not isinstance(event, dict):
+        raise SignatureError("unreadable_body")
+    return event
+
+
+def subscription_from(event: dict) -> Optional[dict]:
+    """The subscription an event is about, or None if it is not about one."""
+    if event.get("type") not in SUBSCRIPTION_EVENTS:
+        return None
+    obj = (event.get("data") or {}).get("object")
+    if not isinstance(obj, dict) or obj.get("object") != "subscription":
+        return None
+    # The id goes into an API URL a moment later, so it is checked here rather
+    # than at the point of use alone.
+    if not valid_object_id(obj.get("id")):
+        return None
+    return obj
+
+
+def guild_id_from(subscription: dict) -> Optional[str]:
+    """Which guild this subscription is for, from its own metadata.
+
+    Read from `subscription.metadata`, not from the checkout session's
+    `client_reference_id`. The distinction matters more than it looks: the
+    reference id appears only on the session, so it is there for the first
+    event and gone by the first renewal, while metadata set on the subscription
+    rides along with every `customer.subscription.*` event for the life of the
+    subscription. The guild binding has to survive to a renewal a year later.
+
+    Returns None rather than guessing. A subscription with no guild is not
+    something to attribute to a plausible one.
+    """
+    metadata = subscription.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    raw = metadata.get("guild_id")
+    if isinstance(raw, int):
+        raw = str(raw)
+    if not isinstance(raw, str) or not raw.strip().isdigit():
+        return None
+    return raw.strip()
+
+
+def price_id_from(subscription: dict) -> Optional[str]:
+    """The price this subscription is on.
+
+    Takes the first line item. These subscriptions carry exactly one — the
+    checkout session is built with a single `line_items[0][price]` — and a
+    subscription with several is not something this product knows how to
+    describe, so the first is the honest answer rather than an arbitrary one.
+    """
+    items = ((subscription.get("items") or {}).get("data")) or []
+    if not items or not isinstance(items[0], dict):
+        return None
+    price = items[0].get("price")
+    if not isinstance(price, dict):
+        return None
+    price_id = price.get("id")
+    return price_id if isinstance(price_id, str) and price_id else None
+
+
+def _iso(epoch) -> Optional[str]:
+    from datetime import datetime, timezone
+
+    if not isinstance(epoch, (int, float)) or isinstance(epoch, bool):
+        return None
+    try:
+        return datetime.fromtimestamp(int(epoch), tz=timezone.utc).isoformat()
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def normalise(subscription: dict, *, event_id: str, event_created) -> Optional[dict]:
+    """Turn a Stripe subscription into the payload the bot accepts.
+
+    Nothing raw from Stripe crosses the wire to the homelab. The bot receives
+    eight named fields it already knows how to validate, and never a nested
+    object it would have to go digging through — which is what keeps the bot
+    free of any opinion about Stripe's schema, and free to keep working when
+    that schema changes.
+
+    Note what is *not* here: no email, no customer name, no payment method, no
+    address. Checkout collects an email and Stripe holds it; mirroring it into
+    the bot's database would add customer PII to the one system in this project
+    that holds Discord-to-VRChat identity links, to power a page that says
+    "manage billing in the portal". The customer id is included because the
+    billing portal needs it, and nothing else about the customer is.
+
+    Returns None when a required field is missing, which the caller treats as
+    an event it cannot act on rather than one to retry.
+    """
+    subscription_id = subscription.get("id")
+    customer = subscription.get("customer")
+    # Expanded or not, depending on how the object was fetched.
+    if isinstance(customer, dict):
+        customer = customer.get("id")
+    status = subscription.get("status")
+    price_id = price_id_from(subscription)
+    period_end = _iso(subscription.get("current_period_end"))
+    created = _iso(event_created)
+
+    if not all(
+        isinstance(value, str) and value
+        for value in (subscription_id, customer, status, price_id, event_id)
+    ):
+        return None
+    if period_end is None or created is None:
+        return None
+
+    return {
+        "event_id": event_id,
+        "event_created": created,
+        "customer_id": customer,
+        "subscription_id": subscription_id,
+        "price_id": price_id,
+        "status": status,
+        "current_period_end": period_end,
+        # A real bool, never a coerced one. The bot refuses anything else, and
+        # this is the field that decides whether the page says "renews" or
+        # "ends".
+        "cancel_at_period_end": bool(subscription.get("cancel_at_period_end")),
+    }

--- a/tests/test_stripe_webhook.py
+++ b/tests/test_stripe_webhook.py
@@ -1,0 +1,865 @@
+"""Unit tests for the Stripe webhook endpoint (issue #88, step 3).
+
+This is **the first public, unauthenticated inbound route this project has ever
+had.** Everything else on the VPS is reached by a browser holding a session;
+this is reached by a third party holding a signature. So these tests are almost
+entirely about the ways that door can be opened by someone who should not be
+able to open it, and about the retry contract that decides whether a paid
+subscription is ever lost.
+
+The themes:
+
+- the signature is the authentication, and it is checked *before* the body is
+  parsed — an endpoint that parses first has already run our JSON parser on an
+  unknown party's bytes
+- every HMAC here is computed in the test, never mocked. A mocked signature
+  check proves the handler calls something, not that the something works
+- the response code is a retry instruction. Stripe retries a non-2xx for three
+  days, so anything we could not finish must be non-2xx, and anything genuinely
+  finished must be 200 — including "not an event we act on", or a checkbox in
+  the Stripe dashboard starts a three-day redelivery storm
+- with the kill switch off the path does not exist at all
+"""
+
+import hmac
+import json
+import time
+from hashlib import sha256
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("flask")
+
+from dashboard import stripe_events  # noqa: E402
+from dashboard.app import create_app  # noqa: E402
+from dashboard.botapi import BotAPIError  # noqa: E402
+from dashboard.config import DashboardConfig, DashboardConfigError  # noqa: E402
+from dashboard.sessions import SessionStore  # noqa: E402
+from dashboard.stripe_api import StripeAPIError  # noqa: E402
+
+GUILD_ID = "111111111111"
+SIGNING_KEY = "s" * 48
+SECRET_KEY = "k" * 48
+WEBHOOK_SECRET = "whsec_" + "w" * 32
+STRIPE_KEY = "sk_test_" + "x" * 24
+
+SUBSCRIPTION_ID = "sub_TEST"
+CUSTOMER_ID = "cus_TEST"
+PRICE_MONTHLY = "price_monthly"
+PRICE_SIX = "price_six_months"
+PRICE_YEARLY = "price_yearly"
+
+WEBHOOK_PATH = "/stripe/webhook"
+
+
+# -------------------------------------------------------------------
+# Fixtures and fakes
+# -------------------------------------------------------------------
+@pytest.fixture
+def certs(tmp_path):
+    for name in ("client.pem", "client.key", "ca.pem"):
+        (tmp_path / name).write_text("placeholder")
+    return tmp_path
+
+
+def make_config(tmp_path, certs, **overrides):
+    base = dict(
+        discord_client_id="1335738139825799188",
+        discord_client_secret="client-secret",
+        oauth_redirect_uri="https://dashboard.vrcverify.com/callback",
+        secret_key=SECRET_KEY,
+        session_db_path=str(tmp_path / "sessions.db"),
+        bot_api_url="https://100.117.6.99:5002",
+        bot_api_client_cert=str(certs / "client.pem"),
+        bot_api_client_key=str(certs / "client.key"),
+        bot_api_ca=str(certs / "ca.pem"),
+        bot_api_signing_key=SIGNING_KEY.encode(),
+        stripe_enabled=True,
+        stripe_secret_key=STRIPE_KEY,
+        stripe_webhook_secret=WEBHOOK_SECRET,
+        stripe_prices={
+            "monthly": PRICE_MONTHLY,
+            "six_months": PRICE_SIX,
+            "yearly": PRICE_YEARLY,
+        },
+    )
+    base.update(overrides)
+    return DashboardConfig(**base)
+
+
+class FakeBotAPI:
+    """Collects what was forwarded, and can refuse on demand."""
+
+    def __init__(self):
+        self.forwarded = []
+        self.error = None
+
+    def put_stripe_subscription(self, guild_id, subscription):
+        self.forwarded.append((str(guild_id), dict(subscription)))
+        if self.error is not None:
+            raise self.error
+        return {"applied": True, "status": subscription.get("status")}
+
+    # The picker calls this on `/`; unused here but the app expects it.
+    def admin_guild_ids(self, actor_id, guild_ids):
+        return set()
+
+
+def make_subscription(
+    *,
+    subscription_id=SUBSCRIPTION_ID,
+    guild_id=GUILD_ID,
+    status="active",
+    price_id=PRICE_MONTHLY,
+    period_end=None,
+    cancel_at_period_end=False,
+    customer=CUSTOMER_ID,
+    metadata=None,
+):
+    if metadata is None:
+        metadata = {} if guild_id is None else {"guild_id": guild_id}
+    return {
+        "id": subscription_id,
+        "object": "subscription",
+        "customer": customer,
+        "status": status,
+        "current_period_end": int(period_end or (time.time() + 30 * 86400)),
+        "cancel_at_period_end": cancel_at_period_end,
+        "metadata": metadata,
+        "items": {"data": [{"price": {"id": price_id}}]},
+        # Fields Stripe really sends that we must not mirror.
+        "latest_invoice": "in_TEST",
+        "default_payment_method": "pm_TEST",
+    }
+
+
+class FakeStripe:
+    """Stands in for the Stripe API. Returns whatever `current` is set to."""
+
+    def __init__(self, current=None):
+        self.current = current if current is not None else make_subscription()
+        self.error = None
+        self.reads = []
+
+    def get_subscription(self, subscription_id):
+        self.reads.append(subscription_id)
+        if self.error is not None:
+            raise self.error
+        return self.current
+
+
+@pytest.fixture
+def bot_api():
+    return FakeBotAPI()
+
+
+@pytest.fixture
+def stripe():
+    return FakeStripe()
+
+
+@pytest.fixture
+def app(tmp_path, certs, bot_api, stripe):
+    config = make_config(tmp_path, certs)
+    application = create_app(
+        config,
+        store=SessionStore(config.session_db_path, config.session_max_age),
+        client=bot_api,
+        stripe=stripe,
+    )
+    application.config.update(TESTING=True)
+    return application
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def make_event(subscription=None, *, event_id="evt_TEST", event_type=None, created=None):
+    return {
+        "id": event_id,
+        "object": "event",
+        "type": event_type or "customer.subscription.updated",
+        "created": int(created or time.time()),
+        "data": {"object": subscription if subscription is not None else make_subscription()},
+    }
+
+
+def sign(body: bytes, *, secret=WEBHOOK_SECRET, timestamp=None) -> str:
+    """Compute a real Stripe-Signature header. Never mocked."""
+    stamp = int(timestamp if timestamp is not None else time.time())
+    signed = f"{stamp}.".encode("utf-8") + body
+    digest = hmac.new(secret.encode("utf-8"), signed, sha256).hexdigest()
+    return f"t={stamp},v1={digest}"
+
+
+def post(client, event=None, *, body=None, header=None, **sign_kwargs):
+    if body is None:
+        body = json.dumps(event if event is not None else make_event()).encode()
+    if header is None:
+        header = sign(body, **sign_kwargs)
+    headers = {"Content-Type": "application/json"}
+    if header is not False:
+        headers["Stripe-Signature"] = header
+    return client.post(WEBHOOK_PATH, data=body, headers=headers)
+
+
+# -------------------------------------------------------------------
+# The kill switch
+# -------------------------------------------------------------------
+class TestKillSwitch:
+    def test_the_route_does_not_exist_when_stripe_is_off(
+        self, tmp_path, certs, bot_api
+    ):
+        """A 404, not a handler that declines.
+
+        The most reliable way to be sure a public endpoint cannot run is for it
+        never to have been added to the routing table.
+        """
+        config = make_config(
+            tmp_path,
+            certs,
+            stripe_enabled=False,
+            stripe_secret_key="",
+            stripe_webhook_secret="",
+            stripe_prices={},
+        )
+        application = create_app(
+            config,
+            store=SessionStore(config.session_db_path, config.session_max_age),
+            client=bot_api,
+        )
+        application.config.update(TESTING=True)
+        response = application.test_client().post(WEBHOOK_PATH, data=b"{}")
+        assert response.status_code == 404
+        assert bot_api.forwarded == []
+
+    def test_no_stripe_client_is_built_when_off(self, tmp_path, certs, bot_api):
+        """With the switch off the process holds no Stripe client at all --
+        not even an unused one holding a secret key."""
+        config = make_config(
+            tmp_path,
+            certs,
+            stripe_enabled=False,
+            stripe_secret_key="",
+            stripe_webhook_secret="",
+            stripe_prices={},
+        )
+        application = create_app(
+            config,
+            store=SessionStore(config.session_db_path, config.session_max_age),
+            client=bot_api,
+        )
+        assert application.config["STRIPE"] is None
+
+
+# -------------------------------------------------------------------
+# The signature
+# -------------------------------------------------------------------
+class TestTheSignature:
+    """Every HMAC below is computed in the test. None of this is mocked."""
+
+    def test_a_valid_signature_is_accepted(self, client, bot_api):
+        assert post(client).status_code == 200
+        assert len(bot_api.forwarded) == 1
+
+    def test_a_tampered_body_is_refused(self, client, bot_api):
+        body = json.dumps(make_event()).encode()
+        header = sign(body)
+        response = post(client, body=body + b" ", header=header)
+        assert response.status_code == 400
+        assert bot_api.forwarded == []
+
+    def test_a_wrong_secret_is_refused(self, client, bot_api):
+        response = post(client, secret="whsec_" + "z" * 32)
+        assert response.status_code == 400
+        assert bot_api.forwarded == []
+
+    def test_an_expired_timestamp_is_refused(self, client, bot_api):
+        response = post(client, timestamp=time.time() - 3600)
+        assert response.status_code == 400
+        assert bot_api.forwarded == []
+
+    def test_a_future_timestamp_is_refused(self, client, bot_api):
+        """Tolerance is absolute, not one-sided.
+
+        A signature dated an hour ahead is as much a sign of something wrong as
+        one an hour behind, and accepting it would widen the replay window by
+        the whole tolerance in the other direction.
+        """
+        response = post(client, timestamp=time.time() + 3600)
+        assert response.status_code == 400
+        assert bot_api.forwarded == []
+
+    def test_a_missing_header_is_refused(self, client, bot_api):
+        response = post(client, header=False)
+        assert response.status_code == 400
+        assert bot_api.forwarded == []
+
+    @pytest.mark.parametrize(
+        "header",
+        [
+            "",
+            "garbage",
+            "t=,v1=",
+            "v1=abc",  # no timestamp
+            "t=123",  # no signature
+            "t=notanumber,v1=abc",
+        ],
+    )
+    def test_a_malformed_header_is_refused(self, client, bot_api, header):
+        response = post(client, header=header)
+        assert response.status_code == 400
+        assert bot_api.forwarded == []
+
+    def test_a_second_signature_is_enough(self, client, bot_api):
+        """Stripe sends more than one v1 while a signing secret is rolled.
+
+        Refusing on the first non-matching one would turn a routine secret
+        rotation into an outage.
+        """
+        body = json.dumps(make_event()).encode()
+        good = sign(body)
+        stamp = good.split(",")[0]
+        header = f"{stamp},v1={'0' * 64},{good.split(',', 1)[1]}"
+        assert post(client, body=body, header=header).status_code == 200
+        assert len(bot_api.forwarded) == 1
+
+    def test_the_response_does_not_say_why_it_failed(self, client):
+        """An endpoint that explains a signature failure helps someone build
+        one that works."""
+        reasons = set()
+        for kwargs in (
+            {"secret": "whsec_" + "z" * 32},
+            {"timestamp": time.time() - 3600},
+        ):
+            response = post(client, **kwargs)
+            reasons.add(response.get_json()["error"])
+        assert reasons == {"invalid_signature"}
+
+    def test_the_body_is_not_parsed_before_the_signature_is_checked(
+        self, client, bot_api
+    ):
+        """The ordering property, asserted rather than assumed.
+
+        Send unparseable JSON with a *bad* signature. If the answer names the
+        parse failure, the parser ran on unverified bytes -- which is exactly
+        the foothold the signature exists to deny.
+        """
+        response = post(client, body=b"{ this is not json", header="t=1,v1=deadbeef")
+        assert response.status_code == 400
+        assert response.get_json()["error"] == "invalid_signature"
+        assert bot_api.forwarded == []
+
+    def test_unparseable_json_with_a_good_signature_is_a_400(self, client, bot_api):
+        response = post(client, body=b"{ this is not json")
+        assert response.status_code == 400
+        assert response.get_json()["error"] == "invalid_payload"
+        assert bot_api.forwarded == []
+
+
+# -------------------------------------------------------------------
+# Which events are acted on
+# -------------------------------------------------------------------
+class TestEventRouting:
+    def test_a_subscription_event_is_forwarded(self, client, bot_api):
+        assert post(client).status_code == 200
+        guild_id, payload = bot_api.forwarded[0]
+        assert guild_id == GUILD_ID
+        assert payload["subscription_id"] == SUBSCRIPTION_ID
+        assert payload["status"] == "active"
+        assert payload["price_id"] == PRICE_MONTHLY
+
+    @pytest.mark.parametrize(
+        "event_type",
+        [
+            "customer.subscription.created",
+            "customer.subscription.updated",
+            "customer.subscription.deleted",
+        ],
+    )
+    def test_every_subscription_lifecycle_event_is_acted_on(
+        self, client, bot_api, event_type
+    ):
+        assert post(client, make_event(event_type=event_type)).status_code == 200
+        assert len(bot_api.forwarded) == 1
+
+    @pytest.mark.parametrize(
+        "event_type",
+        ["invoice.paid", "checkout.session.completed", "payment_intent.succeeded"],
+    )
+    def test_other_events_are_acknowledged_and_ignored(
+        self, client, bot_api, event_type
+    ):
+        """200, not 400.
+
+        Somebody enabling an extra event type in the Stripe dashboard must not
+        start a three-day retry storm over a checkbox.
+        """
+        response = post(client, make_event(event_type=event_type))
+        assert response.status_code == 200
+        assert response.get_json()["ignored"] == "event_type"
+        assert bot_api.forwarded == []
+
+    def test_an_event_with_no_id_is_ignored(self, client, bot_api):
+        assert post(client, make_event(event_id="")).status_code == 200
+        assert bot_api.forwarded == []
+
+    def test_a_subscription_with_no_guild_metadata_is_ignored(
+        self, client, bot_api, stripe
+    ):
+        """Nothing to route it to, and guessing is not an option.
+
+        200 because retrying will not add metadata that was never set -- this
+        is a Checkout Session built wrong, and the log is where it surfaces.
+        """
+        stripe.current = make_subscription(guild_id=None)
+        response = post(client, make_event(make_subscription(guild_id=None)))
+        assert response.status_code == 200
+        assert response.get_json()["ignored"] == "no_guild"
+        assert bot_api.forwarded == []
+
+    def test_the_guild_comes_from_subscription_metadata(self, client, bot_api, stripe):
+        """Not from the checkout session's client_reference_id.
+
+        The reference id exists only on the session, so it is there for the
+        first event and gone by the first renewal. Metadata on the subscription
+        rides along with every event for its life, which is what the binding
+        has to survive to.
+        """
+        stripe.current = make_subscription(guild_id="222222222222")
+        event = make_event(make_subscription(guild_id="222222222222"))
+        event["data"]["object"]["client_reference_id"] = "999999999999"
+        post(client, event)
+        assert bot_api.forwarded[0][0] == "222222222222"
+
+    def test_a_non_numeric_guild_id_is_refused(self, client, bot_api, stripe):
+        stripe.current = make_subscription(metadata={"guild_id": "../../etc/passwd"})
+        response = post(
+            client, make_event(make_subscription(metadata={"guild_id": "nope"}))
+        )
+        assert response.status_code == 200
+        assert bot_api.forwarded == []
+
+
+# -------------------------------------------------------------------
+# Current state, not the event's snapshot
+# -------------------------------------------------------------------
+class TestCurrentStateIsFetched:
+    def test_the_subscription_is_read_back_from_stripe(self, client, stripe):
+        post(client)
+        assert stripe.reads == [SUBSCRIPTION_ID]
+
+    def test_the_fetched_state_wins_over_the_event_body(self, client, bot_api, stripe):
+        """The whole reason for the extra call.
+
+        Stripe promises nothing about event ordering, and `event.created` has
+        one-second resolution -- so whichever delivery does apply must carry
+        current truth rather than a snapshot that may already be stale.
+        """
+        stale = make_subscription(status="active")
+        stripe.current = make_subscription(status="canceled")
+        post(client, make_event(stale))
+        assert bot_api.forwarded[0][1]["status"] == "canceled"
+
+    def test_stripe_being_down_is_a_503_so_it_retries(self, client, bot_api, stripe):
+        stripe.error = StripeAPIError("boom")
+        response = post(client)
+        assert response.status_code == 503
+        assert bot_api.forwarded == []
+
+
+# -------------------------------------------------------------------
+# The retry contract
+# -------------------------------------------------------------------
+class TestTheRetryContract:
+    def test_a_bot_that_cannot_be_reached_is_a_503(self, client, bot_api):
+        """Never 200-and-drop.
+
+        Stripe retries a non-2xx for up to three days, which covers a bot
+        restart, a Tailscale blip or a homelab power cut. Answering 200 on a
+        failed forward is the one outcome that loses a paid subscription
+        permanently.
+        """
+        bot_api.error = BotAPIError("unreachable")
+        assert post(client).status_code == 503
+
+    def test_a_bot_refusal_is_also_a_503(self, client, bot_api):
+        bot_api.error = BotAPIError("unavailable", 503)
+        assert post(client).status_code == 503
+
+    def test_a_duplicate_is_reported_as_handled(self, client, bot_api):
+        """The bot answering "already processed" is success, not failure.
+
+        Retrying a delivery the bot has already applied must not loop for
+        three days.
+        """
+
+        def already_done(guild_id, subscription):
+            return {"applied": False, "reason": "duplicate_event"}
+
+        bot_api.put_stripe_subscription = already_done
+        response = post(client)
+        assert response.status_code == 200
+        assert response.get_json()["applied"] is False
+
+
+# -------------------------------------------------------------------
+# What crosses the wire
+# -------------------------------------------------------------------
+class TestTheForwardedPayload:
+    def test_it_carries_exactly_the_agreed_fields(self, client, bot_api):
+        post(client)
+        assert set(bot_api.forwarded[0][1]) == {
+            "event_id",
+            "event_created",
+            "customer_id",
+            "subscription_id",
+            "price_id",
+            "status",
+            "current_period_end",
+            "cancel_at_period_end",
+        }
+
+    def test_nothing_raw_from_stripe_is_forwarded(self, client, bot_api):
+        """The bot receives eight named fields it already validates, never a
+        nested object it would have to go digging through."""
+        post(client)
+        payload = bot_api.forwarded[0][1]
+        assert "in_TEST" not in repr(payload)
+        assert "pm_TEST" not in repr(payload)
+        assert "items" not in payload
+        assert "metadata" not in payload
+
+    def test_no_customer_pii_is_mirrored(self, client, bot_api, stripe):
+        """Checkout collects an email and Stripe keeps it.
+
+        Mirroring it would add customer PII to the one database in this project
+        holding Discord-to-VRChat identity links, to power a page that says
+        "manage billing in the portal".
+        """
+        stripe.current = make_subscription()
+        stripe.current["customer_email"] = "someone@example.com"
+        stripe.current["billing_details"] = {"name": "A Person"}
+        post(client)
+        rendered = repr(bot_api.forwarded[0][1])
+        assert "someone@example.com" not in rendered
+        assert "A Person" not in rendered
+
+    def test_cancel_at_period_end_is_a_real_boolean(self, client, bot_api, stripe):
+        stripe.current = make_subscription(cancel_at_period_end=True)
+        post(client)
+        assert bot_api.forwarded[0][1]["cancel_at_period_end"] is True
+
+    def test_timestamps_are_iso_utc(self, client, bot_api):
+        post(client)
+        payload = bot_api.forwarded[0][1]
+        assert payload["current_period_end"].endswith("+00:00")
+        assert payload["event_created"].endswith("+00:00")
+
+    def test_an_incomplete_subscription_is_not_forwarded(self, client, bot_api, stripe):
+        stripe.current = make_subscription()
+        del stripe.current["current_period_end"]
+        response = post(client)
+        assert response.status_code == 200
+        assert response.get_json()["ignored"] == "incomplete"
+        assert bot_api.forwarded == []
+
+    def test_an_unknown_price_is_still_forwarded(self, client, bot_api, stripe):
+        """A price absent from our table is a label problem, never a payment
+        problem. The subscription is real and paid for."""
+        stripe.current = make_subscription(price_id="price_SOMETHING_ELSE")
+        assert post(client).status_code == 200
+        assert bot_api.forwarded[0][1]["price_id"] == "price_SOMETHING_ELSE"
+
+
+# -------------------------------------------------------------------
+# Budgets and bounds
+# -------------------------------------------------------------------
+class TestBoundsOnAPublicRoute:
+    def test_an_oversized_body_is_refused(self, client, bot_api):
+        response = post(client, body=b"x" * (stripe_events.MAX_BODY_BYTES + 1))
+        assert response.status_code == 413
+        assert bot_api.forwarded == []
+
+    def test_a_burst_is_rate_limited(self, app, client, bot_api):
+        """429, which Stripe treats as a retry rather than a failure -- so the
+        cost of a burst is delay and never loss."""
+        app.config["STRIPE_RATE"].limit = 3
+        codes = [post(client).status_code for _ in range(5)]
+        assert codes[:3] == [200, 200, 200]
+        assert codes[3:] == [429, 429]
+        assert len(bot_api.forwarded) == 3
+
+    def test_the_limiter_is_not_shared_with_anything_else(self, app):
+        """The webhook is the one route that must keep working when the
+        session-authenticated ones are under load. A subscription must not be
+        lost because somebody is hammering /login."""
+        assert app.config["STRIPE_RATE"] is not app.config.get("STORE")
+        app.config["STRIPE_RATE"].limit = 0
+        assert app.test_client().get("/healthz").status_code == 200
+
+
+class TestFoundByProbing:
+    """Four findings from an adversarial pass over this endpoint.
+
+    None of them was reachable without a valid Stripe signature, which is the
+    argument for why they should never fire — not an argument for leaving them
+    open. The first three chain: a malformed id changes which object comes
+    back, and the object that comes back decides which guild gets written.
+    """
+
+    def test_every_body_is_capped_before_a_handler_sees_it(self, app):
+        """`request.content_length` is None on a chunked request.
+
+        A handler that checks it first sees None and then reads the whole body
+        into memory to measure it -- so the size check inside the webhook is
+        not the half that holds. Werkzeug's global cap is.
+        """
+        assert app.config["MAX_CONTENT_LENGTH"] is not None
+        assert app.config["MAX_CONTENT_LENGTH"] <= 1024 * 1024
+
+    @pytest.mark.parametrize(
+        "subscription_id",
+        [
+            "sub_x/../../v1/customers",
+            "sub_x?expand[]=customer",
+            "sub_x#fragment",
+            "sub_x/../charges",
+            "../v1/account",
+        ],
+    )
+    def test_a_malformed_subscription_id_never_reaches_the_api(
+        self, client, bot_api, stripe, subscription_id
+    ):
+        """That value is interpolated into an API URL a moment later.
+
+        A `/` or a `?` turns a read of one subscription into a request for
+        something else entirely.
+        """
+        response = post(client, make_event(make_subscription(subscription_id=subscription_id)))
+        assert response.status_code == 200
+        assert stripe.reads == []
+        assert bot_api.forwarded == []
+
+    def test_the_api_client_refuses_a_bad_id_on_its_own(self):
+        """Checked where the URL is built, as well as by the caller.
+
+        Neither check is load-bearing alone, which is the point.
+        """
+        from dashboard.stripe_api import StripeClient
+
+        with pytest.raises(StripeAPIError):
+            StripeClient("sk_test_x").get_subscription("sub_x/../../v1/customers")
+
+    def test_a_mismatched_subscription_is_refused(self, client, bot_api, stripe):
+        """We asked about one subscription; anything else means the request did
+        not go where this code believes it went.
+
+        Without this, a read that landed on a different object would be written
+        to whichever guild *that* object names.
+        """
+        stripe.current = make_subscription(
+            subscription_id="sub_SOMEONE_ELSE", guild_id="222222222222"
+        )
+        response = post(client, make_event(make_subscription(subscription_id="sub_TEST")))
+        assert response.status_code == 503
+        assert bot_api.forwarded == []
+
+    @pytest.mark.parametrize("position", ["prepend", "append"])
+    def test_a_second_timestamp_is_refused(self, client, bot_api, position):
+        """Stripe sends exactly one `t`.
+
+        Several is a broken sender or someone probing which one this believes,
+        and whichever answer it gave would be arbitrary. Neither ordering can
+        forge a signature -- the timestamp is inside the signed string -- but a
+        parser with an opinion nobody chose is not one to keep.
+        """
+        body = json.dumps(make_event()).encode()
+        good = sign(body)
+        stale = f"t={int(time.time()) - 100000}"
+        header = (
+            f"{stale},{good}" if position == "prepend" else f"{good},{stale}"
+        )
+        response = post(client, body=body, header=header)
+        assert response.status_code == 400
+        assert bot_api.forwarded == []
+
+    def test_a_replay_inside_the_window_is_safe(self, client, bot_api):
+        """A captured webhook replayed within the 5-minute tolerance verifies
+        again -- and must be harmless.
+
+        Idempotency is the bot's job, keyed on the event id, and this pins that
+        the dashboard forwards the identical event id rather than minting
+        something new that would defeat it.
+        """
+        body = json.dumps(make_event()).encode()
+        header = sign(body)
+        assert post(client, body=body, header=header).status_code == 200
+        assert post(client, body=body, header=header).status_code == 200
+        assert len(bot_api.forwarded) == 2
+        assert bot_api.forwarded[0][1]["event_id"] == bot_api.forwarded[1][1]["event_id"]
+
+
+# -------------------------------------------------------------------
+# Configuration
+# -------------------------------------------------------------------
+class TestConfiguration:
+    """Refuse to boot rather than come up half-configured.
+
+    A dashboard missing its webhook secret rejects every event Stripe sends and
+    looks healthy doing it. One missing a price id renders a plan card that
+    500s when somebody clicks Buy.
+    """
+
+    def base_env(self, tmp_path, certs):
+        return {
+            "DISCORD_CLIENT_ID": "1",
+            "DISCORD_CLIENT_SECRET": "s",
+            "OAUTH_REDIRECT_URI": "https://d.example.com/callback",
+            "DASHBOARD_SECRET_KEY": SECRET_KEY,
+            "BOT_API_TOKEN_SIGNING_KEY": SIGNING_KEY,
+            "BOT_API_URL": "https://10.0.0.1:5002",
+            "BOT_API_CLIENT_CERT": str(certs / "client.pem"),
+            "BOT_API_CLIENT_KEY": str(certs / "client.key"),
+            "BOT_API_CA": str(certs / "ca.pem"),
+            "SESSION_DB_PATH": str(tmp_path / "s.db"),
+        }
+
+    def stripe_env(self):
+        return {
+            "STRIPE_ENABLED": "1",
+            "STRIPE_SECRET_KEY": STRIPE_KEY,
+            "STRIPE_WEBHOOK_SECRET": WEBHOOK_SECRET,
+            "STRIPE_PRICE_MONTHLY": PRICE_MONTHLY,
+            "STRIPE_PRICE_SIX_MONTHS": PRICE_SIX,
+            "STRIPE_PRICE_YEARLY": PRICE_YEARLY,
+        }
+
+    def build(self, monkeypatch, tmp_path, certs, **overrides):
+        env = self.base_env(tmp_path, certs)
+        env.update(overrides)
+        for key in (
+            "STRIPE_ENABLED",
+            "STRIPE_SECRET_KEY",
+            "STRIPE_WEBHOOK_SECRET",
+            "STRIPE_PRICE_MONTHLY",
+            "STRIPE_PRICE_SIX_MONTHS",
+            "STRIPE_PRICE_YEARLY",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+        return DashboardConfig.from_env()
+
+    def test_stripe_off_needs_no_stripe_config(self, monkeypatch, tmp_path, certs):
+        """The whole feature ships dormant. Nothing may be required to boot."""
+        config = self.build(monkeypatch, tmp_path, certs)
+        assert config.stripe_enabled is False
+        assert config.stripe_secret_key == ""
+
+    def test_stripe_on_needs_everything(self, monkeypatch, tmp_path, certs):
+        config = self.build(monkeypatch, tmp_path, certs, **self.stripe_env())
+        assert config.stripe_enabled is True
+        assert config.stripe_prices["six_months"] == PRICE_SIX
+
+    @pytest.mark.parametrize(
+        "missing",
+        [
+            "STRIPE_SECRET_KEY",
+            "STRIPE_WEBHOOK_SECRET",
+            "STRIPE_PRICE_MONTHLY",
+            "STRIPE_PRICE_SIX_MONTHS",
+            "STRIPE_PRICE_YEARLY",
+        ],
+    )
+    def test_a_missing_value_refuses_to_boot(
+        self, monkeypatch, tmp_path, certs, missing
+    ):
+        env = self.stripe_env()
+        env.pop(missing)
+        with pytest.raises(DashboardConfigError):
+            self.build(monkeypatch, tmp_path, certs, **env)
+
+    def test_a_publishable_key_is_refused(self, monkeypatch, tmp_path, certs):
+        """pk_ here would fail every call, at the worst possible moment."""
+        env = self.stripe_env()
+        env["STRIPE_SECRET_KEY"] = "pk_test_" + "x" * 24
+        with pytest.raises(DashboardConfigError):
+            self.build(monkeypatch, tmp_path, certs, **env)
+
+    def test_an_api_key_as_the_webhook_secret_is_refused(
+        self, monkeypatch, tmp_path, certs
+    ):
+        """The signing secret and the API key are different things that both
+        look like opaque strings. Confusing them rejects every event."""
+        env = self.stripe_env()
+        env["STRIPE_WEBHOOK_SECRET"] = STRIPE_KEY
+        with pytest.raises(DashboardConfigError):
+            self.build(monkeypatch, tmp_path, certs, **env)
+
+    def test_two_plans_on_one_price_is_refused(self, monkeypatch, tmp_path, certs):
+        """Someone pays for six months and is billed monthly, or the reverse.
+        Cheap to check, expensive to discover from a customer."""
+        env = self.stripe_env()
+        env["STRIPE_PRICE_YEARLY"] = PRICE_MONTHLY
+        with pytest.raises(DashboardConfigError):
+            self.build(monkeypatch, tmp_path, certs, **env)
+
+    def test_an_unknown_price_has_no_plan_but_is_not_an_error(
+        self, monkeypatch, tmp_path, certs
+    ):
+        """None means "we cannot label this", never "not subscribed".
+
+        A price can be missing from the table for ordinary reasons -- a plan
+        switched in the portal, an id rotated between test and live -- and the
+        subscription is real either way.
+        """
+        config = self.build(monkeypatch, tmp_path, certs, **self.stripe_env())
+        assert config.plan_for(PRICE_SIX) == "six_months"
+        assert config.plan_for("price_who_knows") is None
+
+
+# -------------------------------------------------------------------
+# The pure module, directly
+# -------------------------------------------------------------------
+class TestPureHelpers:
+    def test_verify_accepts_its_own_signature(self):
+        body = b'{"hello":"world"}'
+        stripe_events.verify_signature(
+            body, sign(body), WEBHOOK_SECRET, now=time.time()
+        )
+
+    def test_verify_is_tolerant_within_the_window_and_not_outside_it(self):
+        body = b"{}"
+        stamp = time.time() - 299
+        stripe_events.verify_signature(
+            body, sign(body, timestamp=stamp), WEBHOOK_SECRET, now=time.time()
+        )
+        with pytest.raises(stripe_events.SignatureError):
+            stripe_events.verify_signature(
+                body,
+                sign(body, timestamp=time.time() - 301),
+                WEBHOOK_SECRET,
+                now=time.time(),
+            )
+
+    def test_price_id_comes_from_the_first_line_item(self):
+        assert (
+            stripe_events.price_id_from(make_subscription(price_id="price_x"))
+            == "price_x"
+        )
+
+    def test_a_subscription_with_no_items_has_no_price(self):
+        subscription = make_subscription()
+        subscription["items"] = {"data": []}
+        assert stripe_events.price_id_from(subscription) is None
+
+    def test_an_expanded_customer_object_still_yields_an_id(self):
+        subscription = make_subscription(customer={"id": "cus_EXPANDED"})
+        payload = stripe_events.normalise(
+            subscription, event_id="evt_1", event_created=int(time.time())
+        )
+        assert payload["customer_id"] == "cus_EXPANDED"


### PR DESCRIPTION
Step 3 of #88: the Stripe webhook lands on the VPS, its signature is verified there, and a normalised summary is forwarded to the bot over the mTLS channel that already exists.

Registered only when the dashboard's own `STRIPE_ENABLED` is set, so until step 5 the path is a plain 404 — not a handler trusted to decline. Nothing can be bought yet; there is still no UI.

## Why this one needs a careful read

**This is the first public, unauthenticated inbound route this project has ever had.** Everything else on that host is reached by a browser holding a session. This is reached by a third party holding a signature.

So the order of operations in the handler *is* the security design: budget → size → **signature → parse**. Reversed, our JSON parser runs on an unknown party's bytes before anything has established they may send us anything at all. There is a test that sends unparseable JSON with a *bad* signature and requires the answer to name the signature — if it ever names the parse failure, the ordering has regressed and that test is how you find out.

`/stripe/webhook` is deliberately not under `/guild/`, so no reviewer skimming the route list mistakes it for a session-authenticated one.

## What's here

- **`stripe_events.py`** — pure. No Flask, no network, no clock (`now` is passed in). Signature verification, event routing, normalisation. Every HMAC in the tests is computed in the test; a mocked signature check proves the handler calls something, not that the something works.
- **`stripe_api.py`** — the one call this needs, `GET /v1/subscriptions/{id}`, over `requests`.
- **`POST /stripe/webhook`** in `app.py`, gated and rate limited.
- **`BotAPIClient.put_stripe_subscription`** — the only call in that client with no signed-in user behind it, minting the `SYSTEM_ACTOR_ID` token step 1 built.
- **`DashboardConfig`** — Stripe secrets and the three price ids, all required when the switch is on, refusing to boot otherwise.

**No Stripe SDK.** It would be a large dependency sitting next to a secret key on the box this project's threat model already assumes is compromised, to do fifteen lines of HMAC and one GET. Recorded here rather than left as an omission.

## Current state, not the event's snapshot

The webhook fetches the subscription from Stripe rather than trusting what the event carries. That is the fix for the same-second problem step 1 left open and documented: `event.created` has one-second resolution, so two events for one subscription in the same second are indistinguishable in age and the bot's ordering guard drops the second one.

Fetching means whichever delivery *does* apply carries current truth, so a dropped sibling costs nothing. It also means a redelivery three days later writes today's state rather than the state when the event fired. Subscribing only to `customer.subscription.*` keeps same-second pairs rare to begin with — a checkout emits `checkout.session.completed`, `customer.subscription.created` and `invoice.paid` within the same second, and we act on one of them.

## The response codes are the retry contract

Stripe retries a non-2xx for up to three days, which comfortably covers a bot restart, a Tailscale blip or a homelab power cut.

| Situation | Code | Why |
| --- | --- | --- |
| Bad/missing/expired signature | 400 | Nothing forwarded, reason logged, response says nothing useful |
| Body too large | 413 | Nothing legitimate is |
| Rate limited | 429 | Stripe treats it as retry — cost of a burst is delay, never loss |
| Not an event we act on | **200** | 400 here turns a checkbox in the Stripe dashboard into a three-day retry storm |
| No `guild_id` in metadata | **200** | Retrying will not add metadata that was never set — this is a Checkout Session built wrong, and the log is where it surfaces |
| Stripe unreachable | 503 | Retry |
| Bot unreachable or refusing | 503 | Retry. **200 here is the one outcome that loses a paid subscription permanently**, and it does not exist in this handler |

## Data handling

The guild comes from `subscription.metadata`, never the checkout session's `client_reference_id` — the reference id is on the session, so it is there for the first event and gone by the first renewal, while metadata rides along for the life of the subscription.

No email, no name, no payment method, no address crosses the wire. Checkout collects an email and Stripe keeps it; mirroring customer PII into the one database in this project holding Discord-to-VRChat identity links, to power a page that says "manage billing in the portal", would be a poor trade. The customer id travels because the billing portal needs it, and nothing else about the customer does.

## Adversarial pass before committing

Four findings, all fixed and pinned by tests. **None was reachable without a valid Stripe signature** — which is the argument for why they should never have fired, not for leaving them open. The first three chain.

1. **`MAX_CONTENT_LENGTH` was unset**, so the size check inside the handler was not the half that holds: a chunked request carries no `Content-Length`, and a handler measuring `request.content_length` first sees `None` and then reads the whole body into memory to find out. Now capped app-wide by Werkzeug before a handler sees anything.
2. **A subscription id from the event body went straight into an API URL.** `sub_x/../../v1/customers` reached the client. Now format-checked by the caller *and* again where the URL is built, because neither check should be load-bearing alone.
3. **Nothing verified that the subscription Stripe returned was the one we asked for.** Chained with (2), a redirected read would have been written to whichever guild *that* object named. Now refused loudly.
4. **A signature header carrying two `t` values** was resolved by an arbitrary last-wins rule. Neither ordering can forge a signature — the timestamp is inside the signed string — but a parser with an opinion nobody chose is not one to keep.

Recorded as **A-27** in `SECURITY_AUDIT.md` (gitignored, so not in this diff).

## Tests

72 new in `tests/test_stripe_webhook.py`. **1361 passed, 1 skipped** locally — A-23 still applies, nothing in CI runs pytest, so that is a human claim.

Signature: valid, tampered body, wrong secret, expired, future-dated, missing header, six malformed headers, multiple `v1` during a secret rotation, duplicate `t`, and the verify-before-parse ordering. Routing: each lifecycle event, ignored event types, no event id, no guild metadata, non-numeric guild. Fetching: current state wins over the event body, Stripe down is a 503, mismatched subscription refused. Payload: exact field set, nothing raw, no PII, real booleans, ISO UTC. Bounds: oversized body, burst, limiter not shared. Config: every missing value refuses boot, `pk_` refused, an API key as the webhook secret refused, duplicate prices refused, an unknown price is not an error.

## Before this can go live (step 2 / step 5, not this PR)

- **A-25's Cloudflare WAF skip rule for `/stripe/webhook`**, verified by a test-mode event actually reaching the origin. The hostname carries a managed challenge, Stripe is not a browser, and the failure is silent: Stripe sees 403, retries for three days, and nothing reaches the origin — so nothing appears in the application logs either. A customer would be charged and premium would never switch on.
- **Turn the bot's `STRIPE_ENABLED` on before the dashboard's.** The other order means checkout succeeds, the forward is answered 404 for three days, and premium never switches on. Written into `.env.example` on both sides.

Part of #88. Step 4 (the Subscriptions page) follows on its own branch.
