### PR TITLE
Fill in the page that takes the money

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -1396,10 +1396,17 @@ def load_stripe_subscription(guild_id):
     cache exists to keep the *gate* cheap, and borrowing it here would mean
     either caching five more values or answering with a stale renewal date.
 
-    No customer id and no email leave this function. The page has nothing to do
-    with either — billing details are managed on Stripe's own domain, in the
-    portal — and shipping an id the website does not need across the wire is
-    how it ends up in a log on the internet-facing box.
+    The customer id DOES leave here, and an earlier version of this docstring
+    argued it should not. That was wrong, for two reasons found while building
+    the page: opening Stripe's billing portal requires a customer id, so the
+    website genuinely needs it to offer the one action a subscriber wants; and
+    withholding it buys nothing anyway, because the dashboard holds a Stripe
+    secret key and can enumerate customers with or without our help.
+
+    No **email** leaves here, and that still holds. Checkout collects one and
+    Stripe keeps it; mirroring it would put customer PII in the one database
+    that links Discord accounts to VRChat identities, to power a page whose
+    answer is "manage billing in the portal".
     """
     if not STRIPE_ENABLED:
         return None
@@ -1412,6 +1419,7 @@ def load_stripe_subscription(guild_id):
                     StripeSubscription.price_id,
                     StripeSubscription.current_period_end,
                     StripeSubscription.cancel_at_period_end,
+                    StripeSubscription.stripe_customer_id,
                 )
                 .filter_by(server_id=panel_view_key(guild_id))
                 .all()
@@ -1439,6 +1447,8 @@ def load_stripe_subscription(guild_id):
             )
             return {
                 "status": row.status,
+                # Needed to open Stripe's billing portal, and nothing else.
+                "customer_id": row.stripe_customer_id,
                 # The price id, not a plan name. Turning it into the words
                 # "6 months" needs the slug table, which is dashboard config
                 # precisely because test and live mode have different ids --
@@ -5020,6 +5030,20 @@ async def read_dashboard_settings(guild_id) -> Optional[dict]:
     try:
         flags = await resolve_premium_flags(guild_id)
 
+        # Which of the two sources is live, resolved separately for this
+        # payload only. The gate itself short-circuits on the Discord answer
+        # and is right to -- it does not care *why* a server is premium. The
+        # Subscriptions page does: without this it cannot tell "paying by card"
+        # from "paying by card AND through Discord", and the double-billing
+        # warning the whole feature promises would be unbuildable.
+        #
+        # Both reads are cache hits here, because resolve_premium_flags above
+        # has just taken them, so this costs nothing on the hot path -- and
+        # nothing at all when the tier is off.
+        discord_premium = (
+            await guild_has_premium(guild_id) if PREMIUM_ENFORCED else True
+        )
+
         # Same guard /vrcverify_settings uses: the column post-dates some
         # deployments and a missing one must not break the whole read.
         has_auto_verify = server_has_column("auto_verify_new_members")
@@ -5087,6 +5111,13 @@ async def read_dashboard_settings(guild_id) -> Optional[dict]:
                 # dashboard offers no upgrade at all, which is correct -- there
                 # is nothing to sell when every gate answers "allowed".
                 "sku_id": str(PREMIUM_SKU_ID) if PREMIUM_SKU_ID is not None else None,
+                # Whether the DISCORD half alone grants premium. Not a second
+                # gate for the website to OR -- `premium` above stays the one
+                # answer to "is this server premium". This exists so the
+                # Subscriptions page can tell a card subscriber from someone
+                # paying on both platforms, which is the difference between a
+                # normal page and a "you are being billed twice" warning.
+                "discord": discord_premium,
             },
             # Why the answer above is what it is, for the half of it Discord
             # cannot explain. `premium.premium` stays the single answer to "is
@@ -5107,6 +5138,7 @@ async def read_dashboard_settings(guild_id) -> Optional[dict]:
                 "cancel_at_period_end": bool(
                     (subscription or {}).get("cancel_at_period_end")
                 ),
+                "customer_id": (subscription or {}).get("customer_id"),
                 # More than one means the server is paying twice. The page
                 # warns and links to the portal; nothing anywhere cancels or
                 # refunds on anyone's behalf.

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -64,7 +64,13 @@ from flask import (
 )
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-from dashboard import oauth, overview_view, settings_view, stripe_events
+from dashboard import (
+    oauth,
+    overview_view,
+    settings_view,
+    stripe_events,
+    subscription_view,
+)
 from dashboard.botapi import BotAPIClient, BotAPIError
 from dashboard.config import DashboardConfig
 from dashboard.sessions import SessionStore
@@ -295,6 +301,13 @@ def _bot_api() -> BotAPIClient:
     return current_app.config["BOT_API"]
 
 
+def _stripe() -> StripeClient:
+    """Only ever reached from routes that already checked stripe_enabled."""
+    from flask import current_app
+
+    return current_app.config["STRIPE"]
+
+
 def _register_hooks(app: Flask) -> None:
     @app.before_request
     def load_session():
@@ -498,26 +511,176 @@ def _register_routes(app: Flask) -> None:
 
     @app.get("/guild/<int:guild_id>/subscription")
     def guild_subscription(guild_id: int):
-        """Placeholder for the subscriptions section.
+        """One server's plan, and the two ways to buy it.
 
-        It calls the bot before rendering, which looks like a wasted round trip
-        for a page with nothing on it -- and is the point. An unauthorised
-        visitor must get the same answer here as they would from the other two
-        sections, or this becomes the one route that tells them whether a guild
-        exists. It costs one call on a page nobody reloads.
+        The bot decides everything this page states. It reports whether the
+        tier is enforced, whether the server is premium, whether that came from
+        Discord, and what the mirrored card subscription says -- and this route
+        renders that. It never works out for itself whether a server has paid,
+        because a second opinion about the premium gate is a second thing that
+        can disagree with the one doing the enforcing.
+
+        A failed read is an apology, never "not subscribed". That rule exists
+        everywhere on this site and bites hardest here: "not subscribed" beside
+        a Buy button is how a paying customer buys a second subscription.
         """
         session = _require_login()
         if session is None:
             return redirect(url_for("index"))
 
+        config = _config()
         try:
-            _bot_api().settings(int(session.discord_id), guild_id)
+            settings = _bot_api().settings(int(session.discord_id), guild_id)
         except BotAPIError as error:
             return _guild_page_unavailable(error, guild_id, session, "subscription")
 
