### PR TITLE
Make the deploy files describe the system that exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,7 +793,7 @@ Each component connects to RabbitMQ to exchange verification requests and result
   docker compose -f config/other_configs/docker-compose.yml up -d
 
   # Deployment: pin to the version you just pushed
-  VRCVERIFY_VERSION=2.3.2 docker compose -f config/other_configs/docker-compose.deploy.yml up -d
+  VRCVERIFY_VERSION=2.6.0 docker compose -f config/other_configs/docker-compose.deploy.yml up -d
   ```
 
   To tag and push images, optional helper scripts are provided:

--- a/README.md
+++ b/README.md
@@ -793,7 +793,7 @@ Each component connects to RabbitMQ to exchange verification requests and result
   docker compose -f config/other_configs/docker-compose.yml up -d
 
   # Deployment: pin to the version you just pushed
-  VRCVERIFY_VERSION=1.4.0 docker compose -f config/other_configs/docker-compose.deploy.yml up -d
+  VRCVERIFY_VERSION=2.3.2 docker compose -f config/other_configs/docker-compose.deploy.yml up -d
   ```
 
   To tag and push images, optional helper scripts are provided:

--- a/config/other_configs/docker-compose.dashboard.yml
+++ b/config/other_configs/docker-compose.dashboard.yml
@@ -2,7 +2,7 @@
 # that stays docker-compose.deploy.yml.
 #
 # Usage, on the VPS next to dashboard.env, cloudflared.env and certs/:
-#   VRCVERIFY_VERSION=2.3.2 docker compose -f docker-compose.dashboard.yml up -d
+#   VRCVERIFY_VERSION=2.6.0 docker compose -f docker-compose.dashboard.yml up -d
 #
 # Three properties this file exists to preserve, all easy to undo by accident:
 #

--- a/config/other_configs/docker-compose.dashboard.yml
+++ b/config/other_configs/docker-compose.dashboard.yml
@@ -4,6 +4,14 @@
 # Usage, on the VPS next to dashboard.env, cloudflared.env and certs/:
 #   VRCVERIFY_VERSION=2.6.0 docker compose -f docker-compose.dashboard.yml up -d
 #
+# This is a TEMPLATE. The deployed copy on the VPS is named docker-compose.yml,
+# so it drops the `-f` above, and it carries a header saying it is a copy of
+# this file. Those two lines are the only differences, and they should stay the
+# only two. Keep both in step -- the last drift between a template here and a
+# deployed copy on a box left a comment explaining a control that had been
+# wrong for months, because the edit was made on the server and nothing
+# reviewed it.
+#
 # Three properties this file exists to preserve, all easy to undo by accident:
 #
 # 1. NEITHER SERVICE PUBLISHES A PORT. cloudflared dials out to Cloudflare and

--- a/config/other_configs/docker-compose.dashboard.yml
+++ b/config/other_configs/docker-compose.dashboard.yml
@@ -2,9 +2,9 @@
 # that stays docker-compose.deploy.yml.
 #
 # Usage, on the VPS next to dashboard.env, cloudflared.env and certs/:
-#   VRCVERIFY_VERSION=2.3.0 docker compose -f docker-compose.dashboard.yml up -d
+#   VRCVERIFY_VERSION=2.3.2 docker compose -f docker-compose.dashboard.yml up -d
 #
-# Two properties this file exists to preserve, both easy to undo by accident:
+# Three properties this file exists to preserve, all easy to undo by accident:
 #
 # 1. NEITHER SERVICE PUBLISHES A PORT. cloudflared dials out to Cloudflare and
 #    reaches the dashboard over the Docker network by name. The host firewall
@@ -17,10 +17,36 @@
 #    bot for everything over mTLS. A full compromise of this box yields no
 #    route to the users table. Adding DATABASE_URL here would quietly discard
 #    the main reason the bot API exists.
+#
+#    It DOES hold Stripe's secret key and webhook signing secret, in
+#    dashboard.env (issue #88). That is the intended split and not a weakening
+#    of the point above: the worst those keys yield is Stripe's own dashboard
+#    for this account, which is money and not identities. The bot holds no
+#    Stripe credential at all, in either direction.
+#
+# 3. THE DASHBOARD NOW ANSWERS ONE PUBLIC, UNAUTHENTICATED ROUTE:
+#    POST /stripe/webhook, authenticated by Stripe's signature rather than by a
+#    session. It arrives through the same tunnel as everything else, so
+#    property 1 is unchanged — but the hostname's Cloudflare managed challenge
+#    has to be skipped for that one path, or Stripe is challenged, sees a 403,
+#    and retries for three days while NOTHING reaches this origin and nothing
+#    appears in these logs. That skip rule is SECURITY_AUDIT.md A-25, it is
+#    path-scoped and must never be hostname-wide, and it has to exist and be
+#    verified by a real test-mode event BEFORE STRIPE_ENABLED is set here.
+#
+#    With STRIPE_ENABLED unset the route is not registered at all — a plain
+#    404 — so this file is safe to deploy ahead of any of that.
 
 services:
   dashboard:
     image: italiandogs/vrcverify-dashboard:${VRCVERIFY_VERSION:?Set VRCVERIFY_VERSION to a pushed version tag (never latest)}
+    # Everything comes from dashboard.env, with no `environment:` block to keep
+    # in step with it. That includes the six Stripe variables (STRIPE_ENABLED,
+    # STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET and the three STRIPE_PRICE_*) --
+    # see .env.example. With STRIPE_ENABLED set the dashboard REFUSES TO BOOT
+    # if any of the other five is missing, which is deliberate: a webhook
+    # secret that is absent rejects every event Stripe sends while the service
+    # looks perfectly healthy doing it.
     env_file:
       - dashboard.env
     volumes:

--- a/config/other_configs/docker-compose.deploy.yml
+++ b/config/other_configs/docker-compose.deploy.yml
@@ -6,8 +6,8 @@
 # required; compose refuses to start without it.
 #
 # Usage (on the deploy host, next to your .env):
-#   VRCVERIFY_VERSION=2.3.2 docker compose -f docker-compose.deploy.yml up -d
-# or add VRCVERIFY_VERSION=2.3.2 to the .env file.
+#   VRCVERIFY_VERSION=2.6.0 docker compose -f docker-compose.deploy.yml up -d
+# or add VRCVERIFY_VERSION=2.6.0 to the .env file.
 #
 # This is a TEMPLATE, and the deployed copy on the homelab host differs from it
 # deliberately: there the dashboard API blocks at the bottom are uncommented,

--- a/config/other_configs/docker-compose.deploy.yml
+++ b/config/other_configs/docker-compose.deploy.yml
@@ -6,8 +6,15 @@
 # required; compose refuses to start without it.
 #
 # Usage (on the deploy host, next to your .env):
-#   VRCVERIFY_VERSION=1.4.0 docker compose -f docker-compose.deploy.yml up -d
-# or add VRCVERIFY_VERSION=1.4.0 to the .env file.
+#   VRCVERIFY_VERSION=2.3.2 docker compose -f docker-compose.deploy.yml up -d
+# or add VRCVERIFY_VERSION=2.3.2 to the .env file.
+#
+# This is a TEMPLATE, and the deployed copy on the homelab host differs from it
+# deliberately: there the dashboard API blocks at the bottom are uncommented,
+# because that host runs the API. Keep the two in step when either changes --
+# the last drift between them left a comment on the server telling the reader
+# to leave the API switched off, months after it went live, and nothing caught
+# it because the edit was made on the box rather than here.
 
 services:
   discord-bot:
@@ -39,6 +46,20 @@ services:
       BOT_API_CLIENT_CN: ${BOT_API_CLIENT_CN:-}
       BOT_API_TOKEN_SIGNING_KEY: ${BOT_API_TOKEN_SIGNING_KEY:-}
       BOT_API_ADMIN_TTL: ${BOT_API_ADMIN_TTL:-15}
+      # Card subscriptions (issue #88). Unset by default, so the bot never
+      # reads the stripe_subscription table and never registers the API route
+      # that writes it -- premium keeps coming from Discord entitlements alone.
+      #
+      # NOTE: no Stripe credential appears here and none ever should.
+      # STRIPE_SECRET_KEY and STRIPE_WEBHOOK_SECRET belong to the dashboard on
+      # the VPS. This host reads a table that the dashboard fills in over
+      # mTLS, which is the whole of Stripe's presence on the homelab.
+      #
+      # Turn this on BEFORE the dashboard's own STRIPE_ENABLED. The other
+      # order means a customer completes checkout, is charged, and the forward
+      # is answered 404 until Stripe gives up three days later.
+      STRIPE_ENABLED: ${STRIPE_ENABLED:-}
+      STRIPE_STATUS_TTL: ${STRIPE_STATUS_TTL:-900}
     restart: unless-stopped
     # Docker's json-file driver does not rotate by default, so container logs
     # grow without bound until the disk does. Especially worth having here:
@@ -51,6 +72,11 @@ services:
         max-file: "3"
     #
     # TURNING THE API ON ALSO NEEDS THE TWO LINES BELOW UNCOMMENTED.
+    # The production homelab host runs with them uncommented, and has since
+    # 2026-08-13. They are commented HERE because this is the template: a
+    # self-hoster with no dashboard needs neither, and host networking would
+    # actively break them if DATABASE_URL or RABBITMQ_HOST names a container
+    # rather than a host address.
     #
     # There is deliberately no `ports:` mapping, and there should never be one.
     # A bridged container cannot bind the host's tailnet address, so the usual