-        return render_template(
-            "subscription.html", **_guild_chrome(session, guild_id, "subscription")
+        # Stripe bounces the browser back here after a completed checkout.
+        # A hint, never evidence of payment -- the webhook is what makes a
+        # subscription real and may not have landed yet -- but the page must
+        # not offer to sell again while that is outstanding.
+        just_bought = bool(request.args.get("bought"))
+        page = subscription_view.build(
+            settings,
+            application_id=config.discord_client_id,
+            plan_slug=config.plan_for(
+                ((settings.get("stripe") or {}).get("price_id")) or ""
+            ),
+            stripe_configured=config.stripe_enabled,
+            just_bought=just_bought,
         )
+        notice, notice_kind = _subscription_notice(session)
+        if notice is None and just_bought and page.state == "pending":
+            notice, notice_kind = SUBSCRIPTION_NOTICES["bought"]
+        # csrf_token comes from _guild_chrome, like every other page here.
+        return render_template(
+            "subscription.html",
+            page=page,
+            notice=notice,
+            notice_kind=notice_kind,
+            **_guild_chrome(session, guild_id, "subscription"),
+        )
+
+    @app.post("/guild/<int:guild_id>/subscription/checkout")
+    def subscription_checkout(guild_id: int):
+        """Start a hosted Checkout and hand the browser to Stripe.
+
+        THE PRICE ID IS NEVER TAKEN FROM THE FORM. The browser may name a plan
+        slug and nothing else; the id is looked up server-side. A form-supplied
+        price would let anyone check out against any price on the account,
+        including a $0 one created while testing, and it is the single most
+        likely way to get this endpoint wrong.
+
+        Administrator is re-checked by the bot on the settings read below --
+        the session proves who is asking, never what they may do -- and the
+        same read is what tells us whether this server should be offered a card
+        at all. Buying twice is prevented here as well as in the page: a POST
+        crafted by hand must not be able to reach checkout for a server that
+        already subscribes.
+        """
+        session = _require_login()
+        if session is None:
+            return redirect(url_for("index"))
+        if not _csrf_ok(session):
+            abort(400)
+
+        config = _config()
+        if not config.stripe_enabled:
+            abort(404)
+
+        slug = (request.form.get("plan") or "").strip()
+        price_id = config.stripe_prices.get(slug)
+        if not price_id:
+            logger.warning("checkout refused: unknown plan %r", slug)
+            return _subscription_redirect(session, guild_id, "error:plan")
+
+        try:
+            settings = _bot_api().settings(int(session.discord_id), guild_id)
+        except BotAPIError as error:
+            return _guild_page_unavailable(error, guild_id, session, "subscription")
+
+        page = subscription_view.build(
+            settings,
+            application_id=config.discord_client_id,
+            stripe_configured=True,
+        )
+        if not page.offers_card:
+            # The page would not have shown a Buy button in this state, so a
+            # request that reached here was not made by clicking one.
+            logger.warning(
+                "checkout refused for guild %s: page state is %s", guild_id, page.state
+            )
+            return _subscription_redirect(session, guild_id, "error:already")
+
+        base = url_for("guild_subscription", guild_id=guild_id, _external=True)
+        try:
+            checkout_url = _stripe().create_checkout_session(
+                price_id=price_id,
+                guild_id=str(guild_id),
+                actor_discord_id=str(session.discord_id),
+                success_url=f"{base}?bought=1",
+                cancel_url=base,
+            )
+        except StripeAPIError as error:
+            # The page apologises and offers the Discord path. It does not
+            # pretend to have created a session.
+            logger.warning("could not create a checkout session: %s", error)
+            return _subscription_redirect(session, guild_id, "error:stripe")
+
+        # 303 so the browser re-issues as GET. The CSP is untouched: the
+        # browser leaves rather than loading anything from Stripe here.
+        return redirect(checkout_url, code=303)
+
+    @app.post("/guild/<int:guild_id>/subscription/portal")
+    def subscription_portal(guild_id: int):
+        """Hand the admin to Stripe's billing portal.
+
+        Cancelling, switching plan and updating a card all happen on Stripe's
+        domain, and none of them is reimplemented here. That is not
+        convenience: every one is an action on somebody's money, and this is
+        the process the threat model assumes will be compromised.
+        """
+        session = _require_login()
+        if session is None:
+            return redirect(url_for("index"))
+        if not _csrf_ok(session):
+            abort(400)
+
+        config = _config()
+        if not config.stripe_enabled:
+            abort(404)
+
+        try:
+            settings = _bot_api().settings(int(session.discord_id), guild_id)
+        except BotAPIError as error:
+            return _guild_page_unavailable(error, guild_id, session, "subscription")
+
+        # The customer id comes from the bot's mirrored row, never from the
+        # form. A portal session names a customer, and a customer id a browser
+        # could choose would be a portal into somebody else's billing.
+        customer_id = (settings.get("stripe") or {}).get("customer_id")
+        if not customer_id:
+            return _subscription_redirect(session, guild_id, "error:portal")
+        # Checked here as well as where the URL is built. It arrives over mTLS
+        # from the bot, so this should never fire -- which is the argument for
+        # why it is cheap, not for leaving one of the two checks out.
+        if not stripe_events.valid_object_id(str(customer_id)):
+            logger.error(
+                "guild %s has a malformed Stripe customer id on file", guild_id
+            )
+            return _subscription_redirect(session, guild_id, "error:portal")
+
+        try:
+            portal_url = _stripe().create_portal_session(
+                customer_id=str(customer_id),
+                return_url=url_for(
+                    "guild_subscription", guild_id=guild_id, _external=True
+                ),
+            )
+        except StripeAPIError as error:
+            logger.warning("could not create a portal session: %s", error)
+            return _subscription_redirect(session, guild_id, "error:stripe")
+
+        return redirect(portal_url, code=303)
 
     @app.get("/guild/<int:guild_id>/settings")
     def guild_settings(guild_id: int):
@@ -1147,6 +1310,51 @@ def _save(guild_id: int, session, changes: dict):
 
     _store().set_notice(session.sid, "saved")
     return redirect(url_for("guild_settings", guild_id=guild_id))
+
+
+# What the Subscriptions page may say back to an admin after a POST, keyed so
+# nothing from a form or from Stripe reaches the page as text. Same discipline
+# as the panel results: a message is chosen from this table or not shown.
+SUBSCRIPTION_NOTICES = {
+    "bought": (
+        "Thanks — your subscription is being set up. Premium switches on as "
+        "soon as Stripe confirms the payment, usually within a few seconds.",
+        "ok",
+    ),
+    "plan": ("That plan isn't one we offer. Nothing has been charged.", "error"),
+    "already": (
+        "This server already has Premium, so there was nothing to buy. "
+        "Nothing has been charged.",
+        "error",
+    ),
+    "stripe": (
+        "We couldn't reach Stripe just now, so nothing has been charged. "
+        "Try again in a moment, or subscribe inside Discord instead.",
+        "error",
+    ),
+    "portal": (
+        "There's no card subscription on this server to manage.",
+        "error",
+    ),
+}
+
+
+def _subscription_redirect(session, guild_id: int, notice: str):
+    """Send the admin back to the page with one of the notices above."""
+    _store().set_notice(session.sid, f"subscription:{notice}")
+    return redirect(url_for("guild_subscription", guild_id=guild_id))
+
+
+def _subscription_notice(session):
+    """The pending notice for this page, as (message, kind)."""
+    raw = _store().take_notice(session.sid) or ""
+    if not raw.startswith("subscription:"):
+        return None, None
+    key = raw.partition(":")[2]
+    # `error:stripe` arrives as `error:stripe`; take the last segment.
+    key = key.rpartition(":")[2] or key
+    message = SUBSCRIPTION_NOTICES.get(key)
+    return message if message else (None, None)
 
 
 def _notice_arg(notice: Optional[str], kind: str) -> Optional[str]:

--- a/src/dashboard/static/style.css
+++ b/src/dashboard/static/style.css
@@ -781,3 +781,58 @@ select:focus-visible, textarea:focus-visible { outline-offset: 0; }
  * and being able to read it. Moving between Overview and Settings is something
  * an admin does repeatedly and impatiently, and a transition that is pleasant
  * once is friction the tenth time. Navigation is instant. */
+
+/* --- Subscriptions ------------------------------------------------------ *
+ * Three plan cards side by side, stacking on narrow screens. No colour is
+ * written inline anywhere on this page: `style-src 'self'` drops inline styles
+ * SILENTLY, so a swatch written as style="" would simply not apply and nothing
+ * would say so. */
+.plans {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+  margin: 1rem 0 0;
+}
+
+/* Each card is a form of its own, so the button posts one plan and the plan
+ * cannot be swapped between clicking and submitting. */
+.plan {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  background: var(--inset);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-control);
+}
+
+.plan h3 { font-size: 1rem; font-weight: 700; margin: 0; }
+
+/* Stated as a claim about the plan, never as arithmetic -- no amount appears
+ * anywhere in this repo. Stripe knows what it charges, and a second copy of a
+ * price on a page about money is a second thing to be wrong. */
+.plan-saving {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--ok);
+  font-weight: 500;
+}
+
+/* Keeps the three buttons on one baseline when only two plans have a saving. */
+.plan-saving-none { visibility: hidden; }
+
+.plan .button { margin-top: auto; align-self: stretch; }
+
+.plan-notes {
+  margin: 1rem 0 0;
+  padding-left: 1.1rem;
+  color: var(--muted);
+  font-size: 0.9375rem;
+}
+
+.plan-notes li { margin: 0.3rem 0; }
+
+@media (max-width: 40rem) {
+  .plans { grid-template-columns: 1fr; }
+}

--- a/src/dashboard/stripe_api.py
+++ b/src/dashboard/stripe_api.py
@@ -100,3 +100,102 @@ class StripeClient:
             "Stripe refused a subscription read: %s", response.status_code
         )
         raise StripeAPIError("Stripe refused the request", response.status_code)
+
+    def _post(self, path: str, form: list) -> dict:
+        """One form-encoded POST. Stripe's API is form-encoded, not JSON."""
+        try:
+            response = self._session.post(
+                f"{STRIPE_API_BASE}{path}",
+                headers=self._headers(),
+                data=form,
+                timeout=self.timeout,
+            )
+        except requests.RequestException as error:
+            raise StripeAPIError(f"could not reach Stripe: {error}") from error
+
+        if response.status_code in (200, 201):
+            try:
+                payload = response.json()
+            except ValueError as error:
+                raise StripeAPIError("Stripe returned an unreadable body") from error
+            if not isinstance(payload, dict):
+                raise StripeAPIError("Stripe returned an unexpected body")
+            return payload
+
+        logger.warning("Stripe refused %s: %s", path, response.status_code)
+        raise StripeAPIError("Stripe refused the request", response.status_code)
+
+    def create_checkout_session(
+        self,
+        *,
+        price_id: str,
+        guild_id: str,
+        actor_discord_id: str,
+        success_url: str,
+        cancel_url: str,
+    ) -> str:
+        """Start a hosted Checkout, and return the URL to send the browser to.
+
+        Hosted Checkout by redirect, never embedded Stripe.js. The dashboard's
+        CSP is `default-src 'none'` with `script-src 'self'`, and embedding
+        would mean permanently allowing js.stripe.com plus a frame-src -- a
+        relaxation of the tightest directive set in the app, on the one page
+        that handles money. A 303 needs no CSP change at all, because the
+        browser simply leaves. It also keeps card data off this infrastructure
+        entirely, which is what makes PCI scope SAQ-A.
+
+        `price_id` is looked up by the caller from a plan slug and is never
+        taken from the form. See the route.
+
+        The guild id goes into `subscription_data[metadata]`, not only
+        `client_reference_id`, and the difference matters more than it looks:
+        the reference id exists on the session and is gone by the first
+        renewal, while subscription metadata rides along with every
+        `customer.subscription.*` event for the life of the subscription. The
+        binding has to survive to a renewal a year from now.
+        """
+        form = [
+            ("mode", "subscription"),
+            ("line_items[0][price]", price_id),
+            ("line_items[0][quantity]", "1"),
+            ("client_reference_id", str(guild_id)),
+            ("subscription_data[metadata][guild_id]", str(guild_id)),
+            ("subscription_data[metadata][actor_discord_id]", str(actor_discord_id)),
+            ("success_url", success_url),
+            ("cancel_url", cancel_url),
+            # Tax is collected where it is due and is NOT included in the
+            # advertised price -- the prices are created tax-exclusive, and the
+            # plan cards say "+ tax" for that reason. Automatic tax refuses a
+            # price whose tax_behavior is unspecified, so a plan card that
+            # 500s here means a price was created wrong rather than a bug.
+            ("automatic_tax[enabled]", "true"),
+            # Required once automatic tax is on: without an address Stripe
+            # cannot decide a rate, and the session errors rather than guessing.
+            ("billing_address_collection", "required"),
+            ("customer_update[address]", "auto"),
+        ]
+        session = self._post("/checkout/sessions", form)
+        url = session.get("url")
+        if not isinstance(url, str) or not url.startswith("https://"):
+            raise StripeAPIError("Stripe returned no checkout URL")
+        return url
+
+    def create_portal_session(self, *, customer_id: str, return_url: str) -> str:
+        """Open Stripe's own billing portal for this customer.
+
+        Cancelling, switching plan and updating a card all happen on Stripe's
+        domain. That is deliberate and not laziness: every one of those is an
+        action on somebody's money, and the alternative is reimplementing them
+        against an API on the box this project assumes will eventually be
+        compromised.
+        """
+        if not stripe_events.valid_object_id(customer_id):
+            raise StripeAPIError("refusing to request a malformed customer id")
+        session = self._post(
+            "/billing_portal/sessions",
+            [("customer", customer_id), ("return_url", return_url)],
+        )
+        url = session.get("url")
+        if not isinstance(url, str) or not url.startswith("https://"):
+            raise StripeAPIError("Stripe returned no portal URL")
+        return url

--- a/src/dashboard/subscription_view.py
+++ b/src/dashboard/subscription_view.py
@@ -1,0 +1,322 @@
+"""Turns the bot's settings payload into the Subscriptions page. Pure.
+
+No Flask, no network, no clock — `now` arrives as an argument. That is what
+makes every state below testable without a request, which matters more here
+than anywhere else on the site: this is the page that takes money, and the
+difference between two of its states is the difference between showing a
+paying customer a Buy button and not.
+
+THE STATES, AND WHY THEY ARE NOT A BOOLEAN
+------------------------------------------
+`state` is what the template switches on, so adding one is a change here rather
+than a new branch scattered through the HTML:
+
+* ``off``          — Stripe is switched off in the bot. Discord path only.
+* ``unavailable``  — we could not read the plan. Never rendered as "not
+                     subscribed": "not subscribed" next to a Buy button is how
+                     a paying customer is sold a second subscription.
+* ``none``         — genuinely not subscribed. Plans and both buy paths.
+* ``discord``      — subscribed through Discord. No card buttons at all, which
+                     is half of what keeps double billing rare.
+* ``stripe``       — subscribed by card. Plan, renewal date, portal link.
+* ``past_due``     — subscribed by card, last payment failed. Premium is still
+                     on while Stripe retries. Not an error and not silence.
+* ``both``         — paying on both platforms. Warned, never auto-cancelled.
+* ``pending``      — Stripe has just bounced the browser back from checkout and
+                     the webhook has not landed yet. Offers no way to buy,
+                     because the alternative is three Buy buttons under a
+                     thank-you message.
+
+`grandfathered` rides alongside rather than being an eighth state, because it
+is orthogonal: a grandfathered server can be in any of the unsubscribed ones
+and the reassurance is the same.
+
+WHAT THIS MODULE MAY NOT DO
+---------------------------
+* **It never decides whether a server is premium.** `premium.premium` from the
+  bot is the single answer; the `stripe` block only explains *why*. Re-deriving
+  it here would create a second gate that can disagree with the enforcing one.
+* **It holds no prices.** Stripe knows what it charges. A second copy of an
+  amount on a page about money is a second thing to be wrong, which is the same
+  reasoning that keeps the Discord tier's price out of the bot and lets
+  Discord render its own label.
+* **It maps a price id to a plan, never the reverse.** The reverse direction is
+  a checkout concern and belongs where the form is handled.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+# The three plans, in the order they are offered. Slug, label, and the sentence
+# that justifies the longer terms existing at all.
+#
+# No amounts. The saving is stated as a claim about the plan rather than as
+# arithmetic this file could get out of step with Stripe.
+PLANS = (
+    ("monthly", "Monthly", None),
+    ("six_months", "6 months", "Save about 10%"),
+    ("yearly", "12 months", "Save about 20%"),
+)
+
+# What an unrecognised price id renders as.
+#
+# This will happen: a plan switched in the billing portal, a price replaced
+# during a pricing change, an id rotated between test and live. The
+# subscription is real and paid for and only the *label* is unknown, so it
+# degrades to this and never to "not subscribed" — which would switch off a
+# paying customer over a missing environment variable.
+UNKNOWN_PLAN_LABEL = "Premium"
+
+STORE_URL = "https://discord.com/application-directory/{app_id}/store/{sku_id}"
+
+
+class Plan:
+    """One purchasable plan. Attributes, because Jinja reads them cleanly."""
+
+    def __init__(self, slug: str, label: str, saving: Optional[str]):
+        self.slug = slug
+        self.label = label
+        self.saving = saving
+
+
+class SubscriptionPage:
+    def __init__(
+        self,
+        state: str,
+        *,
+        grandfathered: bool = False,
+        premium: bool = False,
+        plan_label: Optional[str] = None,
+        renews_on: Optional[str] = None,
+        ends_on: Optional[str] = None,
+        plans: tuple = (),
+        store_url: Optional[str] = None,
+        discord_command: bool = False,
+        on_discord: bool = False,
+        card_count: int = 0,
+        ended_on: Optional[str] = None,
+        last_plan_label: Optional[str] = None,
+    ):
+        self.state = state
+        self.grandfathered = grandfathered
+        self.premium = premium
+        self.plan_label = plan_label
+        # Exactly one of these is ever set. "Renews on" and "ends on" are
+        # different promises and a page that says the wrong one is a page
+        # lying about somebody's money.
+        self.renews_on = renews_on
+        self.ends_on = ends_on
+        self.plans = plans
+        self.store_url = store_url
+        self.discord_command = discord_command
+        # Which platforms are involved, for the double-billing notice. It has
+        # to name both, or an admin cannot tell which one to go and cancel.
+        self.on_discord = on_discord
+        self.card_count = card_count
+        # A subscription that has lapsed: when it ended and what it was.
+        self.ended_on = ended_on
+        self.last_plan_label = last_plan_label
+
+    @property
+    def offers_card(self) -> bool:
+        """Should the plan cards render?
+
+        Both halves are required, and the second is not redundant: with Stripe
+        switched off on either host the state is still `none` -- the server
+        genuinely has no subscription -- but there are no plans to show, and
+        checking only the state rendered an empty "Pay by card" section headed
+        by a promise the page could not keep.
+        """
+        return self.state == "none" and bool(self.plans)
+
+    @property
+    def offers_portal(self) -> bool:
+        """Is there a Stripe subscription to manage?"""
+        return self.state in {"stripe", "past_due", "both"}
+
+
+def _format_date(raw: Optional[str]) -> Optional[str]:
+    """An ISO instant as `3 February 2026`, or None.
+
+    Deliberately a date and not a time. Stripe's period end is a moment, but an
+    admin reading "renews on 3 February" and being charged a few hours either
+    side of midnight in their own timezone has been told the truth; rendering
+    an exact UTC timestamp would be precision the reader cannot use and would
+    invite "but it says 00:41" support questions.
+    """
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    # %-d is not portable to Windows, and this runs on Linux in production and
+    # under tests on Windows, so the day is trimmed by hand.
+    return f"{parsed.day} {parsed.strftime('%B %Y')}"
+
+
+def plan_label_for(price_id: Optional[str], plan_slug: Optional[str]) -> str:
+    """The words for a price id, degrading to a generic label.
+
+    `plan_slug` is what the dashboard's own price table made of the id, or None
+    when it recognised nothing. None is not an error — see UNKNOWN_PLAN_LABEL.
+    """
+    if plan_slug:
+        for slug, label, _saving in PLANS:
+            if slug == plan_slug:
+                return label
+    return UNKNOWN_PLAN_LABEL
+
+
+def build(
+    settings: Optional[dict],
+    *,
+    application_id: Optional[str],
+    plan_slug: Optional[str] = None,
+    stripe_configured: bool = True,
+    just_bought: bool = False,
+    now: Optional[datetime] = None,
+) -> SubscriptionPage:
+    """The whole page, from the bot's settings payload.
+
+    `settings` is None when the bot could not answer. That is its own state and
+    is never collapsed into "not subscribed" — the rule the settings page
+    already follows for a failed read, applied here with more force, because
+    the wrong answer on this page costs somebody money rather than a confusing
+    toggle.
+
+    `just_bought` is set when Stripe has bounced the browser back from a
+    completed checkout. It matters more than it sounds: the webhook that makes
+    the subscription real may not have landed yet, so the payload still says
+    "not subscribed" -- and rendering that literally would put three Buy
+    buttons directly under a thank-you message, at the one moment somebody has
+    demonstrably just paid. Found by probing the page rather than by reading
+    it.
+
+    `plan_slug` is the caller's lookup of the stored price id against its own
+    price table, passed in rather than looked up here so this module needs no
+    configuration. `stripe_configured` is the dashboard's own kill switch; the
+    bot's is read from the payload. Both must be on before a card is offered,
+    and they are separate switches on separate hosts on purpose.
+    """
+    if settings is None:
+        return SubscriptionPage("unavailable")
+
+    premium_block = settings.get("premium")
+    if not isinstance(premium_block, dict) or "enforced" not in premium_block:
+        # A payload without a premium block is not a payload saying "free" --
+        # it is one this page cannot read. Treating a missing `enforced` as
+        # falsy would render "every feature is available at no charge" to a
+        # server that may well be paying, which is the same class of lie as
+        # rendering a failed read as "not subscribed".
+        return SubscriptionPage("unavailable")
+    stripe_block = settings.get("stripe") or {}
+
+    enforced = bool(premium_block.get("enforced"))
+    premium = bool(premium_block.get("premium"))
+    grandfathered = bool(premium_block.get("grandfathered"))
+    sku_id = premium_block.get("sku_id")
+
+    store_url = (
+        STORE_URL.format(app_id=application_id, sku_id=sku_id)
+        if sku_id and application_id
+        else None
+    )
+
+    # The tier is switched off entirely: every gate answers "allowed", so there
+    # is nothing to sell and a page offering to sell it would be selling
+    # something already free.
+    if not enforced:
+        return SubscriptionPage("off", premium=True, grandfathered=grandfathered)
+
+    # Two switches on two hosts, and both must be on. The bot's says whether it
+    # would record a purchase; the dashboard's says whether it can take one.
+    # Offering a card when either is off sells something that cannot complete.
+    stripe_on = bool(stripe_block.get("enabled")) and stripe_configured
+    stripe_active = bool(stripe_block.get("active"))
+    status = stripe_block.get("status")
+    # More than one *card* subscription is its own double-billing case, and the
+    # only one the table can count directly.
+    card_count = int(stripe_block.get("active_count") or 0)
+    # Whether Discord alone grants premium. Sent explicitly by the bot rather
+    # than deduced here -- `premium` is an OR and deducing the halves from it
+    # is exactly the kind of second opinion that drifts.
+    discord = bool(premium_block.get("discord"))
+
+    period_end = _format_date(stripe_block.get("current_period_end"))
+    cancelling = bool(stripe_block.get("cancel_at_period_end"))
+    label = plan_label_for(stripe_block.get("price_id"), plan_slug)
+
+    # Exactly one of these is ever set, and they are different promises.
+    renews_on = None if cancelling else period_end
+    ends_on = period_end if cancelling else None
+
+    # Paying twice: on both platforms, or on two cards. Premium stays granted
+    # either way -- being double-billed must not also break something -- and
+    # the page warns rather than acting. Nothing anywhere cancels or refunds on
+    # a customer's behalf; that is a category of bug that costs real money in
+    # the wrong direction.
+    if (stripe_active and discord) or card_count > 1:
+        return SubscriptionPage(
+            "both",
+            premium=True,
+            grandfathered=grandfathered,
+            plan_label=label if stripe_active else None,
+            renews_on=renews_on,
+            ends_on=ends_on,
+            store_url=store_url,
+            discord_command=True,
+            on_discord=discord,
+            card_count=card_count,
+        )
+
+    if stripe_active:
+        return SubscriptionPage(
+            "past_due" if status == "past_due" else "stripe",
+            premium=True,
+            grandfathered=grandfathered,
+            plan_label=label,
+            renews_on=renews_on,
+            ends_on=ends_on,
+        )
+
+    if premium:
+        # Premium with no active card subscription means Discord. Deliberately
+        # no card buttons: offering one here is precisely how a server that
+        # already pays ends up paying twice.
+        return SubscriptionPage(
+            "discord",
+            premium=True,
+            grandfathered=grandfathered,
+            store_url=store_url,
+            discord_command=True,
+            on_discord=True,
+        )
+
+    if just_bought:
+        # Deliberately says nothing certain about payment. The checkout
+        # redirect is a hint, never evidence -- only the webhook is that -- so
+        # the copy promises a wait rather than a subscription, and offers no
+        # way to buy again while we cannot tell.
+        return SubscriptionPage(
+            "pending",
+            grandfathered=grandfathered,
+            store_url=store_url,
+        )
+
+    return SubscriptionPage(
+        "none",
+        grandfathered=grandfathered,
+        plans=tuple(Plan(*plan) for plan in PLANS) if stripe_on else (),
+        store_url=store_url,
+        discord_command=True,
+        # A lapsed subscription leaves its row behind on purpose, so the page
+        # can say when it ended rather than pretending the server was never a
+        # customer. Resubscribing is then a status change, not a re-onboarding.
+        ended_on=period_end if status else None,
+        last_plan_label=label if status else None,
+    )

--- a/src/dashboard/templates/settings.html
+++ b/src/dashboard/templates/settings.html
@@ -61,9 +61,15 @@
     <p class="notice">{{ save_error }}</p>
   {% endif %}
 
-  {# Buying happens inside Discord, never here. The store link cannot name a
-     server -- see settings_view.STORE_URL -- so the slash command leads, and
-     the link is offered as somewhere to read the details. #}
+  {# A pointer, not an offer. This block used to carry the whole upgrade pitch
+     and the Discord store link, which was right while Subscriptions was an
+     empty placeholder and there was one way to buy.
+
+     There are two ways now, and only one page can list both -- the 6- and
+     12-month plans are card-only, so a second copy of this pitch here could
+     never be more than partly true. Two places to buy, with two different sets
+     of options, is how the copy drifts apart; so buying lives on Subscriptions
+     and this says where that is. #}
   {% if upgrade %}
     <section class="upgrade">
       <h2>
@@ -75,25 +81,15 @@
       </h2>
       <p>
         {% if upgrade.grandfathered %}
-          Your grandfathered extras stay free whatever you decide. Premium adds
-          the settings marked below, a shorter wait between verifications, and
-          priority in the verification queue.
+          Your grandfathered extras stay free whatever you decide. Premium
+          unlocks the settings marked below.
         {% else %}
-          Unlocks the settings marked below, shortens the wait between
-          verifications, and moves this server up the verification queue. 18+
-          verification itself stays free.
+          Unlocks the settings marked below. 18+ verification itself stays free.
         {% endif %}
       </p>
       <p>
-        Run <code>/vrcverify_subscription</code> in this server to subscribe.
-        Discord handles the payment, and the command's button is already
-        pointed at this server.
-      </p>
-      <p class="muted">
-        <a href="{{ upgrade.store_url }}" rel="noopener noreferrer" target="_blank">
-          See what's included on Discord's store page</a> — it lists the price
-        and perks, but you choose the server during checkout, so use the command
-        above if you administer more than one.
+        <a href="{{ url_for('guild_subscription', guild_id=guild_id) }}">
+          See plans and subscribe</a>
       </p>
     </section>
   {% endif %}

--- a/src/dashboard/templates/subscription.html
+++ b/src/dashboard/templates/subscription.html
@@ -1,25 +1,228 @@
 {% extends "base.html" %}
 {% block title %}Subscriptions — {{ guild_name }} — VRCVerify{% endblock %}
 
+{# Every branch below switches on `page.state`, which subscription_view builds.
+   Adding a state is a change there and then here, rather than a condition
+   grown into an existing branch -- this is the page that takes money, and the
+   difference between two of its states is the difference between showing a
+   paying customer a Buy button and not.
+
+   No inline styles anywhere. `style-src 'self'` drops them SILENTLY, so a
+   colour written as style="" would simply not apply and nothing would say so.
+   Everything visual is a class in style.css. #}
+
 {% block content %}
-{# Deliberately empty. This section exists so the sidebar has no dead ends and
-   so the follow-up issue is a matter of filling a page rather than building a
-   route. Nothing about buying belongs here yet: purchases happen inside
-   Discord, and the Settings page already explains why (the store link cannot
-   name a server, so the slash command has to lead). #}
+{% if notice %}
+  <p class="notice{% if notice_kind == 'ok' %} ok{% endif %}">{{ notice }}</p>
+{% endif %}
+
 <section class="panel group">
   <h2>Subscriptions</h2>
-  <p class="muted blurb">
-    Managing VRCVerify Premium from the website is still being built. For now,
-    run <code>/vrcverify_subscription</code> in {{ guild_name }} — Discord
-    handles the payment, and the command's button is already pointed at the
-    right server.
-  </p>
-  <p class="muted">
-    Your current plan is shown at the top of
-    <a href="{{ url_for('guild_overview', guild_id=guild_id) }}">Overview</a>,
-    and the settings Premium unlocks are marked on
-    <a href="{{ url_for('guild_settings', guild_id=guild_id) }}">Settings</a>.
-  </p>
+
+  {% if page.state == 'unavailable' %}
+    {# Never "not subscribed". A failed read rendered as "you have no plan",
+       next to a Buy button, is how a paying customer buys a second one. #}
+    <p class="blurb">
+      We couldn't check this server's plan just now. Nothing here is missing —
+      the page simply can't say what's true yet. Try again in a moment.
+    </p>
+
+  {% elif page.state == 'off' %}
+    <p class="blurb">
+      Every VRCVerify feature is currently available to this server at no
+      charge. There's nothing to subscribe to.
+    </p>
+
+  {% elif page.state == 'pending' %}
+    {# Says nothing certain about payment. The checkout redirect is a hint and
+       only the webhook is evidence -- so this promises a wait, and offers no
+       way to buy again while we cannot tell. Without this branch the page
+       rendered three Buy buttons directly under the thank-you message, at the
+       one moment somebody has demonstrably just paid. #}
+    <p class="blurb">
+      Waiting for Stripe to confirm. Premium switches on by itself, usually
+      within a few seconds — reload this page in a moment.
+    </p>
+    <p class="muted">
+      If it hasn't switched on after a minute or two, nothing is lost: Stripe
+      keeps trying to reach us for up to three days, and the subscription takes
+      effect as soon as it gets through. Get in touch if it stays this way.
+    </p>
+
+  {% elif page.state == 'both' %}
+    {# Detected and warned, never auto-cancelled. Code that cancels a
+       subscription and issues a refund without a human deciding is a category
+       of bug that costs real money in the wrong direction. #}
+    <p class="notice">
+      This server looks like it's paying for Premium
+      {% if page.card_count > 1 %}
+        on {{ page.card_count }} separate card subscriptions.
+      {% else %}
+        twice — once by card and once through Discord.
+      {% endif %}
+      Premium is on and stays on; you're just being charged more than once.
+    </p>
+    <p class="blurb">
+      We won't cancel either one for you — that's your call, and getting it
+      wrong with someone else's money isn't a risk worth automating.
+    </p>
+    <ul class="plan-notes">
+      <li>
+        To cancel the card subscription, use <strong>Manage billing</strong>
+        below.
+      </li>
+      {% if page.on_discord %}
+        <li>
+          To cancel the Discord one, open <strong>User Settings →
+          Subscriptions</strong> in Discord, or run
+          <code>/vrcverify_subscription</code> in {{ guild_name }}.
+        </li>
+      {% endif %}
+    </ul>
+    {% if page.plan_label %}
+      <p class="muted">
+        Card plan: {{ page.plan_label }}{% if page.renews_on %}, renews on
+        {{ page.renews_on }}{% elif page.ends_on %}, ends on
+        {{ page.ends_on }}{% endif %}.
+      </p>
+    {% endif %}
+
+  {% elif page.state == 'past_due' %}
+    {# An honest banner. Not an error, and not silence. #}
+    <p class="notice">
+      Your last payment didn't go through. Premium is still on while Stripe
+      retries the card — update your card details under
+      <strong>Manage billing</strong> below.
+    </p>
+    <p class="blurb">
+      Current plan: <strong>{{ page.plan_label }}</strong>{% if page.renews_on %},
+      due to renew on {{ page.renews_on }}{% endif %}.
+    </p>
+
+  {% elif page.state == 'stripe' %}
+    <p class="blurb">
+      This server has <strong>VRCVerify Premium</strong> on the
+      <strong>{{ page.plan_label }}</strong> plan, paid by card.
+    </p>
+    {% if page.ends_on %}
+      <p class="muted">
+        Cancelled — Premium stays on until <strong>{{ page.ends_on }}</strong>,
+        the end of the period you've already paid for.
+      </p>
+    {% elif page.renews_on %}
+      <p class="muted">Renews on <strong>{{ page.renews_on }}</strong>.</p>
+    {% endif %}
+
+  {% elif page.state == 'discord' %}
+    <p class="blurb">
+      This server has <strong>VRCVerify Premium</strong>, bought through
+      Discord.
+    </p>
+    <p class="muted">
+      Discord handles the billing, so cancelling or changing the payment method
+      happens there — <strong>User Settings → Subscriptions</strong>. We can't
+      manage a Discord subscription from here.
+    </p>
+    {# Deliberately no card buttons. Offering one to a server that already pays
+       is precisely how it ends up paying twice. #}
+
+  {% else %}
+    <p class="blurb">
+      18+ verification is free and always will be. Premium unlocks the settings
+      marked on <a href="{{ url_for('guild_settings', guild_id=guild_id) }}">Settings</a>,
+      shortens the wait between verifications, and moves this server up the
+      verification queue.
+    </p>
+    {% if page.grandfathered %}
+      <p class="muted">
+        Your grandfathered extras — unverified-role removal, nickname sync and
+        the custom verification message — stay free whatever you decide here.
+      </p>
+    {% endif %}
+    {% if page.ended_on %}
+      <p class="muted">
+        Your previous {{ page.last_plan_label }} subscription ended on
+        {{ page.ended_on }}. Subscribing again picks up where it left off.
+      </p>
+    {% endif %}
+  {% endif %}
 </section>
+
+{% if page.offers_card %}
+  <section class="panel group">
+    <h2>Pay by card</h2>
+    <p class="blurb muted">
+      Prices are in US dollars and <strong>exclude tax</strong>; any tax due
+      where you are is added at checkout. Payment is handled by Stripe — card
+      details never reach VRCVerify.
+    </p>
+    <div class="plans">
+      {% for plan in page.plans %}
+        <form class="plan" method="post"
+              action="{{ url_for('subscription_checkout', guild_id=guild_id) }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+          {# The browser names a PLAN, never a price. The price id is looked up
+             server-side; a form-supplied one would let anyone check out
+             against any price on the account. #}
+          <input type="hidden" name="plan" value="{{ plan.slug }}">
+          <h3>{{ plan.label }}</h3>
+          {% if plan.saving %}
+            <p class="plan-saving">{{ plan.saving }}</p>
+          {% else %}
+            <p class="plan-saving plan-saving-none">&nbsp;</p>
+          {% endif %}
+          <button class="button" type="submit">Subscribe</button>
+        </form>
+      {% endfor %}
+    </div>
+    <ul class="plan-notes">
+      <li>All plans renew automatically. Cancel any time from this page.</li>
+      <li>
+        <strong>The 6- and 12-month plans are card-only.</strong> Discord
+        subscriptions bill monthly, so those terms can't be offered there.
+      </li>
+    </ul>
+  </section>
+{% endif %}
+
+{% if page.offers_portal %}
+  <section class="panel group">
+    <h2>Manage billing</h2>
+    <p class="blurb muted">
+      Change plan, update your card or cancel — on Stripe's own billing portal.
+      You'll come straight back here afterwards.
+    </p>
+    <form method="post"
+          action="{{ url_for('subscription_portal', guild_id=guild_id) }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+      <button class="button" type="submit">Manage billing</button>
+    </form>
+  </section>
+{% endif %}
+
+{% if page.discord_command %}
+  <section class="panel group">
+    <h2>Buy inside Discord</h2>
+    {% if page.state == 'none' %}
+      <p class="blurb">
+        Run <code>/vrcverify_subscription</code> in {{ guild_name }}. Discord
+        handles the payment, and the command's button is already pointed at
+        this server. Monthly only, at the same price as the monthly plan above.
+      </p>
+    {% else %}
+      <p class="blurb">
+        Run <code>/vrcverify_subscription</code> in {{ guild_name }} to see this
+        server's Discord subscription.
+      </p>
+    {% endif %}
+    {% if page.store_url %}
+      <p class="muted">
+        <a href="{{ page.store_url }}" rel="noopener noreferrer" target="_blank">
+          See what's included on Discord's store page</a> — it lists the price
+        and perks, but you choose the server during checkout, so use the command
+        above if you administer more than one.
+      </p>
+    {% endif %}
+  </section>
+{% endif %}
 {% endblock %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1101,30 +1101,33 @@ class TestPlanBadgesMirrorTheBot:
 
 
 class TestTheUpgradeOffer:
-    """Buying is Discord's flow, and the page has to say so accurately.
+    """Settings points at Subscriptions; it does not sell anything itself.
 
-    The store URL takes an application and a SKU only, so it cannot name the
-    server being configured. For a guild-scoped SKU that is the difference
-    between subscribing this server and subscribing another one the admin also
-    runs, which is why /vrcverify_subscription leads and the link explains
-    itself rather than being presented as the buy button.
+    This block used to carry the whole pitch and the Discord store link, which
+    was right while Subscriptions was a placeholder and there was one way to
+    buy. There are two now, and the 6- and 12-month plans are card-only -- so a
+    copy of the pitch here could never be more than partly true, and two places
+    to buy with two different option sets is how copy drifts apart.
     """
 