--- a/config/other_configs/docker-compose.yml
+++ b/config/other_configs/docker-compose.yml
@@ -1,4 +1,8 @@
-version: "3.9"
+# Local build compose. Produces all three images; only two are meant to run
+# here (see the dashboard service at the bottom).
+#
+# No `version:` key: Compose v2 ignores it and warns that it is obsolete on
+# every single invocation. The other two files in this directory never had one.
 
 services:
   discord-bot:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,4 +44,20 @@ os.environ["PREMIUM_GRANDFATHER_MAX_ID"] = ""
 # directly, which is the honest way to ask for one.
 os.environ["DASHBOARD_URL"] = ""
 
+# Third time, same problem, same fix -- and this one was found the hard way.
+# STRIPE_ENABLED went in with #88 step 1 and was not pinned here, so the moment
+# a developer switched it on in their own .env, load_dotenv() carried it into
+# bot.py at import and every kill-switch test in test_stripe.py went red on a
+# file git has never seen. CI would have stayed green, which is the worse half:
+# the suite would disagree with itself depending on whose machine ran it.
+#
+# Note this covers the dashboard's copy of the switch too. Nothing under
+# src/dashboard/ calls load_dotenv, but bot.py does, and importing bot puts
+# whatever .env says into os.environ for everything that runs afterwards.
+#
+# Tests that want Stripe on set bot.STRIPE_ENABLED directly (see the stripe_on
+# fixture), which is the honest way to ask for it.
+os.environ["STRIPE_ENABLED"] = ""
+os.environ["STRIPE_STATUS_TTL"] = ""
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))


### PR DESCRIPTION
Housekeeping that turned up one real bug. Split out from #88 because none of it is feature work.

## Why

Fixing a stale comment on the homelab host — one telling the reader to leave the dashboard API switched off, months after it went live — turned up that the repo's compose templates had drifted from the deployment they document. That comment existed *only* on the server, which is the tell: it was written on the box, so nothing reviewed it and nothing carried it back.

## What changed

**`docker-compose.deploy.yml`** — says plainly that it is a template, that the deployed copy differs, and which way: production runs with the API blocks uncommented and this file does not, because a self-hoster with no dashboard needs neither and host networking would actively break them if `DATABASE_URL` or `RABBITMQ_HOST` names a container rather than a host address. Gains `STRIPE_ENABLED` and `STRIPE_STATUS_TTL` next to the `BOT_API_*` block — both already reached the container via `env_file`, so this is documentation rather than plumbing, but that block is where every other knob is explained. The note says what must never appear there: no Stripe credential belongs on the homelab in either direction.

**`docker-compose.dashboard.yml`** — preserved two properties, now three. The new one is that this host answers a public, unauthenticated route (`POST /stripe/webhook`, authenticated by Stripe's signature, not a session). It arrives through the same tunnel so "no service publishes a port" is untouched — but the hostname's managed challenge must be skipped for that one path, or Stripe is challenged, sees 403, and retries for three days while nothing reaches the origin and nothing appears in the logs. That is **A-25**, and this file is now where someone deploying meets it. Property 2 also gains the honest correction that the dashboard *does* hold Stripe's keys: the intended split, since the worst they yield is money rather than identities.

**`docker-compose.yml`** — drops the obsolete `version:` key, which Compose v2 ignores while warning about on every invocation. The other two never had one.

**Version examples** — 1.4.0 → 2.3.2 in the deploy file and the README, 2.3.0 → 2.3.2 in the dashboard file.

## The bug

The suite went red while none of the above could have caused it.

`STRIPE_ENABLED` shipped in step 1 without being pinned in `conftest.py`. The moment it was switched on in a local `.env`, `load_dotenv()` carried it into `bot.py` at import and every kill-switch test in `test_stripe.py` failed — on the contents of a file git has never seen.

CI would have stayed green, which is the worse half: the suite would disagree with itself depending on whose machine ran it. `conftest.py` already documents this exact trap twice (`PREMIUM_GRANDFATHER_MAX_ID`, `DASHBOARD_URL`) and now does a third time, with the note that this one was found the hard way rather than anticipated.

Worth reading as one more argument for A-23 — though note CI would *not* have caught this one, since CI has no `.env` at all. What catches it is pinning the variable, which is what this does.

**1361 passed, 1 skipped**, with `STRIPE_ENABLED=1` set locally — which is the condition that was failing.

## Not in this PR

`VPS_RUNBOOK.md` still has no Stripe section. That is step 5 of #88, along with the README's own Stripe documentation.