-    def test_a_free_server_is_told_how_to_subscribe(self, config, store):
+    def test_a_free_server_is_pointed_at_the_subscriptions_page(self, config, store):
         test_client, _api = settings_client(config, store)
         page = test_client.get(f"/guild/{GUILD_IN}/settings").data.decode()
         assert "Upgrade to VRCVerify Premium" in page
-        assert "/vrcverify_subscription" in page
-        assert (
-            f"https://discord.com/application-directory/"
-            f"{config.discord_client_id}/store/{SKU_ID}" in page
-        )
+        assert f"/guild/{GUILD_IN}/subscription" in page
 
-    def test_the_store_link_admits_it_cannot_pick_the_server(self, config, store):
-        """The whole reason the slash command is the primary path."""
+    def test_settings_no_longer_sells_anything_itself(self, config, store):
+        """The pitch lives in exactly one place now.
+
+        Both halves matter: no purchase instructions here, and no store link
+        either -- otherwise the page that cannot mention the longer plans is
+        still the one an admin reads about buying.
+        """
         test_client, _api = settings_client(config, store)
         page = test_client.get(f"/guild/{GUILD_IN}/settings").data.decode()
-        assert "you choose the server during checkout" in page
+        assert "/vrcverify_subscription" not in page
+        assert "application-directory" not in page
+        assert "you choose the server during checkout" not in page
 
     def test_a_subscribed_server_is_not_sold_to(self, config, store):
         test_client, _api = settings_client(
@@ -1147,7 +1150,7 @@ class TestTheUpgradeOffer:
         page = test_client.get(f"/guild/{GUILD_IN}/settings").data.decode()
         assert "Add VRCVerify Premium" in page
         assert "grandfathered extras stay free" in page
-        assert "/vrcverify_subscription" in page
+        assert f"/guild/{GUILD_IN}/subscription" in page
 
     def test_no_offer_when_the_tier_is_switched_off(self, config, store):
         """PREMIUM_SKU_ID unset: every gate answers "allowed", so there is
@@ -2791,19 +2794,35 @@ class TestEverySectionFailsTheSameWay:
         assert test_client.get(f"/guild/{GUILD_IN}{suffix}").status_code == 503
 
 
-class TestTheSubscriptionPlaceholder:
+class TestTheSubscriptionPage:
+    """Reachability only. Every page STATE is pinned in test_subscription_page.
+
+    These two stay here because they are about the route existing and about the
+    sidebar not leading to a dead end, which is this file's concern.
+    """
+
     def test_it_renders(self, config, store):
         test_client, _api = settings_client(config, store)
         response = test_client.get(f"/guild/{GUILD_IN}/subscription")
         assert response.status_code == 200
         assert b"Subscriptions" in response.data
 
-    def test_it_offers_no_way_to_buy_anything(self, config, store):
-        """Purchases happen in Discord. This page must not grow a store link
-        before the follow-up issue decides what belongs here."""
+    def test_the_discord_path_is_offered_when_stripe_is_switched_off(
+        self, config, store
+    ):
+        """With no Stripe configured this page IS the old placeholder's job,
+        done properly: the Discord route, and no card anywhere.
+
+        Note the store link now belongs here rather than on Settings -- this is
+        the page about buying, and it is the only one that can describe both
+        ways to do it.
+        """
         test_client, _api = settings_client(config, store)
         page = test_client.get(f"/guild/{GUILD_IN}/subscription").data.decode()
-        assert "application-directory" not in page
+        assert "/vrcverify_subscription" in page
+        assert "application-directory" in page
+        assert "Pay by card" not in page
+        assert "/subscription/checkout" not in page
 
 
 class TestTheSidebar:
@@ -3125,7 +3144,27 @@ class TestWriteSurface:
             # test_the_nav_preference_never_reaches_the_bot pins that it does
             # not.
             "/prefs/nav",
+            # The two that spend money, or end a subscription. Neither writes
+            # anything here: each creates a session on Stripe and hands the
+            # browser over, so the whole of what they can do is bounded by what
+            # Stripe's hosted pages allow.
+            "/guild/<int:guild_id>/subscription/checkout",
+            "/guild/<int:guild_id>/subscription/portal",
         }, f"an unexpected write route appeared: {posts}"
+
+    def test_the_stripe_webhook_is_not_in_that_list_unless_switched_on(self, app):
+        """The public route is registered by config, so the pin above only
+        describes a dashboard with Stripe off -- which is what `app` is.
+
+        Worth its own assertion: if the webhook ever appeared in a default app,
+        the kill switch would have stopped meaning anything.
+        """
+        posts = {
+            rule.rule
+            for rule in app.url_map.iter_rules()
+            if "POST" in (rule.methods or set())
+        }
+        assert "/stripe/webhook" not in posts
 
     def test_every_group_that_saves_names_a_route_that_exists(self, app, config):
         """A typo in `save_endpoint` would be a 500 on page load, not a test."""

--- a/tests/test_stripe.py
+++ b/tests/test_stripe.py
@@ -934,13 +934,35 @@ class TestTheSettingsPayload:
         assert payload["stripe"]["status"] == "canceled"
         assert payload["stripe"]["active"] is False
 
-    def test_no_customer_id_ever_crosses_the_wire(self, enforced, stripe_on):
-        """The website has no use for it, and shipping it is how it ends up in
-        a log on the internet-facing box."""
+    def test_the_customer_id_is_shipped_because_the_portal_needs_it(
+        self, enforced, stripe_on
+    ):
+        """An earlier version of this test asserted the opposite, and was wrong.
+
+        Opening Stripe's billing portal requires a customer id, so the website
+        genuinely needs it to offer the one action a subscriber wants -- and
+        withholding it bought nothing anyway, since the dashboard holds a
+        Stripe secret key and can enumerate customers with or without our help.
+        """
         make_server()
         store_subscription()
         payload = run(bot.read_dashboard_settings(GUILD_ID))
-        assert CUSTOMER not in repr(payload)
+        assert payload["stripe"]["customer_id"] == CUSTOMER
+
+    def test_no_email_ever_crosses_the_wire(self, enforced, stripe_on):
+        """This is the part that did not change.
+
+        Checkout collects an email and Stripe keeps it. Mirroring it would put
+        customer PII in the one database linking Discord accounts to VRChat
+        identities, to power a page whose answer is "manage billing in the
+        portal".
+        """
+        make_server()
+        store_subscription()
+        payload = run(bot.read_dashboard_settings(GUILD_ID))
+        rendered = repr(payload).lower()
+        assert "email" not in rendered
+        assert "@" not in rendered
 
     def test_an_unreadable_table_refuses_the_whole_read(
         self, enforced, stripe_on, monkeypatch

--- a/tests/test_subscription_page.py
+++ b/tests/test_subscription_page.py
@@ -1,0 +1,635 @@
+"""Unit tests for the Subscriptions page (issue #88, step 4).
+
+The page that takes money, so the tests are mostly about the ways it can say
+something untrue about somebody's subscription:
+
+- a failed read must never render as "not subscribed", because "not
+  subscribed" beside a Buy button is how a paying customer buys a second one
+- a server that already pays must be shown no way to pay again, in the page AND
+  in the route, because a hand-crafted POST is not a click
+- the price id is never taken from the form; the browser may name a plan slug
+  and nothing else
+- "renews on" and "ends on" are different promises and the page must not
+  confuse them
+- an unrecognised price is a labelling problem, never a payment problem
+
+`subscription_view` is pure, so every state below is built without Flask, a
+clock or a network, which is the whole point of that split.
+"""
+
+import json
+import time
+
+import pytest
+
+pytest.importorskip("flask")
+
+from dashboard import subscription_view  # noqa: E402
+from dashboard.app import SESSION_COOKIE, create_app  # noqa: E402
+from dashboard.botapi import BotAPIError  # noqa: E402
+from dashboard.config import DashboardConfig  # noqa: E402
+from dashboard.sessions import SessionStore  # noqa: E402
+from dashboard.stripe_api import StripeAPIError  # noqa: E402
+
+APP_ID = "1335738139825799188"
+SKU_ID = "1533325058573865051"
+GUILD = "111111111111"
+ACTOR = "424242424242"
+
+SIGNING_KEY = "s" * 48
+SECRET_KEY = "k" * 48
+PRICE_MONTHLY = "price_monthly"
+PRICE_SIX = "price_six"
+PRICE_YEARLY = "price_yearly"
+CUSTOMER = "cus_TEST"
+
+FUTURE = "2026-11-03T00:00:00+00:00"
+PAST = "2026-02-03T00:00:00+00:00"
+
+
+# -------------------------------------------------------------------
+# Payloads
+# -------------------------------------------------------------------
+def payload(
+    *,
+    enforced=True,
+    premium=False,
+    discord=False,
+    grandfathered=False,
+    stripe_enabled=True,
+    active=False,
+    status=None,
+    price_id=PRICE_MONTHLY,
+    period_end=FUTURE,
+    cancel=False,
+    active_count=0,
+    customer_id=CUSTOMER,
+):
+    return {
+        "guild_id": GUILD,
+        "premium": {
+            "enforced": enforced,
+            "premium": premium,
+            "grandfathered": grandfathered,
+            "sku_id": SKU_ID,
+            "discord": discord,
+        },
+        "stripe": {
+            "enabled": stripe_enabled,
+            "active": active,
+            "status": status,
+            "price_id": price_id,
+            "current_period_end": period_end,
+            "cancel_at_period_end": cancel,
+            "active_count": active_count,
+            "customer_id": customer_id,
+        },
+        "fields": {},
+    }
+
+
+def build(settings, **kwargs):
+    kwargs.setdefault("application_id", APP_ID)
+    return subscription_view.build(settings, **kwargs)
+
+
+# -------------------------------------------------------------------
+# The states
+# -------------------------------------------------------------------
+class TestTheStates:
+    def test_a_failed_read_is_its_own_state(self):
+        """Never "not subscribed", and this is the most important line here.
+
+        The API turns a failed read into None. Rendering that as "you have no
+        plan" -- next to three Buy buttons -- is how somebody who is already
+        paying buys a second subscription.
+        """
+        page = build(None)
+        assert page.state == "unavailable"
+        assert page.offers_card is False
+        assert page.offers_portal is False
+
+    def test_the_tier_being_off_sells_nothing(self):
+        """Every gate answers "allowed", so there is nothing to sell."""
+        page = build(payload(enforced=False))
+        assert page.state == "off"
+        assert page.offers_card is False
+
+    def test_not_subscribed_offers_both_paths(self):
+        page = build(payload())
+        assert page.state == "none"
+        assert page.offers_card is True
+        assert [plan.slug for plan in page.plans] == [
+            "monthly",
+            "six_months",
+            "yearly",
+        ]
+        assert page.discord_command is True
+        assert page.store_url.endswith(f"/{APP_ID}/store/{SKU_ID}")
+
+    def test_subscribed_by_card(self):
+        page = build(
+            payload(premium=True, active=True, status="active", price_id=PRICE_SIX),
+            plan_slug="six_months",
+        )
+        assert page.state == "stripe"
+        assert page.plan_label == "6 months"
+        assert page.renews_on == "3 November 2026"
+        assert page.ends_on is None
+        assert page.offers_portal is True
+        assert page.offers_card is False
+
+    def test_subscribed_by_discord(self):
+        """No card buttons at all. Offering one to a server that already pays
+        is precisely how it ends up paying twice."""
+        page = build(payload(premium=True, discord=True))
+        assert page.state == "discord"
+        assert page.offers_card is False
+        assert page.offers_portal is False
+        assert page.on_discord is True
+
+    def test_past_due_is_its_own_state(self):
+        """Premium is still on while Stripe retries. Not an error, not silence.
+
+        A boolean could not express this, which is why the bot stores Stripe's
+        status verbatim.
+        """
+        page = build(
+            payload(premium=True, active=True, status="past_due"),
+            plan_slug="monthly",
+        )
+        assert page.state == "past_due"
+        assert page.premium is True
+        assert page.offers_portal is True
+        assert page.offers_card is False
+
+    def test_paying_on_both_platforms_is_warned_not_fixed(self):
+        page = build(
+            payload(premium=True, discord=True, active=True, status="active",
+                    active_count=1),
+            plan_slug="monthly",
+        )
+        assert page.state == "both"
+        assert page.premium is True
+        assert page.on_discord is True
+        # Premium stays granted: being double-billed must not also break
+        # something.
+        assert page.offers_card is False
+        assert page.offers_portal is True
+
+    def test_two_card_subscriptions_is_also_double_billing(self):
+        """The case the table can count directly, and only because it keys by
+        subscription rather than by guild."""
+        page = build(
+            payload(premium=True, active=True, status="active", active_count=2),
+            plan_slug="monthly",
+        )
+        assert page.state == "both"
+        assert page.card_count == 2
+        assert page.on_discord is False
+
+    def test_grandfathered_and_unsubscribed(self):
+        page = build(payload(grandfathered=True))
+        assert page.state == "none"
+        assert page.grandfathered is True
+        assert page.offers_card is True
+
+    def test_grandfathering_rides_alongside_every_state(self):
+        """It is orthogonal, not an eighth state -- the reassurance is the same
+        whichever way the server is or is not paying."""
+        page = build(payload(premium=True, active=True, status="active",
+                             grandfathered=True))
+        assert page.state == "stripe"
+        assert page.grandfathered is True
+
+
+class TestFoundByProbing:
+    """Findings from an adversarial pass over the page, before it merged."""
+
+    def test_just_bought_offers_no_way_to_buy_again(self):
+        """The worst moment for a Buy button, and it was there.
+
+        Stripe bounces the browser back the instant checkout completes, but the
+        webhook that makes the subscription real may not have landed -- so the
+        payload still says "not subscribed" and the page rendered three Buy
+        buttons directly under a thank-you message, to somebody who had
+        demonstrably just paid.
+        """
+        page = build(payload(), just_bought=True)
+        assert page.state == "pending"
+        assert page.offers_card is False
+        assert page.plans == ()
+
+    def test_just_bought_never_claims_the_payment_succeeded(self):
+        """The redirect is a hint. Only the webhook is evidence."""
+        page = build(payload(), just_bought=True)
+        assert page.premium is False
+
+    def test_a_confirmed_subscription_ignores_the_hint(self):
+        """Once the webhook HAS landed, the real state wins."""
+        page = build(
+            payload(premium=True, active=True, status="active"),
+            plan_slug="monthly",
+            just_bought=True,
+        )
+        assert page.state == "stripe"
+
+    @pytest.mark.parametrize(
+        "settings",
+        [
+            {},
+            {"premium": {}},
+            {"premium": {"premium": True}},
+            {"stripe": {"enabled": True}},
+        ],
+    )
+    def test_a_payload_without_a_premium_block_is_unavailable(self, settings):
+        """Not "everything is free".
+
+        A missing `enforced` read as falsy rendered "every feature is available
+        at no charge" to a server that may well be paying -- the same class of
+        lie as rendering a failed read as "not subscribed".
+        """
+        assert build(settings).state == "unavailable"
+
+
+class TestTheKillSwitches:
+    """Two switches on two hosts, and both must be on to offer a card."""
+
+    def test_the_bots_switch_off_hides_the_cards(self):
+        page = build(payload(stripe_enabled=False))
+        assert page.state == "none"
+        assert page.plans == ()
+        assert page.offers_card is False
+        # The Discord path is still offered -- that is the whole page in this
+        # configuration, and it is a complete answer rather than a stub.
+        assert page.discord_command is True
+
+    def test_the_dashboards_switch_off_hides_the_cards(self):
+        page = build(payload(), stripe_configured=False)
+        assert page.offers_card is False
+
+    def test_offers_card_needs_plans_and_not_just_the_state(self):
+        """Found by a failing template test rather than by reading the code.
+
+        With Stripe off the state is still `none` -- the server genuinely has
+        no subscription -- so checking only the state rendered an empty "Pay by
+        card" section headed by a promise the page could not keep.
+        """
+        page = build(payload(stripe_enabled=False))
+        assert page.state == "none" and not page.plans
+        assert page.offers_card is False
+
+
+class TestDatesAndLabels:
+    def test_cancelled_says_ends_on_not_renews_on(self):
+        """Different promises. Saying the wrong one is lying about money."""
+        page = build(
+            payload(premium=True, active=True, status="active", cancel=True),
+            plan_slug="monthly",
+        )
+        assert page.ends_on == "3 November 2026"
+        assert page.renews_on is None
+
+    def test_a_lapsed_subscription_says_when_it_ended(self):
+        """The row survives on purpose, so the page can say this rather than
+        pretend the server was never a customer."""
+        page = build(
+            payload(status="canceled", period_end=PAST, price_id=PRICE_YEARLY),
+            plan_slug="yearly",
+        )
+        assert page.state == "none"
+        assert page.ended_on == "3 February 2026"
+        assert page.last_plan_label == "12 months"
+
+    def test_an_unknown_price_still_reads_as_premium(self):
+        """A price absent from the table is a LABEL problem, never a payment
+        problem. Degrading to "not subscribed" would switch off a paying
+        customer over a missing environment variable."""
+        page = build(
+            payload(premium=True, active=True, status="active",
+                    price_id="price_WHO_KNOWS"),
+            plan_slug=None,
+        )
+        assert page.state == "stripe"
+        assert page.plan_label == subscription_view.UNKNOWN_PLAN_LABEL
+        assert page.premium is True
+
+    @pytest.mark.parametrize("raw", [None, "", "not-a-date", 12345])
+    def test_an_unreadable_date_is_omitted_not_guessed(self, raw):
+        page = build(
+            payload(premium=True, active=True, status="active", period_end=raw),
+            plan_slug="monthly",
+        )
+        assert page.renews_on is None
+        assert page.ends_on is None
+
+    def test_no_amount_appears_anywhere_in_the_module(self):
+        """Stripe knows what it charges.
+
+        A second copy of a price on a page about money is a second thing to be
+        wrong, and it would be wrong silently -- the page would keep rendering
+        the old number long after Stripe charged a new one.
+        """
+        source = open(subscription_view.__file__, encoding="utf-8").read()
+        for amount in ("4.99", "26.99", "47.99", "$"):
+            assert amount not in source
+
+
+# -------------------------------------------------------------------
+# The routes
+# -------------------------------------------------------------------
+@pytest.fixture
+def certs(tmp_path):
+    for name in ("client.pem", "client.key", "ca.pem"):
+        (tmp_path / name).write_text("placeholder")
+    return tmp_path
+
+
+@pytest.fixture
+def config(tmp_path, certs):
+    return DashboardConfig(
+        discord_client_id=APP_ID,
+        discord_client_secret="secret",
+        oauth_redirect_uri="https://d.example.com/callback",
+        secret_key=SECRET_KEY,
+        session_db_path=str(tmp_path / "sessions.db"),
+        bot_api_url="https://10.0.0.1:5002",
+        bot_api_client_cert=str(certs / "client.pem"),
+        bot_api_client_key=str(certs / "client.key"),
+        bot_api_ca=str(certs / "ca.pem"),
+        bot_api_signing_key=SIGNING_KEY.encode(),
+        stripe_enabled=True,
+        stripe_secret_key="sk_test_x",
+        stripe_webhook_secret="whsec_" + "w" * 32,
+        stripe_prices={
+            "monthly": PRICE_MONTHLY,
+            "six_months": PRICE_SIX,
+            "yearly": PRICE_YEARLY,
+        },
+    )
+
+
+class FakeBotAPI:
+    def __init__(self, settings=None):
+        self._settings = settings if settings is not None else payload()
+        self.error = None
+
+    def settings(self, actor_id, guild_id):
+        if self.error is not None:
+            raise self.error
+        return self._settings
+
+    def admin_guild_ids(self, actor_id, guild_ids):
+        return {GUILD}
+
+
+class FakeStripe:
+    def __init__(self):
+        self.checkouts = []
+        self.portals = []
+        self.error = None
+
+    def create_checkout_session(self, **kwargs):
+        self.checkouts.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return "https://checkout.stripe.com/c/pay/session_TEST"
+
+    def create_portal_session(self, **kwargs):
+        self.portals.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return "https://billing.stripe.com/p/session/portal_TEST"
+
+
+def make_client(config, settings=None):
+    store = SessionStore(config.session_db_path, config.session_max_age)
+    bot_api = FakeBotAPI(settings)
+    stripe = FakeStripe()
+    app = create_app(config, store=store, client=bot_api, stripe=stripe)
+    app.config.update(TESTING=True)
+    client = app.test_client()
+
+    pending = store.begin_login("unused-state")
+    session = store.complete_login(
+        pending.sid,
+        ACTOR,
+        [{"id": GUILD, "name": "Alpha", "icon": None, "admin_hint": True}],
+    )
+    client.set_cookie(SESSION_COOKIE, session.sid, domain="localhost")
+    return client, bot_api, stripe, session
+
+
+class TestCheckout:
+    def test_a_plan_slug_becomes_a_price_server_side(self, config):
+        """THE most likely way to get this endpoint wrong.
+
+        A form-supplied price id would let anyone check out against any price
+        on the account, including a $0 one created while testing.
+        """
+        client, _bot, stripe, session = make_client(config)
+        response = client.post(
+            f"/guild/{GUILD}/subscription/checkout",
+            data={"plan": "six_months", "csrf_token": session.csrf_token},
+        )
+        assert response.status_code == 303
+        assert response.headers["Location"].startswith("https://checkout.stripe.com/")
+        assert stripe.checkouts[0]["price_id"] == PRICE_SIX
+
+    def test_a_raw_price_id_in_the_form_is_refused(self, config):
+        client, _bot, stripe, session = make_client(config)
+        response = client.post(
+            f"/guild/{GUILD}/subscription/checkout",
+            data={"plan": PRICE_MONTHLY, "csrf_token": session.csrf_token},
+        )
+        assert response.status_code == 302
+        assert stripe.checkouts == []
+
+    @pytest.mark.parametrize("plan", ["", "free", "MONTHLY", "../monthly", None])
+    def test_an_unknown_plan_buys_nothing(self, config, plan):
+        client, _bot, stripe, session = make_client(config)
+        data = {"csrf_token": session.csrf_token}
+        if plan is not None:
+            data["plan"] = plan
+        response = client.post(f"/guild/{GUILD}/subscription/checkout", data=data)
+        assert response.status_code == 302
+        assert stripe.checkouts == []
+
+    def test_no_csrf_token_buys_nothing(self, config):
+        client, _bot, stripe, _session = make_client(config)
+        response = client.post(
+            f"/guild/{GUILD}/subscription/checkout", data={"plan": "monthly"}
+        )
+        assert response.status_code == 400
+        assert stripe.checkouts == []
+
+    def test_a_server_that_already_pays_cannot_check_out(self, config):
+        """Pinned in the ROUTE, not only in the page.
+
+        The page hides the button, but a hand-crafted POST is not a click, and
+        this is the request that would charge somebody twice.
+        """
+        client, _bot, stripe, session = make_client(
+            config, settings=payload(premium=True, active=True, status="active")
+        )
+        response = client.post(
+            f"/guild/{GUILD}/subscription/checkout",
+            data={"plan": "monthly", "csrf_token": session.csrf_token},
+        )
+        assert response.status_code == 302
+        assert stripe.checkouts == []
+
+    def test_a_discord_subscriber_cannot_check_out_either(self, config):
+        client, _bot, stripe, session = make_client(
+            config, settings=payload(premium=True, discord=True)
+        )
+        client.post(
+            f"/guild/{GUILD}/subscription/checkout",
+            data={"plan": "monthly", "csrf_token": session.csrf_token},
+        )
+        assert stripe.checkouts == []
+
+    def test_the_guild_is_bound_into_subscription_metadata(self, config):
+        """It has to survive to a renewal a year from now, which
+        client_reference_id does not."""
+        client, _bot, stripe, session = make_client(config)
+        client.post(
+            f"/guild/{GUILD}/subscription/checkout",
+            data={"plan": "monthly", "csrf_token": session.csrf_token},
+        )
+        assert stripe.checkouts[0]["guild_id"] == GUILD
+        assert stripe.checkouts[0]["actor_discord_id"] == ACTOR
+
+    def test_stripe_being_down_apologises_rather_than_pretending(self, config):
+        client, _bot, stripe, session = make_client(config)
+        stripe.error = StripeAPIError("boom")
+        response = client.post(
+            f"/guild/{GUILD}/subscription/checkout",
+            data={"plan": "monthly", "csrf_token": session.csrf_token},
+        )
+        assert response.status_code == 302
+        page = client.get(f"/guild/{GUILD}/subscription").data.decode()
+        # Substring without the apostrophe: the notice is a template variable
+        # and Jinja escapes it, so "couldn't" arrives as "couldn&#39;t".
+        assert "reach Stripe just now" in page
+        assert "nothing has been charged" in page.lower()
+
+    def test_the_route_404s_when_stripe_is_switched_off(self, tmp_path, certs):
+        off = DashboardConfig(
+            discord_client_id=APP_ID,
+            discord_client_secret="secret",
+            oauth_redirect_uri="https://d.example.com/callback",
+            secret_key=SECRET_KEY,
+            session_db_path=str(tmp_path / "s2.db"),
+            bot_api_url="https://10.0.0.1:5002",
+            bot_api_client_cert=str(certs / "client.pem"),
+            bot_api_client_key=str(certs / "client.key"),
+            bot_api_ca=str(certs / "ca.pem"),
+            bot_api_signing_key=SIGNING_KEY.encode(),
+        )
+        client, _bot, stripe, session = make_client(off)
+        response = client.post(
+            f"/guild/{GUILD}/subscription/checkout",
+            data={"plan": "monthly", "csrf_token": session.csrf_token},
+        )
+        assert response.status_code == 404
+        assert stripe.checkouts == []
+
+
+class TestPortal:
+    def test_it_opens_for_a_subscriber(self, config):
+        client, _bot, stripe, session = make_client(
+            config, settings=payload(premium=True, active=True, status="active")
+        )
+        response = client.post(
+            f"/guild/{GUILD}/subscription/portal",
+            data={"csrf_token": session.csrf_token},
+        )
+        assert response.status_code == 303
+        assert response.headers["Location"].startswith("https://billing.stripe.com/")
+        assert stripe.portals[0]["customer_id"] == CUSTOMER
+
+    def test_the_customer_id_never_comes_from_the_form(self, config):
+        """A customer id a browser could choose would be a portal into somebody
+        else's billing."""
+        client, _bot, stripe, session = make_client(
+            config, settings=payload(premium=True, active=True, status="active")
+        )
+        client.post(
+            f"/guild/{GUILD}/subscription/portal",
+            data={"csrf_token": session.csrf_token, "customer_id": "cus_SOMEONE_ELSE"},
+        )
+        assert stripe.portals[0]["customer_id"] == CUSTOMER
+
+    def test_no_csrf_token_opens_nothing(self, config):
+        client, _bot, stripe, _session = make_client(
+            config, settings=payload(premium=True, active=True, status="active")
+        )
+        response = client.post(f"/guild/{GUILD}/subscription/portal", data={})
+        assert response.status_code == 400
+        assert stripe.portals == []
+
+    def test_a_server_with_no_card_subscription_gets_nothing(self, config):
+        client, _bot, stripe, session = make_client(
+            config, settings=payload(customer_id=None)
+        )
+        response = client.post(
+            f"/guild/{GUILD}/subscription/portal",
+            data={"csrf_token": session.csrf_token},
+        )
+        assert response.status_code == 302
+        assert stripe.portals == []
+
+
+class TestThePageRenders:
+    def test_a_failed_read_apologises_and_offers_nothing(self, config):
+        client, bot_api, _stripe, _session = make_client(config)
+        bot_api.error = BotAPIError("unavailable", 503)
+        page = client.get(f"/guild/{GUILD}/subscription").data.decode()
+        assert "Subscribe" not in page
+        assert "/subscription/checkout" not in page
+
+    def test_the_plan_cards_say_tax_is_extra(self, config):
+        """$4.99 on the card and more than $4.99 on the statement is the most
+        likely complaint this page will ever produce."""
+        client, _bot, _stripe, _session = make_client(config)
+        page = client.get(f"/guild/{GUILD}/subscription").data.decode()
+        assert "exclude tax" in page
+
+    def test_the_longer_plans_are_declared_card_only(self, config):
+        client, _bot, _stripe, _session = make_client(config)
+        page = client.get(f"/guild/{GUILD}/subscription").data.decode()
+        assert "card-only" in page
+
+    def test_a_double_billed_server_is_told_where_to_cancel_both(self, config):
+        client, _bot, _stripe, _session = make_client(
+            config,
+            settings=payload(premium=True, discord=True, active=True,
+                             status="active"),
+        )
+        page = client.get(f"/guild/{GUILD}/subscription").data.decode()
+        assert "Manage billing" in page
+        assert "/vrcverify_subscription" in page
+        assert "won't cancel either one for you" in page
+
+    def test_a_discord_subscriber_is_shown_no_card_form(self, config):
+        client, _bot, _stripe, _session = make_client(
+            config, settings=payload(premium=True, discord=True)
+        )
+        page = client.get(f"/guild/{GUILD}/subscription").data.decode()
+        assert "/subscription/checkout" not in page
+
+    def test_no_inline_style_reaches_the_page(self, config):
+        """`style-src 'self'` drops inline styles SILENTLY, so a colour written
+        as style="" would simply not apply and nothing would say so."""
+        client, _bot, _stripe, _session = make_client(config)
+        page = client.get(f"/guild/{GUILD}/subscription").data.decode()
+        assert "style=" not in page.lower()
+
+    def test_ko_fi_stays_off_this_page(self, config):
+        """Donations and subscriptions in the same place make both read as
+        optional -- the reasoning already in bot.py, confirmed for the site."""
+        client, _bot, _stripe, _session = make_client(config)
+        page = client.get(f"/guild/{GUILD}/subscription").data.decode()
+        assert "ko-fi" not in page.lower()


### PR DESCRIPTION
Step 4 of #88: `/guild/<id>/subscription` stops being a placeholder and becomes a real point of sale. Three plan cards, hosted Checkout by redirect, Stripe's billing portal, the Discord path alongside, and a double-billing warning.

Still inert — nothing is purchasable until `STRIPE_ENABLED` is set on both hosts, and the checkout/portal routes 404 without it.

## The shape

`subscription_view.py` is **pure** — no Flask, no network, no clock — so all eight page states are built and asserted without a request. That split matters more here than anywhere else on the site: the difference between two of these states is the difference between showing a paying customer a Buy button and not.

| State | Means | Offers |
| --- | --- | --- |
| `unavailable` | the plan could not be read | nothing |
| `off` | tier switched off entirely | nothing to sell |
| `none` | genuinely not subscribed | plans + Discord |
| `pending` | just returned from checkout, webhook not landed | **nothing** — see below |
| `stripe` | paying by card | plan, renewal date, portal |
| `past_due` | card failed, Stripe retrying | honest banner, portal |
| `discord` | paying through Discord | no card buttons at all |
| `both` | paying twice | warning naming both, portal |

`grandfathered` rides alongside rather than being a ninth state — it is orthogonal, and the reassurance is the same whichever way a server is or isn't paying.

## Rules this page must not break

- **It never decides whether a server is premium.** `premium.premium` from the bot stays the one answer; the `stripe` block only explains *why*. There's a test pinning that the page never re-derives it.
- **It holds no prices.** Stripe knows what it charges. A second copy of an amount here would keep rendering the old number long after Stripe charged a new one — a test asserts no amount appears in the module at all.
- **The browser names a plan slug, never a price id.** This is the single most likely way to get the endpoint wrong: a form-supplied price would let anyone check out against any price on the account, including a $0 one made while testing.
- **A server that already pays cannot check out** — enforced in the route as well as the page, because a hand-crafted POST is not a click.

## Two changes to the bot's payload

**`premium.discord`** — whether the Discord half alone grants premium. Without it the double-billing warning was unbuildable: `premium.premium` is deliberately an OR, so the page could not tell "paying by card" from "paying by card *and* through Discord". It is not a second gate for the website to combine.

**`stripe.customer_id`** — reversing a step-1 decision. That docstring argued the website had no use for it; opening the billing portal requires one, so it plainly does. Withholding it bought nothing anyway, since the dashboard holds a Stripe secret key and can enumerate customers regardless. **No email crosses the wire** — that's the part that hasn't changed and the part that mattered.

## Settings now points here

As decided: the upgrade block drops the pitch and the store link for a one-line pointer. Two places to buy, with two different option sets, is how copy drifts apart — and only this page can mention the 6- and 12-month plans, which Discord cannot offer at all.

## Adversarial pass

Two real problems, three confirmed non-problems.

**The serious one.** After a genuine checkout Stripe bounces the browser back before the webhook lands, so the payload still says "not subscribed" — and the page rendered **three Buy buttons directly under a thank-you message**, to somebody who had demonstrably just paid. Now a `pending` state that promises a wait, claims nothing about payment, and offers no way to buy again while we can't tell.

**The second.** A payload with no `premium` block rendered "every feature is available at no charge", because a missing `enforced` read as falsy. Treating an unreadable payload as "free" is the same class of lie as treating a failed read as "not subscribed". Now `unavailable`.

**Confirmed safe:** `success_url`/`cancel_url` are built from `url_for` and can't be steered by the form; a duplicate `plan` parameter resolves to a slug from our own table either way; a malformed customer id is refused where the URL is built — and now in the route too, so neither check is load-bearing alone.

## Tests

**1415 passed, 1 skipped.** 52 new in `test_subscription_page.py`, plus updates to the tests that pinned the old Settings block and the old placeholder — including the write-surface pin, which is the "widen on purpose" gate working as intended.

Also pinned: no inline style reaches the page (`style-src 'self'` drops them *silently*), Ko-fi stays off, the cards say tax is extra, and the longer plans are declared card-only.

## Worth checking at step 5, in a real browser

`form-action 'self'` and the 303 to `checkout.stripe.com`. The spec says form-action doesn't apply to redirects and both major engines now agree, but this is a CSP interaction on the one flow that takes money, and it deserves one manual confirmation rather than my word.

Part of #88. Step 5 is go-live: live keys, both switches on, then README, `VPS_RUNBOOK.md` and `SECURITY_AUDIT.md`.